### PR TITLE
Replace single config.json with a buffer of files

### DIFF
--- a/app/src/browser/config-persistence-manager.es6
+++ b/app/src/browser/config-persistence-manager.es6
@@ -1,7 +1,7 @@
 import path from 'path';
 import fs from 'fs-plus';
 import {BrowserWindow, dialog, app} from 'electron';
-import {atomicWriteFileSync} from '../fs-utils'
+import {atomicWriteFileSync, getMostRecentTimestampedFile} from '../fs-utils'
 
 let _ = require('underscore');
 _ = Object.assign(_, require('../config-utils'));
@@ -16,7 +16,17 @@ export default class ConfigPersistenceManager {
 
     this.userWantsToPreserveErrors = false
     this.saveRetries = 0
-    this.configFilePath = path.join(this.configDirPath, 'config.json')
+    this.loadRetries = 0
+    this.configFilePath = getMostRecentTimestampedFile(this.configDirPath, 'config', 'json');
+    if (typeof this.configFilePath === "string") {
+      this.configFilePath = path.join(this.configDirPath, this.configFilePath);
+    }
+    if (typeof this.configFilePath === "undefined" || !fs.existsSync(this.configFilePath)) {
+      this.configFilePath = path.join(this.configDirPath, 'config.json'); // check legacy file
+      if (!fs.existsSync(this.configFilePath)) {
+        this.configFilePath = path.join(this.configDirPath, 'config.0.json'); // default file for creation
+      }
+    }
     this.settings = {};
 
     this.initializeConfigDirectory();
@@ -55,13 +65,14 @@ export default class ConfigPersistenceManager {
       type: 'error',
       message,
       detail,
-      buttons: ['Quit', 'Try Again', 'Reset Configuration'],
+      buttons: ['Quit', 'Try Again', 'Try Older Configuration', 'Reset Configuration'],
     });
 
     switch (clickedIndex) {
       case 0: return 'quit';
       case 1: return 'tryagain';
-      case 2: return 'reset';
+      case 2: return 'tryolder';
+      case 3: return 'reset';
       default:
         throw new Error('Unknown button clicked');
     }
@@ -93,6 +104,16 @@ export default class ConfigPersistenceManager {
         return;
       }
 
+      if (action === 'tryolder') {
+        this.loadRetries++;
+        this.configFilePath = getMostRecentTimestampedFile(this.configDirPath, 'config', 'json', this.loadRetries);
+        if (typeof this.configFilePath === "string") {
+          this.configFilePath = path.join(this.configDirPath, this.configFilePath);
+        }
+        this.load();
+        return;
+      }
+
       if (action !== 'reset') {
         throw new Error(`Unknown action: ${action}`);
       }
@@ -103,6 +124,7 @@ export default class ConfigPersistenceManager {
       this.writeTemplateConfigFile();
       this.load();
     }
+    this.loadRetries = 0;
   }
 
   _showSaveErrorDialog() {
@@ -124,7 +146,7 @@ export default class ConfigPersistenceManager {
     this.lastSaveTimestamp = Date.now();
 
     try {
-      atomicWriteFileSync(this.configFilePath, allSettingsJSON)
+      atomicWriteFileSync(this.configDirPath, 'config', 'json', allSettingsJSON)
       this.saveRetries = 0
     } catch (error) {
       if (this.saveRetries >= RETRY_SAVES) {

--- a/app/src/fs-utils.es6
+++ b/app/src/fs-utils.es6
@@ -1,9 +1,50 @@
 import fs from 'fs'
-import Utils from './flux/models/utils'
+import path from 'path';
 
-export function atomicWriteFileSync(filepath, content) {
-  const randomId = Utils.generateTempId()
-  const backupPath = `${filepath}.${randomId}.bak`
-  fs.writeFileSync(backupPath, content)
-  fs.renameSync(backupPath, filepath)
+function getSortedTimestampedFilesSync(filepath, basename, extension) {
+  let files = fs.readdirSync(filepath);
+  files = files.filter((file) => {
+    const hasConfig = file.indexOf(`${basename}.`) > -1;
+    const hasJSON = file.indexOf(`.${extension}`) > -1;
+    const hasExactName = file.indexOf(`${basename}.${extension}`) > -1;
+    return hasConfig && hasJSON && !hasExactName;
+  });
+
+  files = files.sort((a, b) => {
+    const aValues = a.split('.');
+    const bValues = b.split('.');
+
+    return parseInt(aValues[1], 10) - parseInt(bValues[1], 10);
+  });
+
+  return files;
+}
+
+export function atomicWriteFileSync(filepath, basename, extension, content) {
+  let fileNum = 0;
+  let newFile;
+  while (typeof newFile === "undefined" || fs.existsSync(newFile)) {
+    const milliseconds = (new Date()).getTime() * 1000 + fileNum;
+    newFile = path.join(filepath, `${basename}.${milliseconds}.${extension}`);
+    fileNum++;
+  }
+  fs.writeFileSync(newFile, content);
+
+  const files = getSortedTimestampedFilesSync(filepath, basename, extension);
+
+  while (files.length > 10) {
+    let fileToDelete = files.splice(0, 1);
+    fileToDelete = fileToDelete[0];
+    fs.unlinkSync(path.join(filepath, fileToDelete));
+  }
+}
+
+export function getMostRecentTimestampedFile(filepath, basename, extension, offset = 0) {
+  let myOffset = offset;
+  if (myOffset < 0) myOffset = 0;
+  if (myOffset > 9) myOffset = 9;
+
+  const files = getSortedTimestampedFilesSync(filepath, basename, extension);
+
+  return files[files.length - 1 - myOffset];
 }


### PR DESCRIPTION
This makes it so that we never have to rename a config.json.bak file over the current config.json file. This also reduces the chance of file writing collusion. This is to prevent corrupt config.json files

See https://github.com/nylas-mail-lives/nylas-mail/issues/15 and https://github.com/nylas/nylas-mail/issues/3382