### PR TITLE
Fixes #2039: wrong time in event header due to timezone mismatch

### DIFF
--- a/app/internal_packages/events/lib/event-header.tsx
+++ b/app/internal_packages/events/lib/event-header.tsx
@@ -103,8 +103,8 @@ export class EventHeader extends React.Component<EventHeaderProps, EventHeaderSt
       return null;
     }
 
-    const startMoment = moment(icsEvent.startDate.toJSDate()).tz(DateUtils.timeZone);
-    const endMoment = moment(icsEvent.endDate.toJSDate()).tz(DateUtils.timeZone);
+    const startMoment = moment.tz(icsEvent.startDate.toString(), icsEvent.startDate.timezone).tz(DateUtils.timeZone);
+    const endMoment = moment.tz(icsEvent.endDate.toString(), icsEvent.endDate.timezone).tz(DateUtils.timeZone);
 
     const daySeconds = 24 * 60 * 60 * 1000;
     let day = '';
@@ -201,12 +201,12 @@ export class EventHeader extends React.Component<EventHeaderProps, EventHeaderSt
             {actionStatus === status || actionStatus !== inflight ? (
               actionLabel
             ) : (
-              <RetinaImg
-                width={18}
-                name="sending-spinner.gif"
-                mode={RetinaImg.Mode.ContentPreserve}
-              />
-            )}
+                <RetinaImg
+                  width={18}
+                  name="sending-spinner.gif"
+                  mode={RetinaImg.Mode.ContentPreserve}
+                />
+              )}
           </div>
         ))}
       </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1051,6 +1051,12 @@
       "integrity": "sha1-vX3CauKXLQ7aJTvgYdupkjScGfA=",
       "dev": true
     },
+    "buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+      "dev": true
+    },
     "buffer-fill": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
@@ -2549,15 +2555,15 @@
       }
     },
     "extract-zip": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.7.tgz",
-      "integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.7.0.tgz",
+      "integrity": "sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==",
       "dev": true,
       "requires": {
-        "concat-stream": "1.6.2",
-        "debug": "2.6.9",
-        "mkdirp": "0.5.1",
-        "yauzl": "2.4.1"
+        "concat-stream": "^1.6.2",
+        "debug": "^2.6.9",
+        "mkdirp": "^0.5.4",
+        "yauzl": "^2.10.0"
       },
       "dependencies": {
         "debug": {
@@ -2567,6 +2573,21 @@
           "dev": true,
           "requires": {
             "ms": "2.0.0"
+          }
+        },
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.5"
           }
         },
         "ms": {
@@ -2602,9 +2623,9 @@
       "dev": true
     },
     "fd-slicer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
-      "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
       "dev": true,
       "requires": {
         "pend": "~1.2.0"
@@ -4295,13 +4316,10 @@
       "dev": true
     },
     "is-finite": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-      "dev": true,
-      "requires": {
-        "number-is-nan": "^1.0.0"
-      }
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
+      "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
+      "dev": true
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
@@ -11295,12 +11313,13 @@
       }
     },
     "yauzl": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
-      "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
       "dev": true,
       "requires": {
-        "fd-slicer": "~1.0.1"
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
       }
     },
     "ycssmin": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@typescript-eslint/parser": "^1.4.2",
     "chalk": "1.x.x",
     "devtron": "^1.4.0",
-    "electron": "4.2.2",
+    "electron": "^4.2.2",
     "electron-installer-dmg": "0.2.x",
     "electron-packager": "14.2.x",
     "electron-winstaller": "2.x.x",


### PR DESCRIPTION
This probably also close #2024 #1546 and #1555 

## Background

The time displayed on the event-header component is wrong. In my case, it displayed the same time with the wrong timezone.

