### PR TITLE
Made GenericName field more useful for app on Linux

### DIFF
--- a/app/build/resources/linux/mailspring.desktop.in
+++ b/app/build/resources/linux/mailspring.desktop.in
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=<%= productName %>
 Comment=<%= description %>
-GenericName=<%= productName %>
+GenericName=Mail Client
 Exec=/usr/bin/mailspring %U
 Icon=mailspring
 Type=Application


### PR DESCRIPTION
Changed GenericName value from "Mailspring" to "Mail Client" so that more useful info about the app is displayed on Linux, like in app launchers and taskbars (demonstrated in screenshots below).

Since the [convention](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#recognized-keys) is a short descriptive label of what the app is, and most other email clients like Thunderbird and KMail use "Mail Client", I also used "Mail Client".

**Pic 1:** Example of what other apps look like In the KDE taskbar:
![thunderbird](https://user-images.githubusercontent.com/29703429/78422763-891cb080-76ad-11ea-8683-1996f212000d.png)

**Pic 2:** What Mailspring looks like before change:
![mailspring_before](https://user-images.githubusercontent.com/29703429/78422776-989bf980-76ad-11ea-8171-bfd7c5f29156.png)

**Pic 3:** What Mailspring looks like after change (subtitle now displays useful info):
![mailspring_after](https://user-images.githubusercontent.com/29703429/78422783-a5b8e880-76ad-11ea-86a2-ac8d2cf97a65.png)

**Pic 4:** Mailspring in KDE Application Launcher before change
![task_launcher_before](https://user-images.githubusercontent.com/29703429/78422805-de58c200-76ad-11ea-9b8e-aab479a7db3c.png)

**Pic 5:** Mailspring in KDE Application Launcher after change
![task_launcher_after](https://user-images.githubusercontent.com/29703429/78422807-e6186680-76ad-11ea-8892-a9ebbc4bdd0d.png)

This brings its behavior/appearance in line with other apps on Linux.