### PR TITLE
Fixed placeholder typo in german translation

### DIFF
--- a/app/lang/de.json
+++ b/app/lang/de.json
@@ -271,7 +271,7 @@
   "Hooray! You’re done.": "Hurra! Sie sind fertig.",
   "Huge": "Riesig",
   "If %@ of the following conditions are met:": "Wenn %@ der folgenden Bedingungen erfüllt sind:",
-  "If you enjoy Mailspring, upgrade to Mailspring Pro from %@ to enable all these great features permanently:": "Wenn Ihnen Mailspring gefällt, upgraden sie von %q zu Mailspring Pro, um alle diese großartigen Funktionen dauerhaft zu aktivieren:",
+  "If you enjoy Mailspring, upgrade to Mailspring Pro from %@ to enable all these great features permanently:": "Wenn Ihnen Mailspring gefällt, upgraden sie von %@ zu Mailspring Pro, um alle diese großartigen Funktionen dauerhaft zu aktivieren:",
   "If you write a draft in another language, Mailspring will auto-detect it and use the correct spelling dictionary after a few sentences.": "Wenn Sie einen Entwurf in einer anderen Sprache verfassen, erkennt Mailspring diese automatisch und verwendet nach wenigen Sätzen das richtige Wörterbuch.",
   "If you've enabled link tracking or read receipts, those events will appear here!": "Wenn Sie das Verfolgen von Links oder Lesebestätigungen aktiviert haben, werden diese Ereignisse hier angezeigt.",
   "Important": "Wichtig",


### PR DESCRIPTION
Haven't tested the change, but as all the other translations are using `%@` I guess it should be working :tada: 