![wrong_time](https://user-images.githubusercontent.com/383862/87514352-bbb84b00-c697-11ea-904e-8fb39ba77e38.png)

8AM-9AM New York timezone is actually 5.30PM-6.30PM Indian Standard Time (IST)

### Bug location

Based on the link from #1546, the bug was located in the [event-header.tsx](https://github.com/Foundry376/Mailspring/blob/33aba8f31fbbbcda924d335804801fcbb4e13f0d/app/internal_packages/events/lib/event-header.tsx#L108) file.

### Investigating the code

Added the following lines to see what is happening in the time conversion.

```js
console.log("Event enddate", icsEvent.endDate);
console.log("Event enddate zone", icsEvent.endDate.zone.toString());
console.log("Event enddate utc offset", icsEvent.endDate.utcOffset());
console.log("Event enddate JSDate", icsEvent.endDate.toJSDate());
```

And got the following output:
![log](https://user-images.githubusercontent.com/383862/87514703-44cf8200-c698-11ea-89d4-885ccaaf2635.png)

Turns out the timezone information that is available in the `timezone` parameter of the ICAL.js library's Event's `endDate` is not stored in its `zone` attribute and instead, it shows the zone as `floating`. To check if iCal.js is parsing it wrong, I looked at the email data, here is the event

```
--000000000000dbd9b005aa540667
Content-Type: text/calendar; charset="UTF-8"; method=REQUEST
Content-Transfer-Encoding: 7bit

BEGIN:VCALENDAR
PRODID:-//Google Inc//Google Calendar 70.9054//EN
VERSION:2.0
CALSCALE:GREGORIAN
METHOD:REQUEST
BEGIN:VTIMEZONE
TZID:America/New_York
X-LIC-LOCATION:America/New_York
BEGIN:DAYLIGHT
TZOFFSETFROM:-0500
TZOFFSETTO:-0400
TZNAME:EDT
DTSTART:19700308T020000
RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU
END:DAYLIGHT
BEGIN:STANDARD
TZOFFSETFROM:-0400
TZOFFSETTO:-0500
TZNAME:EST
DTSTART:19701101T020000
RRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU
END:STANDARD
END:VTIMEZONE
BEGIN:VEVENT

DTSTART;TZID=America/New_York:20200714T080000
DTEND;TZID=America/New_York:20200714T090000

DTSTAMP:20200713T150552Z
ORGANIZER;CN=<redacted>
UID:<redacted>
ATTENDEE;CUTYPE=INDIVIDUAL;ROLE=REQ-PARTICIPANT;PARTSTAT=ACCEPTED;RSVP=TRUE
 ;CN=<redacted>;X-NUM-GUESTS=0:<redacted>
ATTENDEE;CUTYPE=INDIVIDUAL;ROLE=REQ-PARTICIPANT;PARTSTAT=NEEDS-ACTION;RSVP=
 TRUE;CN=<redacted>;X-NUM-GUESTS=0:<redacted>
X-MICROSOFT-CDO-OWNERAPPTID:-567554629
RECURRENCE-ID;TZID=America/New_York:20200716T083000
CREATED:20190604T120754Z
DESCRIPTION:-::~:~::~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~
 :~:~:~:~:~:~:~:~::~:~::-\nPlease do not edit this section of the descriptio
 n.\n\nView your event at <redacted>-::~:~::~:~:~:
 ~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~::~:~::-
LAST-MODIFIED:20200713T150551Z
LOCATION:
SEQUENCE:3
STATUS:CONFIRMED
SUMMARY:<redacted>
TRANSP:OPAQUE
END:VEVENT
END:VCALENDAR

--000000000000dbd9b005aa540667--
```

It can be seen that, both DTSTART and DTEND values have clear timezone information in them and id not marked as a floating timezone. At this point, it seems like a bug in the iCal.js library's parsing.

## Workaround

Until the upstream library (ical.js) fixes the parsing and gets the `timezone` information translated into the `zone` attribute, Mailspring will have to perform the conversion using **moment.js**

## Solution

This PR implements the above-mentioned workaround by creating a datetime object using the `timezone` attribute from the ical's `startDate` and `endDate` values.

Here is the right output of the event after the fix

![image](https://user-images.githubusercontent.com/383862/87515626-beb43b00-c699-11ea-8aaf-82af98df3a13.png)

P.S: A couple of unanticipated changes got added like updated versions in package.json and package lock. A small shift on the `RetinaImg` block due to linting. I noticed it only when writing the PR. Sorry about that.