### PR TITLE
Correctly parse multiple CCs/BCCs in mailto links

### DIFF
--- a/app/spec/stores/contact-store-spec.coffee
+++ b/app/spec/stores/contact-store-spec.coffee
@@ -101,6 +101,10 @@ xdescribe "ContactStore", ->
         new Contact(name: "Evan Morikawa", email: "evan@nylas.com")
         new Contact(name: "Ben", email: "ben@nylas.com")
       ]
+      "Evan Morikawa <evan@nylas.com>; Ben <ben@nylas.com>": [
+        new Contact(name: "Evan Morikawa", email: "evan@nylas.com")
+        new Contact(name: "Ben", email: "ben@nylas.com")
+      ]
       "mark@nylas.com\nGleb (gleb@nylas.com)\rEvan Morikawa <evan@nylas.com>, spang (Christine Spang) <noreply+phabricator@nilas.com>": [
         new Contact(name: "", email: "mark@nylas.com")
         new Contact(name: "Gleb", email: "gleb@nylas.com")

--- a/app/spec/stores/draft-factory-spec.es6
+++ b/app/spec/stores/draft-factory-spec.es6
@@ -744,9 +744,11 @@ describe('DraftFactory', function draftFactory() {
         'mailto:?subject=%52z2a', // passes uriDecode
         'mailto:?subject=Martha Stewart',
         'mailto:?subject=Martha Stewart&cc=cc@nylas.com',
+        'mailto:?subject=Martha Stewart&cc=cc@nylas.com;bengotow@gmail.com',
         'mailto:bengotow@gmail.com&subject=Martha Stewart&cc=cc@nylas.com',
         'mailto:bengotow@gmail.com?subject=Martha%20Stewart&cc=cc@nylas.com&bcc=bcc@nylas.com',
         'mailto:bengotow@gmail.com?subject=Martha%20Stewart&cc=cc@nylas.com&bcc=Ben <bcc@nylas.com>',
+        'mailto:bengotow@gmail.com?subject=Martha%20Stewart&cc=cc@nylas.com&bcc=Ben <bcc@nylas.com>;Shawn <shawn@nylas.com>',
         'mailto:Ben Gotow <bengotow@gmail.com>,Shawn <shawn@nylas.com>?subject=Yes this is really valid',
         'mailto:Ben%20Gotow%20<bengotow@gmail.com>,Shawn%20<shawn@nylas.com>?subject=Yes%20this%20is%20really%20valid',
         'mailto:Reply <d+AORGpRdj0KXKUPBE1LoI0a30F10Ahj3wu3olS-aDk5_7K5Wu6WqqqG8t1HxxhlZ4KEEw3WmrSdtobgUq57SkwsYAH6tG57IrNqcQR0K6XaqLM2nGNZ22D2k@docs.google.com>?subject=Nilas%20Message%20to%20Customers',
@@ -771,6 +773,13 @@ describe('DraftFactory', function draftFactory() {
           subject: 'Martha Stewart',
         }),
         new Message({
+          cc: [
+            new Contact({ name: 'cc@nylas.com', email: 'cc@nylas.com' }),
+            new Contact({ name: 'bengotow@gmail.com', email: 'bengotow@gmail.com' }),
+          ],
+          subject: 'Martha Stewart',
+        }),
+        new Message({
           to: [new Contact({ name: 'bengotow@gmail.com', email: 'bengotow@gmail.com' })],
           cc: [new Contact({ name: 'cc@nylas.com', email: 'cc@nylas.com' })],
           subject: 'Martha Stewart',
@@ -786,6 +795,14 @@ describe('DraftFactory', function draftFactory() {
           cc: [new Contact({ name: 'cc@nylas.com', email: 'cc@nylas.com' })],
           bcc: [new Contact({ name: 'Ben', email: 'bcc@nylas.com' })],
           subject: 'Martha Stewart',
+        }),
+        new Message({
+          to: [new Contact({ name: 'bengotow@gmail.com', email: 'bengotow@gmail.com' })],
+          cc: [new Contact({ name: 'cc@nylas.com', email: 'cc@nylas.com' })],
+          bcc: [
+            new Contact({ name: 'Ben', email: 'bcc@nylas.com' }),
+            new Contact({ name: 'Shawn', email: 'shawn@nylas.com' }),
+          ]
         }),
         new Message({
           to: [

--- a/app/src/flux/stores/contact-store.es6
+++ b/app/src/flux/stores/contact-store.es6
@@ -86,7 +86,7 @@ class ContactStore extends MailspringStore {
 
       if (hasLeadingParen && hasTrailingParen) {
         let nameStart = lastMatchEnd;
-        for (const char of [',', '\n', '\r']) {
+        for (const char of [',', ';', '\n', '\r']) {
           const i = contactString.lastIndexOf(char, match.index);
           if (i + 1 > nameStart) {
             nameStart = i + 1;

--- a/app/src/regexp-utils.coffee
+++ b/app/src/regexp-utils.coffee
@@ -17,7 +17,7 @@ RegExpUtils =
   # See http://tools.ietf.org/html/rfc5322#section-3.4 and
   # https://tools.ietf.org/html/rfc6531 and
   # https://en.wikipedia.org/wiki/Email_address#Local_part
-  emailRegex: -> new RegExp("([a-z.A-Z#{UnicodeEmailChars}0-9!#$%&\\'*+\\-/=?^_`{|}~;]+@[A-Za-z#{UnicodeEmailChars}0-9.-]+\\.[A-Za-z]{2,63})", 'g')
+  emailRegex: -> new RegExp("([a-z.A-Z#{UnicodeEmailChars}0-9!#$%&\\'*+\\-/=?^_`{|}~]+@[A-Za-z#{UnicodeEmailChars}0-9.-]+\\.[A-Za-z]{2,63})", 'g')
 
   # http://stackoverflow.com/questions/16631571/javascript-regular-expression-detect-all-the-phone-number-from-the-page-source
   # http://www.regexpal.com/?fam=94521


### PR DESCRIPTION
(copied from my original PR: [nylas/nylas-mail #3636](https://github.com/nylas/nylas-mail/pull/3636))

Fixing [nylas/nylas-mail #3635](https://github.com/nylas/nylas-mail/issues/3635).

- Removed semicolon from the valid email check in `regexp-utils`.
- Added semicolon to the list of email separators, in `ContactStore.parseContactsInString()`
- Added test cases in `parseContactsInString()`, and also the `DraftFactory` (where the mailto click is handled & a new/draft email is created).