### PR TITLE
issue/669

### DIFF
--- a/app/build/resources/linux/mailspring.desktop.in
+++ b/app/build/resources/linux/mailspring.desktop.in
@@ -7,5 +7,5 @@ Icon=mailspring
 Type=Application
 StartupNotify=true
 StartupWMClass=<%= productName %>
-Categories=GNOME;GTK;Network;Email;Utility;Development;
+Categories=GNOME;GTK;Network;Email;
 MimeType=x-scheme-handler/mailto;x-scheme-handler/mailspring;


### PR DESCRIPTION
Removed categories that are not matching Mailspring, as per Desktop Menu Specification. This should address #669. It's an almost trivial pull request, but it hopefully gets me back in the hang of creating pull requests on forks.