### PR TITLE
Allow data from "Copy Image.." to be pasted as an attachment (check all clipboard contents for Files, not just the first.)

### DIFF
--- a/app/src/components/composer-editor/composer-editor.tsx
+++ b/app/src/components/composer-editor/composer-editor.tsx
@@ -277,6 +277,8 @@ export function handleFilePasted(event: ClipboardEvent, onFileReceived: (path: s
   if (event.clipboardData.items.length === 0) {
     return false;
   }
+  // See https://github.com/Foundry376/Mailspring/pull/2104 - if you right-click + Copy Image in Chrome,
+  // the image file is item 1, not item 0. We want to prefer the files whenever one is present.
   for (const i in event.clipboardData.items) {
     const item = event.clipboardData.items[i];
     // If the pasteboard has a file on it, stream it to a temporary


### PR DESCRIPTION
This was implemented for the "Copy Image" function of browsers, which on Firefox and Chrome on Linux was tested to give item[0] as "text/html" and item[1] as a file.
This effectively worked in rich text mode anyway as it is able to paste text/html snippets, but was unable to work in plain text mode.

To demonstrate:
 - "Copy Image" from Firefox or Chome
 - Paste into a plaintext Mailspring composer

Current behaviour:
 Does nothing

Behaviour with this PR:
 Pastes image as an attachment.

Other changes of this PR:
 Rich text composer will now inline-attach images that are pasted this way, I believe previously an \<img src=http://..> live ref would have been pasted as part of the text/html snippet. IMO this change is better behaviour as
 - the end result for the user is the same ("my image appears in the email where I pasted it"),
 - it might fix broken/403 link issues ("I copied an image from google pictures but my recipient couldn't see it"),
 - and it unifies behaviour between plaintext and richtext modes.

If you don't like this change then I could special-case the plaintext editor but that would mean more code, conditional branches, eww, etc. :)