### PR TITLE
[Signature] Twitter profile image support and better handling of Tiwtter handle.

### DIFF
--- a/app/internal_packages/composer-signature/lib/constants.es6
+++ b/app/internal_packages/composer-signature/lib/constants.es6
@@ -39,8 +39,8 @@ export const DataShape = [
     label: 'Facebook URL',
   },
   {
-    key: 'twitterURL',
-    label: 'Twitter URL',
+    key: 'twitterHandle',
+    label: 'Twitter Handle',
   },
   {
     key: 'tintColor',
@@ -52,11 +52,24 @@ export const DataShape = [
 export const ResolveSignatureData = data => {
   data = Object.assign({}, data);
 
-  ['websiteURL', 'twitterURL', 'facebookURL'].forEach(key => {
+  ['websiteURL', 'facebookURL'].forEach(key => {
     if (data[key] && !data[key].includes(':')) {
       data[key] = `http://${data[key]}`;
     }
   });
+
+  // sanitize twitter handle
+  if (data.twitterHandle) {
+    if (data.twitterHandle.includes('/')) {
+      // a url was likely entered, lets grab the user (last portion).
+      const split = data.twitterHandle.split('/');
+      data.twitterHandle = split[split.length - 1];
+    }
+    if (data.twitterHandle[0] === '@') {
+      // an at symbol was added, lets remove it.
+      data.twitterHandle = data.twitterHandle.slice(1);
+    }
+  }
 
   if (data.photoURL === 'gravatar') {
     const hash = crypto
@@ -64,6 +77,10 @@ export const ResolveSignatureData = data => {
       .update((data.email || '').toLowerCase().trim())
       .digest('hex');
     data.photoURL = `https://www.gravatar.com/avatar/${hash}`;
+  }
+
+  if (data.photoURL === 'twitter') {
+    data.photoURL = `https://twitter.com/${data.twitterHandle}/profile_image?size=original`;
   }
 
   if (data.photoURL === 'company') {

--- a/app/internal_packages/composer-signature/lib/preferences-signatures.jsx
+++ b/app/internal_packages/composer-signature/lib/preferences-signatures.jsx
@@ -251,7 +251,7 @@ class SignaturePhotoPicker extends React.Component {
     const { isDropping, isUploading } = this.state;
 
     let source = data.photoURL || '';
-    if (!['gravatar', 'company', ''].includes(source)) {
+    if (!['gravatar', 'twitter', 'company', ''].includes(source)) {
       source = 'custom';
     }
 
@@ -297,6 +297,7 @@ class SignaturePhotoPicker extends React.Component {
             >
               <option value="">None</option>
               <option value="gravatar">Gravatar Profile Photo</option>
+              <option value="twitter">Twitter Profile Image</option>
               <option value="company">Company / Domain Logo</option>
               <option disabled>──────────</option>
               <option value="custom">Custom Image</option>

--- a/app/internal_packages/composer-signature/lib/templates.es6
+++ b/app/internal_packages/composer-signature/lib/templates.es6
@@ -100,9 +100,9 @@ function GenericInfoBlock(props, prefixStyle = PrefixStyles.None) {
             {FB_SHARE}
           </a>
         )}
-        {props.twitterURL && (
+        {props.twitterHandle && (
           <a
-            href={props.twitterURL}
+            href={`https://twitter.com/${props.twitterHandle}`}
             title="Twitter"
             style={{ marginRight: 8, color: props.tintColor }}
           >
@@ -367,9 +367,9 @@ const Templates = [
                       {FB_SHARE}
                     </a>
                   )}
-                  {props.twitterURL && (
+                  {props.twitterHandle && (
                     <a
-                      href={props.twitterURL}
+                      href={`https://twitter.com/${props.twitterHandle}`}
                       title="Twitter"
                       style={{ marginRight: 8, color: props.tintColor }}
                     >


### PR DESCRIPTION
Your Twitter profile image is now supported for use in your signature!
Also added by this commit:
* if you enter a Twitter handle with an "@" sign, we remove the "@" sign (`@mailspringapp` -> `mailspringapp`).
* if you enter your twitter handle as a URL, we convert it down to just your Twitter handle (`http://twitter.com/mailspringapp` -> `mailspringapp`).

The above changes allow the signature system to work better with regards to Twitter handles.

![screenshot from 2017-12-29 13-05-38](https://user-images.githubusercontent.com/4079608/34444018-031724a2-ec99-11e7-8094-147248f144ab.png)
