### PR TITLE
debian: Update "Depends:" to include python2

### DIFF
--- a/app/build/resources/linux/debian/control.in
+++ b/app/build/resources/linux/debian/control.in
@@ -1,6 +1,6 @@
 Package: <%= name %>
 Version: <%= version %>
-Depends: libsecret-1-dev, git, gconf2, gconf-service, libgtk2.0-0, libudev0 | libudev1, libgcrypt11 | libgcrypt20, libnotify4, libxtst6, libnss3, python, gvfs-bin, xdg-utils
+Depends: libsecret-1-dev, git, gconf2, gconf-service, libgtk2.0-0, libudev0 | libudev1, libgcrypt11 | libgcrypt20, libnotify4, libxtst6, libnss3, python | python2, gvfs-bin, xdg-utils
 Suggests: gir1.2-gnomekeyring-1.0
 Section: <%= section %>
 Priority: optional


### PR DESCRIPTION
Adds support for Ubuntu 20.04, which has no package named "python".

Should fix #1880 to make this app's `.deb` package insallable on fresh installs of Ubuntu 20.04.