### PR TITLE
Decrease container minWidth to allow window to snap to half a screen

### DIFF
--- a/app/internal_packages/message-list/lib/message-list.tsx
+++ b/app/internal_packages/message-list/lib/message-list.tsx
@@ -47,7 +47,7 @@ const PREF_DESCENDING_ORDER = 'core.reading.descendingOrderMessageList';
 class MessageList extends React.Component<{}, MessageListState> {
   static displayName = 'MessageList';
   static containerStyles = {
-    minWidth: 500,
+    minWidth: 480,
     maxWidth: 999999,
   };
 

--- a/app/internal_packages/message-list/lib/sidebar-plugin-container.tsx
+++ b/app/internal_packages/message-list/lib/sidebar-plugin-container.tsx
@@ -69,7 +69,7 @@ export class SidebarPluginContainer extends React.Component {
   static containerStyles = {
     order: 1,
     flexShrink: 0,
-    minWidth: 200,
+    minWidth: 150,
     maxWidth: 300,
   };
 

--- a/app/internal_packages/thread-list/lib/thread-list.tsx
+++ b/app/internal_packages/thread-list/lib/thread-list.tsx
@@ -34,7 +34,7 @@ class ThreadList extends React.Component<{}, { style: string; syncing: boolean }
   static displayName = 'ThreadList';
 
   static containerStyles = {
-    minWidth: DOMUtils.getWorkspaceCssNumberProperty('thread-list-min-width', 300),
+    minWidth: DOMUtils.getWorkspaceCssNumberProperty('thread-list-min-width', 100),
     maxWidth: DOMUtils.getWorkspaceCssNumberProperty('thread-list-max-width', 3000),
   };
 


### PR DESCRIPTION
Decreasing the minimum width of certain elements allows the Mailspring window to be placed on half a screen (eg. snapping on Ubuntu using `Windows Key + Left Arrow`) even if the two coulmn layout is chosen. The minimum size is chosen so that the icons are still displayed correctly.