### PR TITLE
Czech translation improved

### DIFF
--- a/app/lang/cs.json
+++ b/app/lang/cs.json
@@ -717,7 +717,7 @@
   "The server said you must sign in via your webmail.": "Server uvedl, že se musíte přihlásit přes webmail.",
   "The subject field is blank.": "Pole předmětu je prázdné.",
   "The template and its file will be permanently deleted.": "Šablona a její soubor budou trvale smazány.",
-  "The thread %@ does not exist in your mailbox!": "Niť %@ ve vaší poštovní schránce neexistuje!",
+  "The thread %@ does not exist in your mailbox!": "Vlákno %@ ve vaší poštovní schránce neexistuje!",
   "Theme Color": "Barva motivu",
   "Theme and Style": "Téma a styl",
   "Themes": "Témata",

--- a/app/lang/cs.json
+++ b/app/lang/cs.json
@@ -607,7 +607,7 @@
   "Sending is not enabled for this account.": "Odesílání není pro tento účet povoleno.",
   "Sending message": "Odeslání zprávy",
   "Sending now": "Odesílání",
-  "Sending soon...": "Čoskoro se odešle ...",
+  "Sending soon...": "Brzy se odešle ...",
   "Sent Mail": "Odeslaná pošta",
   "Sent from Mailspring, the best free email app for work": "Odeslané z Mailspring, nejlepší bezplatná e-mailová aplikace pro práci",
   "Services": "Služby",


### PR DESCRIPTION
I have corrected two mistakes in czech translation of Mailspring.

1. "Čoskoro" is not a czech word, it is a Slovak word, so I have it replaced with czech equivalent of soon.
2. "Niť" is not good translation of thread. Better word is "vlákno" which is used in the rest of the application.