### PR TITLE
mailcore-provider-settings: Add Hostinger email provider

### DIFF
--- a/app/internal_packages/onboarding/lib/mailcore-provider-settings.json
+++ b/app/internal_packages/onboarding/lib/mailcore-provider-settings.json
@@ -1305,5 +1305,53 @@
       "sentmail": "Sent Items",
       "trash": "Deleted Items"
     }
+  },
+  "hostinger": {
+    "servers": {
+      "imap": [
+        {
+          "port": 993,
+          "hostname": "imap.hostinger.com",
+          "ssl": true
+        },
+        {
+          "port": 143,
+          "hostname": "imap.hostinger.com",
+          "starttls": true
+        }
+      ],
+      "pop": [
+        {
+          "port": 995,
+          "hostname": "pop.hostinger.com",
+          "ssl": true
+        },
+        {
+          "port": 110,
+          "hostname": "pop.hostinger.com",
+          "starttls": true
+        }
+      ],
+      "smtp": [
+        {
+          "port": 465,
+          "hostname": "smtp.hostinger.com",
+          "ssl": true
+        },
+        {
+          "port": 587,
+          "hostname": "smtp.hostinger.com",
+          "starttls": true
+        }
+      ]
+    },
+    "mx-match": ["mx[0-9]*\\.hostinger\\.*"],
+    "mailboxes": {
+      "drafts": "Drafts",
+      "allmail": "Archive",
+      "spam": "Junk",
+      "sentmail": "Sent Messages",
+      "trash": "Deleted Messages"
+    }
   }
 }

--- a/app/internal_packages/onboarding/lib/mailspring-provider-settings.json
+++ b/app/internal_packages/onboarding/lib/mailspring-provider-settings.json
@@ -6433,5 +6433,24 @@
     "smtp_port": "465",
     "smtp_security": "SSL / TLS",
     "smtp_user_format": "email"
+  },
+  "hostinger.com": {
+    "display_name": "HOSTINGER",
+    "display_short_name": "HOSTINGER",
+    "imap_host": "imap.hostinger.com",
+    "imap_port": "993",
+    "imap_security": "SSL / TLS",
+    "imap_user_format": "email",
+    "imap_authentication": [
+      "password-cleartext"
+    ],
+    "smtp_host": "smtp.hostinger.com",
+    "smtp_port": "465",
+    "smtp_security": "SSL / TLS",
+    "smtp_user_format": "email",
+    "smtp_authentication": [
+      "password-cleartext"
+    ],
+    "enable_steps": []
   }
 }


### PR DESCRIPTION
Hello,
I would like to add Hostinger to email providers in MailSpring. We have noticed that our users are using MailSpring email clients and we would like to offer automated email configuration function.
Hostinger International, Ltd is an employee-owned web hosting provider and internet domain registrar. Established in 2004, Hostinger now has over 29 million users, collectively with its subsidiaries in 178 countries.