### PR TITLE
Added mod+shift+a shortcut for selecting an attachment in composer (fixes #92)

### DIFF
--- a/app/internal_packages/composer/lib/composer-view.jsx
+++ b/app/internal_packages/composer/lib/composer-view.jsx
@@ -102,6 +102,7 @@ export default class ComposerView extends React.Component {
       'composer:show-and-focus-cc': () => this._els.header.showAndFocusField(Fields.Cc),
       'composer:focus-to': () => this._els.header.showAndFocusField(Fields.To),
       'composer:show-and-focus-from': () => {},
+      'composer:select-attachment': () => Actions.selectAttachment({ headerMessageId: this.props.draft.headerMessageId });,
       'core:undo': event => {
         event.preventDefault();
         event.stopPropagation();

--- a/app/internal_packages/composer/lib/composer-view.jsx
+++ b/app/internal_packages/composer/lib/composer-view.jsx
@@ -102,7 +102,7 @@ export default class ComposerView extends React.Component {
       'composer:show-and-focus-cc': () => this._els.header.showAndFocusField(Fields.Cc),
       'composer:focus-to': () => this._els.header.showAndFocusField(Fields.To),
       'composer:show-and-focus-from': () => {},
-      'composer:select-attachment': () => Actions.selectAttachment({ headerMessageId: this.props.draft.headerMessageId });,
+      'composer:select-attachment': () => this._onSelectAttachment(),
       'core:undo': event => {
         event.preventDefault();
         event.stopPropagation();

--- a/app/internal_packages/preferences/lib/tabs/keymaps/displayed-keybindings.js
+++ b/app/internal_packages/preferences/lib/tabs/keymaps/displayed-keybindings.js
@@ -31,6 +31,7 @@ module.exports = [
       ['composer:focus-to', 'Focus the To field'],
       ['composer:show-and-focus-cc', 'Focus the Cc field'],
       ['composer:show-and-focus-bcc', 'Focus the Bcc field'],
+      ['composer:select-attachment', 'Select file attachment'],
     ],
   },
   {

--- a/app/keymaps/base.json
+++ b/app/keymaps/base.json
@@ -57,5 +57,7 @@
   "contenteditable:outdent": "mod+[",
   "contenteditable:indent": "mod+]",
   "contenteditable:next-selection": "mod+\"",
-  "contenteditable:open-spelling-suggestions": "mod+m"
+  "contenteditable:open-spelling-suggestions": "mod+m",
+
+  "composer:select-attachment": "mod+shift+a"
 }


### PR DESCRIPTION
I know @nickolasclarke has already added a PR for #92 but I thought I'd add mine to compare.

Feel free to close mine if it isn't useful.