### PR TITLE
Ensure background start works in maximized mode

### DIFF
--- a/app/src/app-env.ts
+++ b/app/src/app-env.ts
@@ -558,12 +558,13 @@ export default class AppEnvConstructor {
   }
 
   restoreWindowDimensions() {
+    const settings = this.getLoadSettings();
     let dimensions = this.savedState.windowDimensions;
     if (!this.isValidDimensions(dimensions)) {
       dimensions = this.getDefaultWindowDimensions();
     }
     this.setWindowDimensions(dimensions);
-    if (dimensions.maximized && process.platform !== 'darwin') {
+    if (dimensions.maximized && !settings.initializeInBackground) {
       this.maximize();
     }
     if (dimensions.fullScreen) {


### PR DESCRIPTION
This PR fixes #1953 and fixes #1978

For more information see: https://community.getmailspring.com/t/run-as-minimized-on-startup/57


I tested the behaviour on macOS thoroughly and could not determine any reason why there was an extra handling implemented here. In my opiniton it is save to remove this extra check.