### PR TITLE
add frame and remove toolbar from calendar preview

### DIFF
--- a/app/src/browser/window-manager.ts
+++ b/app/src/browser/window-manager.ts
@@ -267,8 +267,8 @@ export default class WindowManager {
       title: localized('Calendar Preview'),
       width: 900,
       height: 600,
-      frame: false,
-      toolbar: true,
+      frame: true,
+      toolbar: false,
       hidden: false,
     };
 


### PR DESCRIPTION
fixes #1541 - just enable the frame and disable the toolbar, that's all.