### PR TITLE
Read some layout properties from CSS instead of hardcoded values

### DIFF
--- a/app/internal_packages/account-sidebar/lib/components/account-sidebar.tsx
+++ b/app/internal_packages/account-sidebar/lib/components/account-sidebar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Utils, Account, AccountStore } from 'mailspring-exports';
+import { Utils, DOMUtils, Account, AccountStore } from 'mailspring-exports';
 import { OutlineView, ScrollRegion, Flexbox } from 'mailspring-component-kit';
 import AccountSwitcher from './account-switcher';
 import SidebarStore from '../sidebar-store';
@@ -17,8 +17,8 @@ export default class AccountSidebar extends React.Component<{}, AccountSidebarSt
 
   static containerRequired = false;
   static containerStyles = {
-    minWidth: 165,
-    maxWidth: 250,
+    minWidth: DOMUtils.getWorkspaceCssNumberProperty('account-sidebar-min-width', 165),
+    maxWidth: DOMUtils.getWorkspaceCssNumberProperty('account-sidebar-max-width', 250),
   };
 
   unsubscribers = [];

--- a/app/internal_packages/thread-list/lib/thread-list.tsx
+++ b/app/internal_packages/thread-list/lib/thread-list.tsx
@@ -18,6 +18,7 @@ import {
   ChangeStarredTask,
   ChangeFolderTask,
   ChangeLabelsTask,
+  DOMUtils,
   ExtensionRegistry,
   FocusedContentStore,
   FocusedPerspectiveStore,
@@ -33,8 +34,8 @@ class ThreadList extends React.Component<{}, { style: string; syncing: boolean }
   static displayName = 'ThreadList';
 
   static containerStyles = {
-    minWidth: 300,
-    maxWidth: 3000,
+    minWidth: DOMUtils.getWorkspaceCssNumberProperty('thread-list-min-width', 300),
+    maxWidth: DOMUtils.getWorkspaceCssNumberProperty('thread-list-max-width', 3000),
   };
 
   refs: {
@@ -86,10 +87,10 @@ class ThreadList extends React.Component<{}, { style: string; syncing: boolean }
     let columns, itemHeight;
     if (this.state.style === 'wide') {
       columns = ThreadListColumns.Wide;
-      itemHeight = 36;
+      itemHeight = DOMUtils.getWorkspaceCssNumberProperty('thread-list-item-height-wide', 36);
     } else {
       columns = ThreadListColumns.Narrow;
-      itemHeight = 85;
+      itemHeight = DOMUtils.getWorkspaceCssNumberProperty('thread-list-item-height-narrow', 85);
     }
 
     return (
@@ -234,9 +235,10 @@ class ThreadList extends React.Component<{}, { style: string; syncing: boolean }
   _onDragEnd = event => {};
 
   _onResize = (event?: any) => {
+    const narrowStyleWidth = DOMUtils.getWorkspaceCssNumberProperty('thread-list-narrow-style-width', 540);
     const current = this.state.style;
     const desired =
-      (ReactDOM.findDOMNode(this) as HTMLElement).offsetWidth < 540 ? 'narrow' : 'wide';
+      (ReactDOM.findDOMNode(this) as HTMLElement).offsetWidth < narrowStyleWidth ? 'narrow' : 'wide';
     if (current !== desired) {
       this.setState({ style: desired });
     }

--- a/app/src/dom-utils.ts
+++ b/app/src/dom-utils.ts
@@ -197,5 +197,17 @@ var DOMUtils = {
   looksLikeBlockElement(node) {
     return ['BR', 'P', 'BLOCKQUOTE', 'DIV', 'TABLE'].includes(node.nodeName);
   },
+
+  getWorkspaceCssNumberProperty(property, defaultValue) {
+    const workspaceElement = document.querySelector('mailspring-workspace');
+    if (workspaceElement) {
+      const value = getComputedStyle(workspaceElement).getPropertyValue(`--${property}`);
+      if (value.length > 0) {
+        return +value;
+      }
+    }
+
+    return defaultValue;
+  },
 };
 export default DOMUtils;


### PR DESCRIPTION
As the title says, allows to override some layout properties using themes. For example:

```
mailspring-workspace {
    // Allow wide sidebar.
    --account-sidebar-max-width: 500;
    // Effectively always 'narrow' multiline style.
    --thread-list-narrow-style-width: 5000;
    // Make taller previews, two lines.
    --thread-list-item-height-narrow: 110;
}
```

The only issue I know of: some properties are only read on component creation/render time, for example row height. When switching a theme, only the CSS is getting applied, so some theme changes will only apply after reload or a major UI re-render.