### PR TITLE
Correctly place the header-toggle-control for e-mails with reminders

### DIFF
--- a/app/internal_packages/send-reminders/styles/send-reminders.less
+++ b/app/internal_packages/send-reminders/styles/send-reminders.less
@@ -60,6 +60,10 @@
     margin-top: -6px;
     margin-right: 10px;
   }
+
+  ~ .header-toggle-control {
+      top: 57px !important;
+  }
 }
 .message-list-headers .send-reminders-header {
   padding-left: 15px;


### PR DESCRIPTION
This resolves #2019 / https://community.getmailspring.com/t/header-toggle-control-in-wrong-place-for-reminders/903