### PR TITLE
Allow `mail` as a valid hostname

### DIFF
--- a/app/internal_packages/onboarding/lib/onboarding-helpers.es6
+++ b/app/internal_packages/onboarding/lib/onboarding-helpers.es6
@@ -152,7 +152,7 @@ export async function finalizeAndValidateAccount(account) {
 }
 
 export function isValidHost(value) {
-  if (value === 'localhost') {
+  if (value === 'localhost' || value === 'mail') {
     return true;
   }
   return RegExpUtils.domainRegex().test(value) || RegExpUtils.ipAddressRegex().test(value);


### PR DESCRIPTION
At work we have our mailserver resolving to `mail`.

I cannot use Mailspring at work unless `mail` is a valid host.

Curious as to whether we can expand this with a set of common values?