### PR TITLE
Make Mailspring ID optional, allow plugins to indicate dependency on synced metadata

### DIFF
--- a/app/internal_packages/account-sidebar/lib/sidebar-section.ts
+++ b/app/internal_packages/account-sidebar/lib/sidebar-section.ts
@@ -53,7 +53,7 @@ class SidebarSection {
       return this.empty(account.label);
     }
 
-    const items = _.reject(cats, cat => cat.role === 'drafts').map(cat =>
+    const items = _.reject(cats, cat => ['drafts', 'snoozed'].includes(cat.role)).map(cat =>
       SidebarItem.forCategories([cat], { editable: false, deletable: false })
     );
 
@@ -95,15 +95,7 @@ class SidebarSection {
       return this.standardSectionForAccount(accounts[0]);
     }
 
-    const standardNames = [
-      'inbox',
-      'important',
-      'snoozed',
-      'sent',
-      ['archive', 'all'],
-      'spam',
-      'trash',
-    ];
+    const standardNames = ['inbox', 'important', 'sent', ['archive', 'all'], 'spam', 'trash'];
     const items = [];
 
     for (const nameOrNames of standardNames) {

--- a/app/internal_packages/activity/package.json
+++ b/app/internal_packages/activity/package.json
@@ -11,6 +11,7 @@
   },
 
   "isOptional": true,
+  "isIdentityRequired": true,
 
   "title":"Activity Notifications and Dashboard",
   "icon":"./assets/icon.png",

--- a/app/internal_packages/link-tracking/package.json
+++ b/app/internal_packages/link-tracking/package.json
@@ -12,6 +12,7 @@
   "description": "Track when links in an email have been clicked by recipients.",
   "icon": "./icon.png",
   "isOptional": true,
+  "isIdentityRequired": true,
   "supportedEnvs": ["development", "staging", "production"],
 
   "repository": {

--- a/app/internal_packages/onboarding/lib/newsletter-signup.tsx
+++ b/app/internal_packages/onboarding/lib/newsletter-signup.tsx
@@ -2,7 +2,7 @@ import _ from 'underscore';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { RetinaImg, Flexbox } from 'mailspring-component-kit';
-import { localized, MailspringAPIRequest } from 'mailspring-exports';
+import { IdentityStore, localized, MailspringAPIRequest } from 'mailspring-exports';
 
 interface NewsletterSignupProps {
   name: string;
@@ -54,6 +54,11 @@ export default class NewsletterSignup extends React.Component<
 
   _onGetStatus = async (props = this.props) => {
     this._setState({ status: 'Pending' });
+
+    if (!IdentityStore.identity()) {
+      return;
+    }
+
     try {
       const { status } = await MailspringAPIRequest.makeRequest({
         server: 'identity',
@@ -144,6 +149,10 @@ export default class NewsletterSignup extends React.Component<
   }
 
   render() {
+    if (!IdentityStore.identity()) {
+      return <span />;
+    }
+
     return (
       <Flexbox direction="row" height="auto" style={{ textAlign: 'left' }}>
         <div style={{ minWidth: 15 }}>{this._renderControl()}</div>

--- a/app/internal_packages/open-tracking/package.json
+++ b/app/internal_packages/open-tracking/package.json
@@ -12,6 +12,7 @@
   "description": "Track when email messages have been opened by recipients.",
   "icon": "./icon.png",
   "isOptional": true,
+  "isIdentityRequired": true,
   "supportedEnvs": ["development", "staging", "production"],
 
   "repository": {

--- a/app/internal_packages/participant-profile/package.json
+++ b/app/internal_packages/participant-profile/package.json
@@ -4,7 +4,8 @@
   "title": "Participant Profile",
   "description": "Information about a participant",
 
-  "isOptional": false,
+  "isOptional": true,
+  "isIdentityRequired": true,
 
   "main": "lib/main",
   "windowTypes": {

--- a/app/internal_packages/preferences/styles/preferences-identity.less
+++ b/app/internal_packages/preferences/styles/preferences-identity.less
@@ -139,7 +139,7 @@
   }
   .feature-explore-grid {
     margin-top: 7px;
-    width: 100%;
+    margin-right: -20px;
     position: relative;
 
     .feature {

--- a/app/internal_packages/send-reminders/package.json
+++ b/app/internal_packages/send-reminders/package.json
@@ -3,10 +3,12 @@
   "version": "1.0.0",
   "title": "Send Reminders",
   "description": "Get reminded if you don't receive a reply for a message within a specified time in the future",
-  "isHiddenOnPluginsPage": true,
   "icon": "./icon.png",
   "main": "lib/main",
   "supportedEnvs": ["development", "staging", "production"],
+
+  "isOptional": true,
+  "isIdentityRequired": true,
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
@@ -14,7 +16,6 @@
     "default": true,
     "composer": true
   },
-  "isOptional": true,
   "engines": {
     "mailspring": "*"
   },

--- a/app/internal_packages/thread-list/lib/thread-list.tsx
+++ b/app/internal_packages/thread-list/lib/thread-list.tsx
@@ -177,12 +177,11 @@ class ThreadList extends React.Component<{}, { style: string; syncing: boolean }
       callback(true);
     };
 
-    const disabledPackages = AppEnv.config.get('core.disabledPackages') || [];
-    if (disabledPackages.includes('thread-snooze')) {
-      return props;
-    }
+    // Technically this should be exposed as an API so thread-snooze can register for this
+    // behavior, but for now we just check for it explicitly.
+    const snoozePresent = AppEnv.packages.isPackageActive('thread-snooze');
 
-    if (FocusedPerspectiveStore.current().isInbox()) {
+    if (snoozePresent && FocusedPerspectiveStore.current().isInbox()) {
       props.onSwipeLeftClass = 'swipe-snooze';
       props.onSwipeCenter = () => {
         Actions.closePopover();

--- a/app/internal_packages/thread-sharing/package.json
+++ b/app/internal_packages/thread-sharing/package.json
@@ -7,6 +7,8 @@
     "production": "https://share.getmailspring.com"
   },
 
+  "isOptional": true,
+  "isIdentityRequired": true,
   "title": "Thread Sharing",
   "description": "Share a thread through the web.",
   "main": "./lib/main",

--- a/app/internal_packages/thread-snooze/lib/main.ts
+++ b/app/internal_packages/thread-snooze/lib/main.ts
@@ -1,7 +1,8 @@
-import { localized, ComponentRegistry } from 'mailspring-exports';
+import { localized, ComponentRegistry, ExtensionRegistry } from 'mailspring-exports';
 import { HasTutorialTip } from 'mailspring-component-kit';
 
 import { ToolbarSnooze, QuickActionSnooze } from './snooze-buttons';
+import * as AccountSidebarExtension from './snooze-account-sidebar-extension';
 import { SnoozeMailLabel } from './snooze-mail-label';
 import { SnoozeStore } from './snooze-store';
 
@@ -17,12 +18,14 @@ export function activate() {
   ComponentRegistry.register(ToolbarSnoozeWithTutorialTip, { role: 'ThreadActionsToolbarButton' });
   ComponentRegistry.register(QuickActionSnooze, { role: 'ThreadListQuickAction' });
   ComponentRegistry.register(SnoozeMailLabel, { role: 'Thread:MailLabel' });
+  ExtensionRegistry.AccountSidebar.register(AccountSidebarExtension);
 }
 
 export function deactivate() {
   ComponentRegistry.unregister(ToolbarSnooze);
   ComponentRegistry.unregister(QuickActionSnooze);
   ComponentRegistry.unregister(SnoozeMailLabel);
+  ExtensionRegistry.AccountSidebar.unregister(AccountSidebarExtension);
   SnoozeStore.deactivate();
 }
 

--- a/app/internal_packages/thread-snooze/lib/snooze-account-sidebar-extension.ts
+++ b/app/internal_packages/thread-snooze/lib/snooze-account-sidebar-extension.ts
@@ -1,0 +1,13 @@
+import { localized, MailboxPerspective } from 'mailspring-exports';
+
+export const name = 'SnoozeAccountSidebarExtension';
+
+export function sidebarItem(accountIds: string[]) {
+  return {
+    id: 'snoozed',
+    name: localized('Snoozed'),
+    iconName: 'snoozed.png',
+    perspective: MailboxPerspective.forStandardCategories(accountIds, 'snoozed'),
+    insertAtTop: true,
+  };
+}

--- a/app/internal_packages/thread-snooze/package.json
+++ b/app/internal_packages/thread-snooze/package.json
@@ -4,6 +4,8 @@
   "title": "Thread Snooze",
   "description": "Snooze mail!",
   "main": "lib/main",
+  "isOptional": true,
+  "isIdentityRequired": true,
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/app/internal_packages/translation/package.json
+++ b/app/internal_packages/translation/package.json
@@ -4,6 +4,7 @@
   "main": "./lib/main",
 
   "isOptional": true,
+  "isIdentityRequired": true,
 
   "title": "Translation",
   "description": "Translate your drafts in the composer into other languages using the Yandex Translation API.",

--- a/app/src/browser/application.ts
+++ b/app/src/browser/application.ts
@@ -269,9 +269,8 @@ export default class Application extends EventEmitter {
 
     const accounts = this.config.get('accounts');
     const hasAccount = accounts && accounts.length > 0;
-    const hasIdentity = this.config.get('identity.id');
 
-    if (hasAccount && hasIdentity) {
+    if (hasAccount) {
       this.windowManager.ensureWindow(WindowManager.MAIN_WINDOW);
     } else {
       this.windowManager.ensureWindow(WindowManager.ONBOARDING_WINDOW, {
@@ -355,6 +354,19 @@ export default class Application extends EventEmitter {
         return;
       }
       win.browserWindow.inspectElement(x, y);
+    });
+
+    this.on('application:add-identity', () => {
+      const onboarding = this.windowManager.get(WindowManager.ONBOARDING_WINDOW);
+      if (onboarding) {
+        onboarding.show();
+        onboarding.focus();
+      } else {
+        this.windowManager.ensureWindow(WindowManager.ONBOARDING_WINDOW, {
+          title: localized('Welcome to Mailspring'),
+          windowProps: {},
+        });
+      }
     });
 
     this.on('application:add-account', ({ existingAccountJSON } = {}) => {

--- a/app/src/browser/main.js
+++ b/app/src/browser/main.js
@@ -8,7 +8,9 @@ const fs = require('fs');
 fs.statSyncNoException = function(...args) {
   try {
     return fs.statSync.apply(fs, args);
-  } catch (e) {}
+  } catch (e) {
+    //pass
+  }
   return false;
 };
 
@@ -16,7 +18,7 @@ console.inspect = function consoleInspect(val) {
   console.log(util.inspect(val, true, 7, true));
 };
 
-const app = require('electron').app;
+const { app, session } = require('electron');
 const path = require('path');
 const mkdirp = require('mkdirp');
 
@@ -281,7 +283,7 @@ const start = () => {
     // Block remote JS execution in a second way in case our <meta> tag approach
     // is compromised somehow https://www.electronjs.org/docs/tutorial/security
     // This CSP string should match the one in app/static/index.html
-    require('electron').session.defaultSession.webRequest.onHeadersReceived((details, callback) => {
+    session.defaultSession.webRequest.onHeadersReceived((details, callback) => {
       if (details.url.startsWith('devtools://')) {
         return callback(details);
       }

--- a/app/src/components/webview.tsx
+++ b/app/src/components/webview.tsx
@@ -1,6 +1,5 @@
 import url from 'url';
 import React from 'react';
-import PropTypes from 'prop-types';
 import { shell } from 'electron';
 import ReactDOM from 'react-dom';
 import classnames from 'classnames';
@@ -233,7 +232,7 @@ export default class Webview extends React.Component<WebviewProps, WebviewState>
   render() {
     return (
       <div className="webview-wrap">
-        <webview ref="webview" partition="in-memory-only" />
+        <webview ref="webview" partition="in-memory-only" enableremotemodule="false" />
         <div className={`webview-loading-spinner loading-${this.state.webviewLoading}`}>
           <RetinaImg
             style={{ width: 20, height: 20 }}

--- a/app/src/flux/stores/identity-store.ts
+++ b/app/src/flux/stores/identity-store.ts
@@ -1,6 +1,7 @@
 import MailspringStore from 'mailspring-store';
 import { remote } from 'electron';
 import url from 'url';
+import querystring from 'querystring';
 
 import * as Utils from '../models/utils';
 import * as Actions from '../actions';
@@ -190,8 +191,7 @@ class _IdentityStore extends MailspringStore {
     try {
       const json = await makeRequest({
         server: 'identity',
-        path: '/api/login-link',
-        qs: qs,
+        path: `/api/login-link?${querystring.stringify(qs)}`,
         body: body,
         timeout: 1500,
         method: 'POST',

--- a/app/src/flux/stores/identity-store.ts
+++ b/app/src/flux/stores/identity-store.ts
@@ -29,6 +29,8 @@ export interface IIdentity {
   };
 }
 
+export type IdentityAuthResponse = IIdentity | { skipped: true };
+
 export const EMPTY_IDENTITY: IIdentity = {
   id: '',
   token: '',
@@ -103,7 +105,7 @@ class _IdentityStore extends MailspringStore {
     }, 1000 * 60 * 10); // 10 minutes
   }
 
-  async saveIdentity(identity) {
+  async saveIdentity(identity: IIdentity | null) {
     if (!identity) {
       this._identity = null;
       await KeyManager.deletePassword(KEYCHAIN_NAME);

--- a/app/src/flux/stores/identity-store.ts
+++ b/app/src/flux/stores/identity-store.ts
@@ -31,17 +31,6 @@ export interface IIdentity {
 
 export type IdentityAuthResponse = IIdentity | { skipped: true };
 
-export const EMPTY_IDENTITY: IIdentity = {
-  id: '',
-  token: '',
-  firstName: '',
-  lastName: '',
-  emailAddress: '',
-  stripePlan: 'basic',
-  stripePlanEffective: '',
-  featureUsage: {},
-};
-
 export const EMPTY_FEATURE_USAGE = {
   featureLimitName: 'pro',
   period: 'monthly',
@@ -140,9 +129,10 @@ class _IdentityStore extends MailspringStore {
    * cache and set the token from the keychain.
    */
   _onIdentityChanged = async () => {
-    const next = Object.assign({}, AppEnv.config.get('identity') || {});
-    next.token = await KeyManager.getPassword(KEYCHAIN_NAME);
-    this._identity = next;
+    const value = AppEnv.config.get('identity');
+    this._identity = value
+      ? { ...value, token: await KeyManager.getPassword(KEYCHAIN_NAME) }
+      : null;
     this.trigger();
   };
 

--- a/app/src/package.ts
+++ b/app/src/package.ts
@@ -81,6 +81,14 @@ export default class Package {
     return !!this.json.isOptional;
   }
 
+  isEngineSet() {
+    return !!this.json.engines.mailspring;
+  }
+
+  isIdentityRequired() {
+    return !!this.json.isIdentityRequired;
+  }
+
   isDefault() {
     return !!this.json.isDefault;
   }

--- a/app/static/db-migration.html
+++ b/app/static/db-migration.html
@@ -2,7 +2,7 @@
 <html style="background: #fff">
 <head>
   <title>Updating Mailspring Database...</title>
-  <meta http-equiv="Content-Security-Policy" content="default-src * mailspring:; script-src 'self' 'unsafe-eval' chrome-extension://react-developer-tools; style-src * 'unsafe-inline' mailspring:; img-src * data: mailspring: file:;">
+  <meta http-equiv="Content-Security-Policy" content="default-src * mailspring:; script-src 'self' chrome-extension://react-developer-tools; style-src * 'unsafe-inline' mailspring:; img-src * data: mailspring: file:;">
   <style>
     .progress {
       position: relative;

--- a/app/static/db-vacuum.html
+++ b/app/static/db-vacuum.html
@@ -2,7 +2,7 @@
 <html style="background: #fff">
 <head>
   <title>Preparing Mailspring...</title>
-  <meta http-equiv="Content-Security-Policy" content="default-src * mailspring:; script-src 'self' 'unsafe-eval' chrome-extension://react-developer-tools; style-src * 'unsafe-inline' mailspring:; img-src * data: mailspring: file:;">
+  <meta http-equiv="Content-Security-Policy" content="default-src * mailspring:; script-src 'self' chrome-extension://react-developer-tools; style-src * 'unsafe-inline' mailspring:; img-src * data: mailspring: file:;">
   <style>
     .progress {
       position: relative;

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -3,7 +3,7 @@
 <head>
   <title>Mailspring</title>
 
-  <meta http-equiv="Content-Security-Policy" content="default-src * mailspring:; script-src 'self' 'unsafe-inline' chrome-extension://react-developer-tools; style-src * 'unsafe-inline' mailspring:; img-src * data: mailspring: file:;">
+  <meta http-equiv="Content-Security-Policy" content="default-src * mailspring:; script-src 'self' chrome-extension://react-developer-tools; style-src * 'unsafe-inline' mailspring:; img-src * data: mailspring: file:;">
 
   <script src="index.js"></script>
 </head>


### PR DESCRIPTION
Hey folks - this one has been a long time coming, but here we go!

This PR makes the Mailspring ID optional. When you launch the app for the first time, you can now bypass the Mailspring ID setup screen by choosing "Not Now" on the create an account page (it's at the bottom beneath sign in). The app reminds you that some features will be disabled, and then you're set!

When you opt out of the Mailspring ID, the value of `IdentityStore.identity()` is just `null`, rather than a placeholder identity or something like that. This required a few more code changes but it felt like the right approach.

On the mailsync side (also now GPLv3!), the tasks that sync message metadata to the cloud become no-ops and the metadata sync worker is disabled, but that's about all that had to change there. There is still one place where we use `https://id.getmailspring.com` to resolve CalDAV DNS but that API endpoint has been changed to not require auth. I think in the future this could be removed, but CalDAV uses some bizarre DNS records to indicate where the caldav root for an email domain is, and I wasn't able to get the DNS queries to work from C++ on Windows so I implemented them on the server.

There are several plugins like thread-sharing, translation and read-receipts that don't work at all without Mailspring's web services, and I updated the package manager so that these plugins can specify `isIdentityRequired: true` in their `package.json` files and be automatically disabled when a Mailspring ID isn't present.  The snooze plugin /mostly/ works without a Mailspring ID (since the cloud metadata sync is more optional there), but without the cloud saving your snooze dates any event that causes a full mail resync will wipe the local metadata table and reset snoozes, which could be pretty annoying. I disabled that one too, and maybe if there's a lot of interest we could evaluate how to make the local cache more persistent.

@notpushkin I'd love to get your thoughts about this since you've been leading the charge on Mailspring-Libre and have a better idea of what this slice of the Mailspring community is looking for! This PR leaves a lot of the links in the app (to documentation, setup guides etc) untouched, but I went through the mailspring-libre <> mailspring diff and tried to pull in the work of the community. Let me know if there's anything I missed - I'm sure there's more we can work on once this merges!

Also as a sidenote, while fixing this stuff I was relaunching Mailspring over and over and I was able to reproduce a C++ "dangling process at 100% CPU" issue that I think was reported elsewhere! Excited to get that fixed too.