### PR TITLE
Fix moment-timezone errors on calendar invites

### DIFF
--- a/app/internal_packages/events/lib/event-header.tsx
+++ b/app/internal_packages/events/lib/event-header.tsx
@@ -17,6 +17,7 @@ import {
   DatabaseStore,
 } from 'mailspring-exports';
 import ICAL from 'ical.js';
+import { findOneIana } from "windows-iana";
 
 const moment = require('moment-timezone');
 
@@ -103,8 +104,22 @@ export class EventHeader extends React.Component<EventHeaderProps, EventHeaderSt
       return null;
     }
 
-    const startMoment = moment.tz(icsEvent.startDate.toString(), icsEvent.startDate.timezone).tz(DateUtils.timeZone);
-    const endMoment = moment.tz(icsEvent.endDate.toString(), icsEvent.endDate.timezone).tz(DateUtils.timeZone);
+    // Workaround to convert calendar invites sent out from Microsoft calendars to IANA timezones
+    // that can be handled by moments-timezone.
+    let startTimezone = findOneIana(icsEvent.startDate.timezone) || icsEvent.startDate.timezone;
+    let endTimezone = findOneIana(icsEvent.endDate.timezone) || icsEvent.endDate.timezone;
+
+    // Workaround to convert calendar invites sent out from Google calendar with "Z" timezone
+    // to IANA timezone that can be handled by moments-timezone.
+    if (startTimezone === "Z") {
+      startTimezone = "UTC";
+    }
+    if (endTimezone === "Z") {
+      endTimezone = "UTC";
+    }
+
+    const startMoment = moment.tz(icsEvent.startDate.toString(), startTimezone).tz(DateUtils.timeZone);
+    const endMoment = moment.tz(icsEvent.endDate.toString(), endTimezone).tz(DateUtils.timeZone);
 
     const daySeconds = 24 * 60 * 60 * 1000;
     let day = '';

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1999,9 +1999,9 @@
       "integrity": "sha1-W68rdS6F0PaiJ8Chb2++EHwqLTk="
     },
     "moment-timezone": {
-      "version": "0.5.27",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.27.tgz",
-      "integrity": "sha512-EIKQs7h5sAsjhPCqN6ggx6cEbs94GK050254TIJySD1bzoM5JTYDwAU1IoVOeTOL6Gm27kYJ51/uuvq1kIlrbw==",
+      "version": "0.5.32",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.32.tgz",
+      "integrity": "sha512-Z8QNyuQHQAmWucp8Knmgei8YNo28aLjJq6Ma+jy1ZSpSk5nyfRT8xgUbSQvD2+2UajISfenndwvFuH3NGS+nvA==",
       "requires": {
         "moment": "2.24.0"
       }
@@ -3376,6 +3376,11 @@
       "requires": {
         "string-width": "1.0.2"
       }
+    },
+    "windows-iana": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/windows-iana/-/windows-iana-4.2.1.tgz",
+      "integrity": "sha512-ewNtGiWhAh66r5lYeWwiYWgg3ERcD+KiLMOqA8UCAKnKkFieb9M0VprLt7HD37bRFZKP7CLyXksj2L5hbrtnnw=="
     },
     "windows-quiet-hours": {
       "version": "1.2.7",

--- a/app/package.json
+++ b/app/package.json
@@ -43,7 +43,7 @@
     "mkdirp": "^0.5",
     "moment": "^2.24.0",
     "moment-round": "^1.0.1",
-    "moment-timezone": "^0.5.27",
+    "moment-timezone": "^0.5.32",
     "mousetrap": "^1.5.3",
     "node-emoji": "^1.2.1",
     "optimist": "0.4.0",
@@ -78,6 +78,7 @@
     "utf7": "^1.0.2",
     "uuid": "^3.0.0",
     "vcf": "^2.0.5",
+    "windows-iana": "^4.2.1",
     "windows-shortcuts": "emorikawa/windows-shortcuts#b0a0fc7",
     "xlsx": "0.14.1"
   },


### PR DESCRIPTION
While debugging different calendar invite issues, I noticed that the timezone of Google and Microsoft calendar invites could not be parsed correctly. This resolves the issue by adjusting some "uncommon" timezone formattings that are not understood by moment-timezone otherwise.