### PR TITLE
Allow subscription nag to be dismissed once per session

### DIFF
--- a/app/internal_packages/notifications/lib/items/please-subscribe-notif.jsx
+++ b/app/internal_packages/notifications/lib/items/please-subscribe-notif.jsx
@@ -44,6 +44,7 @@ export default class PleaseSubscribeNotification extends React.Component {
     return (
       <Notification
         priority="0"
+        isDismissable={true}
         title={this.state.msg}
         actions={[
           {


### PR DESCRIPTION
I understand your desire to push the user to buying the pro version of Mailspring but I think it is reasonable to make that message pop up at the start of each session but allow it to be dismissed. I cannot stand seeing this brightly colored box (theme dependent of course) every time I look at my email client and being unable to make it go away without paying $8 a month.

Before: ![before](https://i.imgur.com/UIusji1.png)
After: ![after](https://i.imgur.com/jSNtuYw.png)
