### PR TITLE
Removed "Nylas Team" from quick replies preferences

### DIFF
--- a/app/internal_packages/composer-templates/assets/Welcome to Quick Replies.html
+++ b/app/internal_packages/composer-templates/assets/Welcome to Quick Replies.html
@@ -13,4 +13,4 @@ never sees it.
 Enjoy!
 <br/>
 <br/>
--Nylas Team
+-The Mailspring Team


### PR DESCRIPTION
When a user first came on to the "Quick replies" preference pane, it would fire a message signed by the Nylas Team.

This is a really little modification but i hope to do more in the future. 

- Simon