### PR TITLE
Update weird translation in fr.json

### DIFF
--- a/app/lang/fr.json
+++ b/app/lang/fr.json
@@ -48,7 +48,7 @@
   "An error has occurred": "Une erreur est survenue ",
   "An unknown error has occurred": "Une erreur inconnue s'est produite",
   "An update to Mailspring is available %@": "Une mise à jour de Mailspring est disponible %@",
-  "Any": "Tous",
+  "Any": "L'une",
   "App Password": "Mot de passe de l'application",
   "Appearance": "Apparence",
   "Application": "Application",


### PR DESCRIPTION
The rule editor was badly translated. Any was translated into "tous" which means "all' in this context. Which brings to the filter rules not understandable for french people. This fixes it