### PR TITLE
Add DISABLE_WAYLAND to snapcraft.yaml

### DIFF
--- a/snap/snapcraft.template.yaml
+++ b/snap/snapcraft.template.yaml
@@ -64,6 +64,8 @@ apps:
       # are used and do not fall back to Notification Area applets
       # or disappear completely.
       XDG_CURRENT_DESKTOP: Unity
+      # Fallback to XWayland if running in a Wayland session.
+      DISABLE_WAYLAND: 1
     plugs:
       - avahi-observe
       - browser-support


### PR DESCRIPTION
There is an issue with the confluence of Electron, snaps, and Wayland that causes the snap packaged version of Mailspring to not launch when the desktop environment is using the Wayland compositor.

This fix follows the lead of other popular Electron apps (including Visual Studio Code and Atom) in working around the issue by falling back to XWayland. 

Fixes #1220.
Fixes #1067.
Fixes #982.