### PR TITLE
Add preferences option 'show detailed message header by default'

### DIFF
--- a/app/internal_packages/message-list/lib/message-item.tsx
+++ b/app/internal_packages/message-list/lib/message-item.tsx
@@ -58,7 +58,7 @@ export default class MessageItem extends React.Component<MessageItemProps, Messa
       // keyed by a fileId. The value is the downloadData.
       downloads: AttachmentStore.getDownloadDataForFiles(fileIds),
       filePreviewPaths: AttachmentStore.previewPathsForFiles(fileIds),
-      detailedHeaders: false,
+      detailedHeaders: AppEnv.config.get('core.reading.messageHeader'),
     };
   }
 
@@ -287,7 +287,10 @@ export default class MessageItem extends React.Component<MessageItemProps, Messa
   }
 
   _renderCollapsed() {
-    const { message: { snippet, from, files, date, draft }, className } = this.props;
+    const {
+      message: { snippet, from, files, date, draft },
+      className,
+    } = this.props;
 
     const attachmentIcon = Utils.showIconForAttachments(files) ? (
       <div className="collapsed-attachment" />

--- a/app/src/config-schema.ts
+++ b/app/src/config-schema.ts
@@ -129,6 +129,11 @@ export default {
             default: false,
             title: localized('Display conversations in descending chronological order'),
           },
+          messageHeader: {
+            type: 'boolean',
+            default: false,
+            title: localized('Show detailed message header by default'),
+          },
         },
       },
       composing: {


### PR DESCRIPTION
Since I was also missing the expanded message header as default to easily detect spam emails myself, I implemented it in this PR as an opt-in option to avoid changing current user default settings.

Fixes #1521.