### PR TITLE
Add snooze date shorthand expander

### DIFF
--- a/app/src/date-utils.ts
+++ b/app/src/date-utils.ts
@@ -149,8 +149,8 @@ function expandDateLikeString(dateLikeString: string) {
     return `${numWeeks} weeks`;
   }
 
-  // Short format: 2m
-  if (/^\d+m$/.test(dateLikeString)) {
+  // Short format: 2m, 2mo
+  if (/^\d+mo?$/.test(dateLikeString)) {
     const numMonths = dateLikeString.match(/^\d+/)[0]; // Extract number
     return `${numMonths} months`;
   }

--- a/app/src/date-utils.ts
+++ b/app/src/date-utils.ts
@@ -156,13 +156,17 @@ function expandDateLikeString(dateLikeString: string) {
   }
 
   // Short format: t, to, tom => tomorrow
-  if (['t', 'to', 'tom'].indexOf(dateLikeString) >= 0) {
+  if (['t', 'to', 'tom', 'tom '].indexOf(dateLikeString) >= 0) {
     return `tomorrow morning`;
   }
 
   // Short format: nw, next week => next week
   if (['nw', 'next week'].indexOf(dateLikeString) >= 0) {
     return `next Monday`;
+  }
+
+  if (dateLikeString.indexOf('tom ') === 0) {
+    return dateLikeString.replace('tom ', 'tomorrow ');
   }
 
   return dateLikeString; // Return original string if no match

--- a/app/src/date-utils.ts
+++ b/app/src/date-utils.ts
@@ -149,10 +149,20 @@ function expandDateLikeString(dateLikeString: string) {
     return `${numWeeks} weeks`;
   }
 
-  // Short format: 2mo
+  // Short format: 2m
   if (/^\d+m$/.test(dateLikeString)) {
     const numMonths = dateLikeString.match(/^\d+/)[0]; // Extract number
     return `${numMonths} months`;
+  }
+
+  // Short format: t, to, tom => tomorrow
+  if (['t', 'to', 'tom'].indexOf(dateLikeString) >= 0) {
+    return `tomorrow morning`;
+  }
+
+  // Short format: nw, next week => next week
+  if (['nw', 'next week'].indexOf(dateLikeString) >= 0) {
+    return `next Monday`;
   }
 
   return dateLikeString; // Return original string if no match

--- a/app/src/date-utils.ts
+++ b/app/src/date-utils.ts
@@ -130,6 +130,34 @@ function getChronoPast() {
   return _chronoPast;
 }
 
+function expandDateLikeString(dateLikeString: string) {
+  // Short format: 2h
+  if (/^\d+h$/.test(dateLikeString)) {
+    const numHours = dateLikeString.match(/^\d+/)[0]; // Extract number
+    return `${numHours} hours`;
+  }
+
+  // Short format: 2d
+  if (/^\d+d$/.test(dateLikeString)) {
+    const numDays = dateLikeString.match(/^\d+/)[0]; // Extract number
+    return `${numDays} days`;
+  }
+
+  // Short format: 2w
+  if (/^\d+w$/.test(dateLikeString)) {
+    const numWeeks = dateLikeString.match(/^\d+/)[0]; // Extract number
+    return `${numWeeks} weeks`;
+  }
+
+  // Short format: 2mo
+  if (/^\d+m$/.test(dateLikeString)) {
+    const numMonths = dateLikeString.match(/^\d+/)[0]; // Extract number
+    return `${numMonths} months`;
+  }
+
+  return dateLikeString; // Return original string if no match
+}
+
 const DateUtils = {
   // Localized format: ddd, MMM D, YYYY h:mmA
   DATE_FORMAT_LONG: 'llll',
@@ -288,7 +316,8 @@ const DateUtils = {
    * @return {moment} - moment object representing date
    */
   futureDateFromString(dateLikeString) {
-    const date = getChronoFuture().parseDate(dateLikeString);
+    const expanded = expandDateLikeString(dateLikeString);
+    const date = getChronoFuture().parseDate(expanded);
     if (!date) {
       return null;
     }


### PR DESCRIPTION
Adds the ability to type in shorthand dates for Snooze. So instead of having to type out the entire string `4 hours`, you can just type `4h`, and the snoozer will intelligently interpret it.

<img width="70%" src="http://g.recordit.co/dw7LCzDMyh.gif" />

This addition applies to Reminders, too:

<img width="70%" src="https://user-images.githubusercontent.com/6979755/63643785-896fba80-c68d-11e9-8aaa-c748452e30a3.png" />
