### PR TITLE
 Fix onboarding process

### DIFF
--- a/app/internal_packages/onboarding/lib/onboarding-helpers.ts
+++ b/app/internal_packages/onboarding/lib/onboarding-helpers.ts
@@ -239,4 +239,5 @@ export async function finalizeAndValidateAccount(account: Account) {
 
   // Record the date of successful auth
   account.authedAt = new Date();
+  return account;
 }


### PR DESCRIPTION
When running onboarding process, the following error is displayed:

```
TypeError: Cannot read property 'emailAddress' of undefined
    at _AccountStore.addAccount (account-store.ts:223)
    at OnboardingStore._onFinishAndAddAccount (onboarding-store.ts:129)
    at EventEmitter.eventHandler (/home/ale/dev/Mailspring/Mailspring-Libre/app/node_modules/reflux/src/PublisherMethods.js:36)
    at EventEmitter.emit (/home/ale/dev/Mailspring/Mailspring-Libre/app/node_modules/eventemitter3/index.js:72)
    at Function.trigger (/home/ale/dev/Mailspring/Mailspring-Libre/app/node_modules/reflux/src/PublisherMethods.js:52)
    at Object.functor [as finishAndAddAccount] (/home/ale/dev/Mailspring/Mailspring-Libre/app/node_modules/reflux/src/createAction.js:32)
    at onboarding_helpers_1.finalizeAndValidateAccount.then.validated (create-page-for-form.tsx:170)
```

I believe this is caused by [`c4d7b22` We can now ask Google for auth/contacts permission (not readonly!) ](https://github.com/Foundry376/Mailspring/commit/c4d7b229f435dd440fdceaa7f9e2c574c4cdb090#diff-b076661317e311dde309543ebadb2612L237) which removed the return value from `finalizeAndValidateAccount`. This PR adds it back.