### PR TITLE
Fix centering window on linux (fixes #122)

### DIFF
--- a/app/src/app-env.es6
+++ b/app/src/app-env.es6
@@ -2,6 +2,7 @@
 /* eslint import/no-dynamic-require: 0 */
 import _ from 'underscore';
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 import { ipcRenderer, remote } from 'electron';
 import { Emitter } from 'event-kit';
@@ -585,7 +586,16 @@ export default class AppEnvConstructor {
 
   // Extended: Move current window to the center of the screen.
   center() {
-    return ipcRenderer.send('call-window-method', 'center');
+    if (os.platform() === 'linux') {
+      let dimensions = this.getWindowDimensions();
+      let bounds = remote.screen.getPrimaryDisplay().bounds;
+      let x = bounds.x + ((bounds.width - dimensions.width) / 2);
+      let y = bounds.y + ((bounds.height - dimensions.height) / 2);
+
+      return this.setPosition(x, y);
+    } else {
+      return ipcRenderer.send('call-window-method', 'center');
+    }
   }
 
   // Extended: Focus the current window. Note: this will not open the window

--- a/app/src/app-env.es6
+++ b/app/src/app-env.es6
@@ -588,7 +588,7 @@ export default class AppEnvConstructor {
   center() {
     if (os.platform() === 'linux') {
       let dimensions = this.getWindowDimensions();
-      let bounds = remote.screen.getPrimaryDisplay().bounds;
+      let bounds = remote.screen.getDisplayMatching(dimensions).bounds;
       let x = bounds.x + ((bounds.width - dimensions.width) / 2);
       let y = bounds.y + ((bounds.height - dimensions.height) / 2);
 

--- a/app/src/app-env.es6
+++ b/app/src/app-env.es6
@@ -587,9 +587,9 @@ export default class AppEnvConstructor {
   center() {
     if (process.platform === 'linux') {
       let dimensions = this.getWindowDimensions();
-      let bounds = remote.screen.getDisplayMatching(dimensions).bounds;
-      let x = bounds.x + ((bounds.width - dimensions.width) / 2);
-      let y = bounds.y + ((bounds.height - dimensions.height) / 2);
+      let display = remote.screen.getDisplayMatching(dimensions) || remote.screen.getPrimaryDisplay();
+      let x = display.bounds.x + ((display.bounds.width - dimensions.width) / 2);
+      let y = display.bounds.y + ((display.bounds.height - dimensions.height) / 2);
 
       return this.setPosition(x, y);
     } else {

--- a/app/src/app-env.es6
+++ b/app/src/app-env.es6
@@ -2,7 +2,6 @@
 /* eslint import/no-dynamic-require: 0 */
 import _ from 'underscore';
 import fs from 'fs';
-import os from 'os';
 import path from 'path';
 import { ipcRenderer, remote } from 'electron';
 import { Emitter } from 'event-kit';
@@ -586,7 +585,7 @@ export default class AppEnvConstructor {
 
   // Extended: Move current window to the center of the screen.
   center() {
-    if (os.platform() === 'linux') {
+    if (process.platform === 'linux') {
       let dimensions = this.getWindowDimensions();
       let bounds = remote.screen.getDisplayMatching(dimensions).bounds;
       let x = bounds.x + ((bounds.width - dimensions.width) / 2);


### PR DESCRIPTION
This is a workaround for #122 . On Linux there is an open issue with electron (See electron/electron#3490).

Since the electron has been outstanding for quite a while, I can't see it being fixed soon.

This workaround finds the window that mostly intersects the window and uses those bounds to centre the window.

It isn't perfect, but does a better job than splitting across multiple windows.