### PR TITLE
Fix picking participants with undefined names

### DIFF
--- a/app/internal_packages/message-list/lib/sidebar-participant-picker.jsx
+++ b/app/internal_packages/message-list/lib/sidebar-participant-picker.jsx
@@ -43,7 +43,7 @@ export default class SidebarParticipantPicker extends React.Component {
   _onSelectContact = event => {
     const { sortedContacts } = this.state;
     const [email, name] = event.target.value.split(SPLIT_KEY);
-    const contact = sortedContacts.find(c => c.name === name && c.email === email);
+    const contact = sortedContacts.find(c => (c.name === name || typeof c.name == "undefined" ) && c.email === email);
     return Actions.focusContact(contact);
   };
 


### PR DESCRIPTION
The participant picker wasn't able to find a match for a participant with an undefined name, resulting in sending a null to _onFocusContact() instead of the desired Contact object.

Fixes: #177