### PR TITLE
Ignores dll dependencies in git and VSCode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,5 +71,7 @@ client_secret.json
 **.so*
 **.bin
 **.tar.gz
+**.dll
+/app/mailsync.exe
 /app/mailsync.dSYM
 .idea

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -26,5 +26,8 @@
     "thread": "cpp",
     "typeinfo": "cpp"
   },
-  "git.ignoreLimitWarning": true
+  "git.ignoreLimitWarning": true,
+  "files.exclude": {
+    "**/*.dll": true
+  }
 }


### PR DESCRIPTION
Simply added DLLs and mailsync.exe to the .gitignore so that development on Windows is a bit friendlier.