### PR TITLE
Don't compact the display name for thread list participants

### DIFF
--- a/app/internal_packages/thread-list/lib/thread-list-participants.cjsx
+++ b/app/internal_packages/thread-list/lib/thread-list-participants.cjsx
@@ -42,10 +42,7 @@ class ThreadListParticipants extends React.Component
         accumulate('...')
       else
         if contact.name and contact.name.length > 0
-          if items.length > 1
-            short = contact.displayName(includeAccountLabel: false, compact: true)
-          else
-            short = contact.displayName(includeAccountLabel: false)
+          short = contact.displayName(includeAccountLabel: false)
         else
           short = contact.email
         if idx < items.length-1 and not items[idx+1].spacer


### PR DESCRIPTION
Related to https://github.com/Foundry376/Mailspring/issues/505
Compacting thread list participants is leading to strange truncation on participants that may be company or organization names. Ultimately, it might be nice to have this sort of smart truncation for first names, but in the meantime, I'd prefer to be able to see the full participant rather than an incorrectly truncated snippet.