### PR TITLE
Added "Show original" in Message controls Actions Menu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,4 @@ client_secret.json
 **.bin
 **.tar.gz
 /app/mailsync.dSYM
+.idea

--- a/app/internal_packages/message-list/lib/message-controls.tsx
+++ b/app/internal_packages/message-list/lib/message-controls.tsx
@@ -41,13 +41,18 @@ export default class MessageControls extends React.Component<MessageControlsProp
       select: this._onForward,
     };
 
+    const showOriginal = {
+      name: localized('Show Original'),
+      select: this._onShowOriginal,
+    };
+
     if (!this.props.message.canReplyAll()) {
-      return [reply, forward];
+      return [reply, forward, showOriginal];
     }
     const defaultReplyType = AppEnv.config.get('core.sending.defaultReplyType');
     return defaultReplyType === 'reply-all'
-      ? [replyAll, reply, forward]
-      : [reply, replyAll, forward];
+      ? [replyAll, reply, forward, showOriginal]
+      : [reply, replyAll, forward, showOriginal];
   }
 
   _dropdownMenu(items) {


### PR DESCRIPTION
I love this product and would like to contribute a little bit actively both in terms of internal functions and developing external plugins.

One thing I find really difficult is showing the original content of the email.
On my Ubuntu is very tricky enabling the secret context menu using the right button.
I thought that integrating it directly into the dropdown would not be bad, personally I find it very useful.

Maybe could be good prepend an icon too, as in other dropdown menu items.

![Schermata da 2020-04-24 09-52-55](https://user-images.githubusercontent.com/3198901/80188587-ae983c80-8611-11ea-875a-93a7ae28ad97.png)
