### PR TITLE
[WIP] Customizable notification options per account

### DIFF
--- a/app/internal_packages/preferences/lib/tabs/preferences-account-details.tsx
+++ b/app/internal_packages/preferences/lib/tabs/preferences-account-details.tsx
@@ -354,6 +354,18 @@ class PreferencesAccountDetails extends Component<
             ? localized('Re-authenticate...')
             : localized('Update Connection Settings...')}
         </div>
+        <div style={{ display: 'flex', alignItems: 'baseline', marginBottom: 3, marginTop: 6 }}>
+          {localized('Notify for')}:
+          <select
+            style={{ marginTop: 0, marginLeft: 8 }}
+            value={account.notifyFor}
+            onChange={e => this._setStateAndSave({ notifyFor: e.target.value })}
+          >
+            <option value="inbox">{localized('Inbox Only')}</option>
+            <option value="all">{localized('All Folders')}</option>
+            <option value="none">{localized('None')}</option>
+          </select>
+        </div>
         <h6>{localized('Local Data')}</h6>
         <div className="btn" onClick={this._onResetCache}>
           {localized('Rebuild Cache...')}

--- a/app/internal_packages/unread-notifications/specs/main-spec.es6
+++ b/app/internal_packages/unread-notifications/specs/main-spec.es6
@@ -12,6 +12,8 @@ import {
 
 import { Notifier } from '../lib/main';
 
+// TODO: Add some tests here @nocommit
+
 describe('UnreadNotifications', function UnreadNotifications() {
   beforeEach(() => {
     this.notifier = new Notifier();

--- a/app/src/flux/models/account.ts
+++ b/app/src/flux/models/account.ts
@@ -10,6 +10,13 @@ export interface AccountAutoaddress {
   value: string;
   type: 'cc' | 'bcc';
 }
+
+export enum NotifyFor {
+  Inbox = 'inbox',
+  All = 'all',
+  None = 'none',
+}
+
 /*
  * Public: The Account model represents a Account served by the Mailspring Platform API.
  * Every object on the Mailspring platform exists within a Account, which typically represents
@@ -86,6 +93,10 @@ export class Account extends ModelWithMetadata {
     color: Attributes.String({
       modelKey: 'color',
     }),
+
+    notifyFor: Attributes.String({
+      modelKey: 'notifyFor',
+    }),
   };
 
   public name: string;
@@ -114,6 +125,7 @@ export class Account extends ModelWithMetadata {
   public syncState: string;
   public syncError: MailsyncProcessExit | null;
   public color: string;
+  public notifyFor: NotifyFor;
 
   constructor(args) {
     super(args);
@@ -126,6 +138,7 @@ export class Account extends ModelWithMetadata {
       value: '',
     };
     this.color = this.color || '';
+    this.notifyFor = this.notifyFor || NotifyFor.Inbox;
   }
 
   toJSON() {


### PR DESCRIPTION
Adds a new dropdown in the account settings to allow notifications to be configured for the account:

![image](https://user-images.githubusercontent.com/91933/111847739-afd7f500-88c6-11eb-9ea0-673fdc92b292.png)

The options are:
- **Inbox Only**: Current behaviour of only showing notifications for emails in the inbox. This is the default
- **All Folders**: Shows notifications for all folders. Technically this isn't actually "all" as it excludes spam and trash, but it's what users would expect "all" to mean
- **None**: Completely disables notifications of new emails for the account

I'd like to implement per-folder notification settings, but that can come as a followup

This PR solves the following feature requests:
 - [Notifications on Non-Inbox Folders](https://community.getmailspring.com/t/notifications-on-non-inbox-folders/323/)
 - [Per-account / mailbox notification settings](https://community.getmailspring.com/t/per-account-mailbox-notification-settings/133)

This is still a WIP as:
1. I'm hitting a bug where new emails in folders don't appear until a long time later, even after I do "Sync New Mail Now". Inbox is fine, but folders aren't. I tried waiting ten minutes and doing a sync, and the new emails still didn't appear. However, they do appear after some period of time (unsure as to how long it takes) or when I restartg Mailspring.  This is blocking me from fully testing. Related bug report: https://community.getmailspring.com/t/folders-not-updating-until-much-later/943
2. I want to write a unit test for my `shouldNotifyFor` function but I can't figure out how to run the tests in this project - `npm test` just pops up a white screen and throws this error:
```
index.js:26 Error: Could not find a file at path '../../static/jasmine'
    at ThemeManager.requireStylesheet (file:///C:/src/Mailspring/app/src/theme-manager.ts:163:13)
    at SpecRunner._setupAppEnv (file:///C:/src/Mailspring/app/spec/spec-runner/spec-runner.ts:118:19)
    at SpecRunner.runSpecs (file:///C:/src/Mailspring/app/spec/spec-runner/spec-runner.ts:30:10)
    at Object.<anonymous> (file:///C:/src/Mailspring/app/spec/spec-runner/spec-bootstrap.ts:15:34)
    at Object.<anonymous> (file:///C:/src/Mailspring/app/spec/spec-runner/spec-bootstrap.ts:15:57)
    at Module._compile (internal/modules/cjs/loader.js:968:30)
    at Object.value [as .ts] (C:\src\Mailspring\app\src\compile-cache.js:145:21)
    at Module.load (internal/modules/cjs/loader.js:816:32)
    at Module._load (internal/modules/cjs/loader.js:728:14)
    at Function.Module._load (electron/js2c/asar.js:748:26)
    at Module.require (internal/modules/cjs/loader.js:853:19)
    at require (internal/modules/cjs/helpers.js:74:18)
    at setupWindow (file:///C:/src/Mailspring/app/static/index.js:47:3)
    at window.onload (file:///C:/src/Mailspring/app/static/index.js:75:5)
```
I'm used to Jest tests, but this seems like it uses older Jasmine tests.