### PR TITLE
Make "Run on Startup" UI state persistent

### DIFF
--- a/app/internal_packages/preferences/lib/tabs/workspace-section.tsx
+++ b/app/internal_packages/preferences/lib/tabs/workspace-section.tsx
@@ -78,12 +78,14 @@ class DefaultMailClientItem extends React.Component<{}, DefaultMailClientItemSta
   }
 }
 
+interface LaunchSystemStartItemState {
+  launchOnStart: boolean | 'unavailable';
+}
+
 class LaunchSystemStartItem extends React.Component {
   _service = new SystemStartService();
-  state = {
-    available: false,
-    launchOnStart: false,
-  };
+
+  state: LaunchSystemStartItemState = { launchOnStart: 'unavailable' };
 
   _mounted: boolean;
 
@@ -92,12 +94,13 @@ class LaunchSystemStartItem extends React.Component {
 
     const available = await service.checkAvailability();
     if (!this._mounted) return;
-    this.setState({ available });
 
     if (available) {
-      const launchOnStart = service.doesLaunchOnSystemStart();
+      const launchOnStart = await service.doesLaunchOnSystemStart();
       if (!this._mounted) return;
-      this.setState({ launchOnStart });
+      this.setState({ launchOnStart: launchOnStart });
+    } else {
+      this.setState({ launchOnStart: 'unavailable' });
     }
   }
 
@@ -117,7 +120,7 @@ class LaunchSystemStartItem extends React.Component {
   };
 
   render() {
-    if (!this.state.available) return false;
+    if (this.state.launchOnStart === 'unavailable') return false;
 
     return (
       <div className="item">


### PR DESCRIPTION
Resolves #2265

This appears to be resolved now, at least on Ubuntu 20.04.

The only "oddity" about the fix is that it can take a moment for the checkbox to update its state. This is due to the fact that it pulls its state from an awaitable. It was already *supposed* to be, but the promise was not being awaited, which I believe was part of the problem.

While I was at it, I adjusted the pattern to match that of the Default Mail Client checkbox. That enabled me to find the problem better.

I'd appreciate any suggestions on how to improve this further. Otherwise, it should be ready to land.