### PR TITLE
Fix Appveyor Status Failure

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,6 +6,8 @@ branches:
     - /ci.*/
     - /stable.*/
 
+skip_non_tags: true
+
 init:
   - ps: $env:commit = $env:appveyor_repo_commit.SubString(0,8)
 


### PR DESCRIPTION
# Fix Appveyor CI
- Appveyor CI does not have access to the secrets from forks
- Skip Appveyor CI if the PR is a non-release commit
- Fix #1365

![appvyeor](https://user-images.githubusercontent.com/28627982/95676396-d5c8d300-0b8b-11eb-8135-23931743603c.png)
