### PR TITLE
Allow two points character inside urls for links

### DIFF
--- a/app/src/regexp-utils.es6
+++ b/app/src/regexp-utils.es6
@@ -145,7 +145,7 @@ const RegExpUtils = {
       '(',
       // URL components
       // (last character must not be puncation, hence two groups)
-      '(?:[\\+=~%\\/\\.\\w\\-_@]*[\\+~%\\/\\w\\-_]+)?',
+      '(?:[\\+=~%\\/\\.\\w\\-_@]*[\\+~%\\/\\w\\-:_]+)?',
 
       // optionally followed by: a query string and/or a #location
       // (last character must not be puncation, hence two groups)


### PR DESCRIPTION
This PR fix bug #417