### PR TITLE
Remove nslog

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -50,7 +50,6 @@
     "mousetrap": "^1.5.3",
     "node-emoji": "^1.2.1",
     "node-uuid": "^1.4",
-    "nslog": "^3",
     "optimist": "0.4.0",
     "pathwatcher": "~6.2",
     "pick-react-known-prop": "0.x.x",

--- a/app/src/error-logger.js
+++ b/app/src/error-logger.js
@@ -125,12 +125,6 @@ module.exports = ErrorLogger = (function() {
 
   ErrorLogger.prototype._extendNativeConsole = function(args) {
     console.debug = this._consoleDebug.bind(this);
-
-    if (process.type === 'browser' && process.platform === 'darwin') {
-      var nslog = require('nslog');
-      console.log = nslog;
-      console.error = nslog;
-    }
   };
 
   // globally define Error.toJSON. This allows us to pass errors via IPC


### PR DESCRIPTION
Native logging can be enabled with the `ELECTRON_ENABLE_LOGGING=1` environment variable.