### PR TITLE
Ensure that the tray icon does not appear multiple times on linux

### DIFF
--- a/app/lang/de.json
+++ b/app/lang/de.json
@@ -445,6 +445,7 @@
   "Of your emails are opened": "Ihrer E-Mails sind geöffnet",
   "Offline": "Immer offline starten",
   "Okay": "okay",
+  "On Linux you need to restart Mailspring for the tray icon to disappear.": "Unter Linux musst du Mailspring neu starten, damit das Symbol in der Menüleiste verschwindet.",
   "One message in this thread is hidden because it was moved to trash or spam.": "Eine Nachricht in diesem Thread ist ausgeblendet, weil sie in Papierkorb oder Spam verschoben wurde.",
   "One or more of your mail rules have been disabled.": "Eine oder mehrere E-Mail-Regeln wurden deaktiviert.",
   "One or more of your mail rules requires the bodies of messages being processed. These rules can't be run on your entire mailbox.": "Eine oder mehrere Ihrer Mail-Regeln erfordern, dass die Nachrichtentexte verarbeitet werden. Diese Regeln können nicht für Ihr gesamtes Postfach ausgeführt werden.",

--- a/app/src/browser/system-tray-manager.ts
+++ b/app/src/browser/system-tray-manager.ts
@@ -104,7 +104,9 @@ class SystemTrayManager {
   }
 
   destroyTray() {
-    if (this._tray) {
+    // Due to https://github.com/electron/electron/issues/17622
+    // we cannot destroy the tray icon on linux.
+    if (this._tray && process.platform !== 'linux') {
       this._tray.removeListener('click', this._onClick);
       this._tray.destroy();
       this._tray = null;

--- a/app/src/config-schema.ts
+++ b/app/src/config-schema.ts
@@ -37,6 +37,9 @@ export default {
             default: true,
             title: localized('Show icon in menu bar / system tray'),
             platforms: ['darwin', 'linux'],
+            note: localized(
+              'On Linux you need to restart Mailspring for the tray icon to disappear.'
+            ),
           },
           showImportant: {
             type: 'boolean',


### PR DESCRIPTION
While checking out this feature request, i noticed a bug: https://community.getmailspring.com/t/exit-on-x-button/207/5

When the "Show icon in menu bar / system tray" configuration is unchecked on linux, the tray icon does not disappear. When the configuration is checked again, a second tray icon appears. This fix resolves the issue by adding a workaround around a known electron issue: https://github.com/electron/electron/issues/17622