### PR TITLE
Collect Characters Typed while Showing move-picker-popover

### DIFF
--- a/app/internal_packages/category-picker/lib/move-picker-popover.jsx
+++ b/app/internal_packages/category-picker/lib/move-picker-popover.jsx
@@ -31,7 +31,7 @@ export default class MovePickerPopover extends Component {
 
   componentDidMount() {
     this._isMounted = true;
-    this._registerObservables();
+    setImmediate(this._registerObservables);
   }
 
   componentWillReceiveProps(nextProps) {


### PR DESCRIPTION
Fixes #242

The characters typed between triggering the popover and the popover’s input field getting the focus were lost and sometimes triggered unwanted actions.

This implementation listens to all keypresses between the rendering of the component and the search input field getting the focus.

~Note that it’s not possible to fix the issue by giving the input the focus sooner. Because focusing the input can be done only *after* it was added to the DOM. But the focus will be given to the input asynchronously, which means that keypresses that came earlier will be handled before the input gets the focus.~  