### PR TITLE
add libglib2-bin as alternative to gvfs-bin

### DIFF
--- a/app/build/resources/linux/debian/control.in
+++ b/app/build/resources/linux/debian/control.in
@@ -1,6 +1,6 @@
 Package: <%= name %>
 Version: <%= version %>
-Depends: libsecret-1-dev, git, gconf2, gconf-service, libgtk2.0-0, libudev0 | libudev1, libgcrypt11 | libgcrypt20, libnotify4, libxtst6, libnss3, python | python2, gvfs-bin, xdg-utils
+Depends: libsecret-1-dev, git, gconf2, gconf-service, libgtk2.0-0, libudev0 | libudev1, libgcrypt11 | libgcrypt20, libnotify4, libxtst6, libnss3, python | python2, gvfs-bin | libglib2.0-bin, xdg-utils
 Suggests: gir1.2-gnomekeyring-1.0
 Section: <%= section %>
 Priority: optional


### PR DESCRIPTION
Should fix #2154, fix #2179, and fix #2198. Add libglib2.0-bin as an alternative dependency to gvfs-bin.
Resultant deb from current HEAD is here: https://github.com/akdor1154/Mailspring/releases/download/pr1/mailspring-1.7.8-amd64.deb . It installs here on Ubuntu 20.10 x86-64.

That deb is published purely to to allow others to test whether this dependency change works on their system. It is **not** a workaround to install Mailspring for you: it contains whatever is in master at this current point and is not a stable release.