### PR TITLE
Update Mailspring paths for bundled themes/plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,11 @@ The Mailspring user interface is styled using CSS, which means it's easy to modi
 
 
 #### Bundled Themes
-- [Dark](https://github.com/Foundry376/Mailspring/tree/master/internal_packages/ui-dark)
-- [Darkside](https://github.com/Foundry376/Mailspring/tree/master/internal_packages/ui-darkside) (designed by [Jamie Wilson](https://github.com/jamiewilson))
-- [Taiga](https://github.com/Foundry376/Mailspring/tree/master/internal_packages/ui-taiga) (designed by [Noah Buscher](https://github.com/noahbuscher))
-- [Ubuntu](https://github.com/Foundry376/Mailspring/tree/master/internal_packages/ui-ubuntu) (designed by [Ahmed Elhanafy](https://github.com/ahmedlhanafy))
-- [Less Is More](https://github.com/Foundry376/Mailspring/tree/master/internal_packages/ui-less-is-more) (designed by [Alexander Adkins](https://github.com/P0WW0W))
+- [Dark](https://github.com/Foundry376/Mailspring/tree/master/app/internal_packages/ui-dark)
+- [Darkside](https://github.com/Foundry376/Mailspring/tree/master/app/internal_packages/ui-darkside) (designed by [Jamie Wilson](https://github.com/jamiewilson))
+- [Taiga](https://github.com/Foundry376/Mailspring/tree/master/app/internal_packages/ui-taiga) (designed by [Noah Buscher](https://github.com/noahbuscher))
+- [Ubuntu](https://github.com/Foundry376/Mailspring/tree/master/app/internal_packages/ui-ubuntu) (designed by [Ahmed Elhanafy](https://github.com/ahmedlhanafy))
+- [Less Is More](https://github.com/Foundry376/Mailspring/tree/master/app/internal_packages/ui-less-is-more) (designed by [Alexander Adkins](https://github.com/P0WW0W))
 
 
 
@@ -107,13 +107,13 @@ We're working on building a plugin index that makes it super easy to add them to
 
 #### Bundled Plugins
 Great starting points for creating your own plugins!
-- [Translate](https://github.com/Foundry376/Mailspring/tree/master/internal_packages/composer-translate)—Works with 10 languages
-- [Quick Replies](https://github.com/Foundry376/Mailspring/tree/master/internal_packages/composer-templates)—Send emails faster with templates
-- [Emoji Keyboard](https://github.com/Foundry376/Mailspring/tree/master/internal_packages/composer-emoji)—Insert emoji by typing a colon (:) followed by the name of an emoji symbol
-- [GitHub Sidebar Info](https://github.com/Foundry376/Mailspring/tree/master/internal_packages/github-contact-card)
-- [View on GitHub](https://github.com/Foundry376/Mailspring/tree/master/internal_packages/message-view-on-github)
-- [Personal Level Indicators](https://github.com/Foundry376/Mailspring/tree/master/internal_packages/personal-level-indicators)
-- [Phishing Detection](https://github.com/Foundry376/Mailspring/tree/master/internal_packages/phishing-detection)
+- [Translate](https://github.com/Foundry376/Mailspring/tree/master/app/internal_packages/composer-translate)—Works with 10 languages
+- [Quick Replies](https://github.com/Foundry376/Mailspring/tree/master/app/internal_packages/composer-templates)—Send emails faster with templates
+- [Emoji Keyboard](https://github.com/Foundry376/Mailspring/tree/master/app/internal_packages/composer-emoji)—Insert emoji by typing a colon (:) followed by the name of an emoji symbol
+- [GitHub Sidebar Info](https://github.com/Foundry376/Mailspring/tree/master/app/internal_packages/github-contact-card)
+- [View on GitHub](https://github.com/Foundry376/Mailspring/tree/master/app/internal_packages/message-view-on-github)
+- [Personal Level Indicators](https://github.com/Foundry376/Mailspring/tree/master/app/internal_packages/personal-level-indicators)
+- [Phishing Detection](https://github.com/Foundry376/Mailspring/tree/master/app/internal_packages/phishing-detection)
 
 ## Configuration
 You can configure Mailspring in a few ways—for instance, pointing it to your self-hosted instance of the sync engine or changing the interface zoom level. [Learn more about how.](https://github.com/Foundry376/Mailspring/blob/master/CONFIGURATION.md)


### PR DESCRIPTION
The current links in the readme are pointed to an old folder structure; this PR fixes those paths to the current folder structure