### PR TITLE
Use space/shift+space for additional pagedown/pageup

### DIFF
--- a/app/keymaps/base.json
+++ b/app/keymaps/base.json
@@ -27,8 +27,8 @@
   "core:pop-sheet": "escape",
   "core:show-keybindings": "?",
 
-  "core:messages-page-up": "pageup",
-  "core:messages-page-down": "pagedown",
+  "core:messages-page-up": ["pageup", "shift+space"],
+  "core:messages-page-down": ["pagedown", "space"],
   "core:list-page-up": "shift+pageup",
   "core:list-page-down": "shift+pagedown",
 


### PR DESCRIPTION
This seems to be universal behavior across a wide variety of apps & browsers, and I think this would improve the user's experience.  

Addresses issue #255. 