### PR TITLE
fix an escaped tag

### DIFF
--- a/app/internal_packages/preferences/lib/tabs/workspace-section.jsx
+++ b/app/internal_packages/preferences/lib/tabs/workspace-section.jsx
@@ -144,7 +144,7 @@ const WorkspaceSection = props => {
 
       <div className="platform-note platform-linux-only">
         &quot;Launch on system start&quot; only works in XDG-compliant desktop environments. To
-        enable the N1 icon in the system tray, you may need to install libappindicator1. (i.e.,
+        enable the Mailspring icon in the system tray, you may need to install libappindicator1. (i.e.,
         <code>sudo apt-get install libappindicator1</code>)
       </div>
     </section>

--- a/app/internal_packages/preferences/lib/tabs/workspace-section.jsx
+++ b/app/internal_packages/preferences/lib/tabs/workspace-section.jsx
@@ -145,7 +145,7 @@ const WorkspaceSection = props => {
       <div className="platform-note platform-linux-only">
         &quot;Launch on system start&quot; only works in XDG-compliant desktop environments. To
         enable the N1 icon in the system tray, you may need to install libappindicator1. (i.e.,
-        &lt;code&gt;sudo apt-get install libappindicator1&lt;/code&gt;)
+        <code>sudo apt-get install libappindicator1</code>)
       </div>
     </section>
   );


### PR DESCRIPTION
In the General preferences tab, a code tag was visible inside of a note