### PR TITLE
Do not auto-hide menu-bar

### DIFF
--- a/app/src/browser/mailspring-window.coffee
+++ b/app/src/browser/mailspring-window.coffee
@@ -53,7 +53,7 @@ class MailspringWindow
       resizable: resizable
       webPreferences:
         directWrite: true
-      autoHideMenuBar: true
+      autoHideMenuBar: false
 
     if @neverClose
       # Prevents DOM timers from being suspended when the main window is hidden.


### PR DESCRIPTION
This removes the autohiding menu behaviour which results in users having to press alt to access the menu, as some key parts of the app are not easily accessible through the rest of the interfaces (such as preferences) it makes sense to keep the menu bar visible.

Fixes #81  