### PR TITLE
Fix paste files on Linux ( or other XDG desktops)

### DIFF
--- a/app/src/components/composer-editor/composer-editor.tsx
+++ b/app/src/components/composer-editor/composer-editor.tsx
@@ -311,8 +311,19 @@ export function handleFilePasted(event: ClipboardEvent, onFileReceived: (path: s
     new RegExp(String.fromCharCode(0), 'g'),
     ''
   );
+  const xdgCopiedFiles = (
+    (ElectronClipboard.read('text/uri-list') || '')
+      .split('\r\n') // yes, really
+      .filter(path => path.startsWith('file://'))
+      .map(path => path.replace('file://', ''))
+      .filter(path => path.length)
+  )
   if (macCopiedFile.length || winCopiedFile.length) {
     onFileReceived(macCopiedFile || winCopiedFile);
+    return true;
+  }
+  if (xdgCopiedFiles.length) {
+    xdgCopiedFiles.forEach(onFileReceived);
     return true;
   }
 


### PR DESCRIPTION
This adds a check to look for text/uri-list entries on the clipboard to paste files when available. This is analogous to the existing mac and Windows checks.

To demonstrate:
 - Open Thunar / Dolphin / Gnome Files on Linux
 - Copy a file
 - Paste into a mailspring compose window

Current behaviour:
- File path is pasted as text

Behaviour with this PR:
- File is pasted as an attachment


Thanks for maintaining a great email client on Linux!