### PR TITLE
[Hack] Fix for #1153

### DIFF
--- a/app/src/flux/models/contact.es6
+++ b/app/src/flux/models/contact.es6
@@ -479,7 +479,7 @@ export default class Contact extends Model {
     let name = this.name;
 
     // At this point, if the name is empty we'll use the email address
-    if (!name || name.length === 0) {
+    if (!name || name.length === 0 || name === 'NIL') {
       name = this.email || '';
 
       // If the phrase has an '@', use everything before the @ sign


### PR DESCRIPTION
Quick fix that I discovered which solves the issue of contact name being shown as NIL.

Before : 
![selection_081](https://user-images.githubusercontent.com/9157531/47563877-cde0db80-d940-11e8-9b49-994a13172330.png)

After : 
![selection_082](https://user-images.githubusercontent.com/9157531/47563884-d33e2600-d940-11e8-90c4-83a45779b500.png)

This is *NOT* a proper fix, it's something I was able to find by analyzing the code for an hour. Hopefully project maintainers will find this helpful and can come up with a better solution, till then feel free to use this.

Rel : #1153 

