### PR TITLE
fixed regex issue with long processing

### DIFF
--- a/app/src/services/autolinker.ts
+++ b/app/src/services/autolinker.ts
@@ -30,7 +30,8 @@ function _runOnTextNode(node, matchers) {
       return;
     }
   }
-  if (node.textContent.trim().length < 4) {
+  let nodeTextContentLen = node.textContent.trim().length;
+  if (nodeTextContentLen < 4 || nodeTextContentLen > 5_000) {
     return;
   }
 


### PR DESCRIPTION
When in email content is adaptivecard as JWT it can be 50kB of text and regex processing tooks ~8s. Limited regex search to 5 000 characters

![Screenshot_20210402_022658](https://user-images.githubusercontent.com/79226331/113366933-f31c7400-935a-11eb-9491-914a96f56f2e.png)

