### PR TITLE
Don't crash on startup if there is no internet connection

### DIFF
--- a/app/src/browser/autoupdate-impl-base.es6
+++ b/app/src/browser/autoupdate-impl-base.es6
@@ -20,7 +20,7 @@ export default class AutoupdateImplBase extends EventEmitter {
   }
 
   emitError = err => {
-    this.emit('error', err.toString());
+    this.emit('error', err.message);
   };
 
   manuallyQueryUpdateServer(successCallback) {
@@ -54,7 +54,7 @@ export default class AutoupdateImplBase extends EventEmitter {
           this.emitError(err);
         }
       });
-    });
+    }).on('error', this.emitError);
   }
 
   /* Public: Check for updates and emit events if an update is available. */

--- a/app/src/browser/autoupdate-manager.es6
+++ b/app/src/browser/autoupdate-manager.es6
@@ -62,7 +62,7 @@ export default class AutoUpdateManager extends EventEmitter {
       autoUpdater = require('electron').autoUpdater;
     }
 
-    autoUpdater.on('error', (event, message) => {
+    autoUpdater.on('error', (message) => {
       if (this.specMode) return;
       console.error(`Error Downloading Update: ${message}`);
       this.setState(ErrorState);


### PR DESCRIPTION
Handle internet errors of AutoUpdater on Linux instead of crashing.
Fix the EventListener so we log the error proprely.

Resolves: #140, #90