### PR TITLE
Construct a birthday year if none provided and hide its display

### DIFF
--- a/app/internal_packages/contacts/lib/ContactDetailRead.tsx
+++ b/app/internal_packages/contacts/lib/ContactDetailRead.tsx
@@ -149,7 +149,11 @@ const ContactAttributes = ({
               <Icons.Crown />
             </label>
             <div>
-              {new Date(item.date.year, item.date.month - 1, item.date.day).toLocaleDateString()}
+              { // If there is no year given, solely display the month and day
+                item.date.year ?
+                  new Date(item.date.year, item.date.month - 1, item.date.day).toLocaleDateString() :
+                  new Date(new Date().getFullYear(), item.date.month - 1, item.date.day).toLocaleDateString(undefined, { month: 'numeric', day: 'numeric' })
+              }
             </div>
           </div>
         ))}


### PR DESCRIPTION
This resolves #2018 / https://community.getmailspring.com/t/contact-birthdays-without-a-year-appears-as-invalid/902