### PR TITLE
Add hotkey F5 for sync

### DIFF
--- a/app/keymaps/base.json
+++ b/app/keymaps/base.json
@@ -42,6 +42,8 @@
   "window:select-account-7": "mod+8",
   "window:select-account-8": "mod+9",
 
+  "window:sync-mail-now": "f5",
+
   "contenteditable:underline": "mod+u",
   "contenteditable:bold": "mod+b",
   "contenteditable:italic": "mod+i",


### PR DESCRIPTION
See issue #1412. Adds a hotkey for the "Sync New Mail Now" command. Someone suggested `CTRL+R`, but that's already taken by reply, so I opted for `F5`, which I feel is pretty standard.

I almost feel silly submitting such a small change, but kudos on the app architecture for making something like this so easy to change!