### PR TITLE
Add setting to disable opening containing folder on attachment download

### DIFF
--- a/app/src/config-schema.es6
+++ b/app/src/config-schema.es6
@@ -77,6 +77,11 @@ export default {
             enumLabels: ['When Read', 'Manually'],
             title: 'Download attachments for new mail',
           },
+          openFolderAfterDownload: {
+            type: 'boolean',
+            default: false,
+            title: 'Open containing folder after downloading attachment',
+          },
           displayFilePreview: {
             type: 'boolean',
             default: true,

--- a/app/src/flux/stores/attachment-store.es6
+++ b/app/src/flux/stores/attachment-store.es6
@@ -225,8 +225,15 @@ class AttachmentStore extends MailspringStore {
         .then(download => this._writeToExternalPath(download, actualSavePath))
         .then(() => {
           if (AppEnv.savedState.lastDownloadDirectory !== newDownloadDirectory) {
-            shell.showItemInFolder(actualSavePath);
             AppEnv.savedState.lastDownloadDirectory = newDownloadDirectory;
+
+            if (
+              this._lastDownloadDirectory !== newDownloadDirectory &&
+              AppEnv.config.get('core.attachments.openFolderAfterDownload')
+            ) {
+              this._lastDownloadDirectory = newDownloadDirectory;
+              shell.showItemInFolder(actualSavePath);
+            }
           }
         })
         .catch(this._catchFSErrors)
@@ -254,6 +261,7 @@ class AttachmentStore extends MailspringStore {
         if (!dirPath) {
           return;
         }
+        this._lastDownloadDirectory = dirPath;
         AppEnv.savedState.lastDownloadDirectory = dirPath;
 
         const lastSavePaths = [];
@@ -266,7 +274,10 @@ class AttachmentStore extends MailspringStore {
 
         Promise.all(savePromises)
           .then(() => {
-            if (lastSavePaths.length > 0) {
+            if (
+              lastSavePaths.length > 0 &&
+              AppEnv.config.get('core.attachments.openFolderAfterDownload')
+            ) {
               shell.showItemInFolder(lastSavePaths[0]);
             }
             return resolve(lastSavePaths);


### PR DESCRIPTION
Defaults to previous behavior, although it is possible that the previous default behavior doesn't make sense anymore.

Previous Behavior: If the last directory downloaded to (persistent across sessions) is the same directory we are downloading to, don't open it. Else, open it.

This configuration setting adds a way to disable this behavior and never open the directory, however this leads me to wonder if the previous behavior should now be changed to always open the directory (unless the configuration option is set to never open the directory) as the previous behavior seems odd to me.

This feature was requested in #156 