### PR TITLE
Ignore mailto protocol links for link-tracking

### DIFF
--- a/app/internal_packages/link-tracking/lib/link-tracking-composer-extension.es6
+++ b/app/internal_packages/link-tracking/lib/link-tracking-composer-extension.es6
@@ -51,6 +51,9 @@ export default class LinkTrackingComposerExtension extends ComposerExtension {
       if (!RegExpUtils.urlRegex().test(url)) {
         return;
       }
+      if (RegExpUtils.mailtoProtocolRegex().test(url)) {
+        return; // Ignore mailto links; see #877
+      }
       const encoded = encodeURIComponent(url);
       const redirectUrl = `${PLUGIN_URL}/link/${draft.headerMessageId}/${
         links.length

--- a/app/src/regexp-utils.es6
+++ b/app/src/regexp-utils.es6
@@ -163,6 +163,12 @@ const RegExpUtils = {
     return new RegExp(parts.join(''), 'gi');
   },
 
+  // Test cases: https://regex101.com/r/gro8Su/1
+  // Matches if it starts with mailto:
+  mailtoProtocolRegex() {
+    return new RegExp(/^mailto:.+/);
+  },
+
   // Test cases: https://regex101.com/r/jD5zC7/2
   // Returns the following capturing groups:
   // 1. start of the opening a tag to href="


### PR DESCRIPTION
A temporary, client-side fix for #877, until a server-side fix is presented. I had a hell of a time trying to get the project installed and started up (see #762), so please 2x-check. Thanks!