### PR TITLE
CI: cleanup code, use xenial container as base and build snap using core18

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ client_secret.json
 /app/dist-docs
 /app/mailsync.dSYM.zip
 /snap/snapcraft.yml
+/snap/.snapcraft/
 
 **.so*
 **.bin

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "mailsync"]
 	path = mailsync
-	url = git@github.com:Foundry376/Mailspring-Sync.git
+	url = https://github.com/Foundry376/Mailspring-Sync.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -101,8 +101,6 @@ cache:
     - /var/lib/docker/aufs
 
 after_success:
-  # Grab the version number from the .deb product and update the snapcraft.yml file
-  - sed "s/MAILSPRING_VERSION/$(grep -E -o '([0-9]+.[0-9]+.[0-9]+)' <<< "$(find app/dist -type f -name mailspring-*.deb)")/g" snap/snapcraft.template.yaml > snap/snapcraft.yaml
   # Decrypt the snapcraft login information
   - openssl aes-256-cbc -K $encrypted_d506bd5213c4_key -iv $encrypted_d506bd5213c4_iv -in .snapcraft/credentials.enc -out .snapcraft/credentials -d
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ addons:
       - Mailspring.zip
       - $(find . -type f -name mailspring-*.deb | tr "\n" ":")
       - $(find . -type f -name mailspring-*.rpm | tr "\n" ":")
+      - $(find . -type f -name mailspring-*.snap | tr "\n" ":")
   apt:
     sources:
       - ubuntu-toolchain-r-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,13 @@ addons:
       - $(find . -type f -name mailspring-*.deb | tr "\n" ":")
       - $(find . -type f -name mailspring-*.rpm | tr "\n" ":")
       - $(find . -type f -name mailspring-*.snap | tr "\n" ":")
+  snaps:
+    - name: snapcraft
+      channel: candidate
+      confinement: classic
+    - name: transfer
+    - name: lxd
+      channel: stable
   apt:
     sources:
       - ubuntu-toolchain-r-test
@@ -101,19 +108,25 @@ cache:
     - node_modules
     - app/node_modules
     - /tmp/mailsync-build-deps-v2
-    - /var/lib/docker/aufs
 
 after_success:
+  # Prepare the snapcraft environment
+  - sudo /snap/bin/lxd.migrate -yes
+  - sudo /snap/bin/lxd waitready
+  - sudo /snap/bin/lxd init --auto
+  - mkdir -p "$TRAVIS_BUILD_DIR/snaps-cache"
+  - sudo SNAPCRAFT_ENABLE_DEVELOPER_DEBUG=y /snap/bin/snapcraft --use-lxd
+  - timeout 180 sudo /snap/bin/transfer *.snap
   # Decrypt the snapcraft login information
   - openssl aes-256-cbc -K $encrypted_d506bd5213c4_key -iv $encrypted_d506bd5213c4_iv -in .snapcraft/credentials.enc -out .snapcraft/credentials -d
 
-services:
-  - docker
+after_failure:
+  - test "$TRAVIS_OS_NAME" = "linux" && sudo journalctl -u snapd || true
 
 deploy:
   'on':
     branch: master
     condition: $TRAVIS_OS_NAME = linux
   provider: script
-  script: docker run -v $(pwd):$(pwd) -t snapcore/snapcraft sh -c "apt update -qq && cd $(pwd) && snapcraft && snapcraft login --with .snapcraft/credentials && (snapcraft push *.snap --release edge || true)"
+  script: sudo snapcraft login --with .snapcraft/credentials && sudo snapcraft push *.snap --release edge || true
   skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,11 +71,14 @@ matrix:
 
 before_install:
   # Decrypt and uncompress code signing certs, etc.
-  - openssl aes-256-cbc -K $encrypted_faf2708e46e2_key -iv $encrypted_faf2708e46e2_iv
-    -in app/build/resources/certs.tar.enc -out app/build/resources/certs.tar -d;
+  - if [ -n "$encrypted_faf2708e46e2_key" ] || [ "$TRAVIS_REPO_SLUG" = "Foundry376/Mailspring" ]; then
+    openssl aes-256-cbc -K $encrypted_faf2708e46e2_key -iv $encrypted_faf2708e46e2_iv
+    -in app/build/resources/certs.tar.enc -out app/build/resources/certs.tar -d; fi
   - mkdir app/build/resources/certs;
-  - tar xvf app/build/resources/certs.tar --directory=app/build/resources/;
-  - source app/build/resources/certs/mac/set_unix_env.sh;
+  - tar xvf app/build/resources/certs.tar --directory=app/build/resources/ ||
+    [ "$TRAVIS_REPO_SLUG" != "Foundry376/Mailspring" ]
+  - source app/build/resources/certs/mac/set_unix_env.sh ||
+    [ "$TRAVIS_REPO_SLUG" != "Foundry376/Mailspring" ]
   # Checkout the C++ Mailsync codebase
   - git submodule update --init mailsync
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,11 +75,8 @@ before_install:
   - mkdir app/build/resources/certs;
   - tar xvf app/build/resources/certs.tar --directory=app/build/resources/;
   - source app/build/resources/certs/mac/set_unix_env.sh;
-  # Checkout the (currently private) C++ Mailsync codebase
-  - GIT_SSH_COMMAND='ssh -i app/build/resources/certs/mailsync-deploy-key -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no'
-    SSH_ASKPASS=/Users/travis/build/Foundry376/Mailspring/app/build/resources/certs/ssh-askpass-fix
-    DISPLAY=nothing:0
-    git submodule update --init mailsync
+  # Checkout the C++ Mailsync codebase
+  - git submodule update --init mailsync
 
 # Resolves https://travis-ci.community/t/npm-ci-will-fail-if-cached-dependency-includes-npm/4203/6
 # Don't run the copy of npm inside node_modules when erasing + building the node_modules...

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,19 +23,35 @@ addons:
     sources:
       - ubuntu-toolchain-r-test
     packages:
+      - autoconf
+      - automake
       - build-essential
       - clang
+      - cmake
       - execstack
       - fakeroot
-      - g++-4.8
+      - g++-5
       - git
+      - libc-ares-dev
+      - libctemplate-dev
+      - libcurl4-openssl-dev
+      - libglib2.0-dev
       - libgnome-keyring-dev
+      - libicu-dev
+      - libsasl2-dev
+      - libsasl2-modules
+      - libsasl2-modules-gssapi-mit
       - libsecret-1-dev
-      - xvfb
-      - rpm
+      - libssl-dev
+      - libtidy-dev
+      - libtool
       - libxext-dev
-      - libxtst-dev
       - libxkbfile-dev
+      - libxml2-dev
+      - libxtst-dev
+      - rpm
+      - uuid-dev
+      - xvfb
 
 branches:
   only:
@@ -46,16 +62,14 @@ branches:
 matrix:
   include:
     - os: linux
-      env: CC=gcc-4.8 CXX=g++-4.8
-      dist: trusty
+      env: CC=gcc-5 CXX=g++-5
+      dist: xenial
     - os: osx
       osx_image: xcode10.1
       env: CC=clang CXX=clang++ SIGN_BUILD=true
 
 before_install:
   # Decrypt and uncompress code signing certs, etc.
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install cmake execstack g++-5 autoconf automake libtool libc-ares-dev libctemplate-dev libcurl4-openssl-dev libicu-dev libxext-dev libsasl2-dev libsasl2-modules libsasl2-modules-gssapi-mit libssl-dev libtidy-dev libxtst-dev libxkbfile-dev libglib2.0-dev libxml2-dev uuid-dev; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export CC=gcc-5 CXX=g++-5; fi
   - openssl aes-256-cbc -K $encrypted_faf2708e46e2_key -iv $encrypted_faf2708e46e2_iv
     -in app/build/resources/certs.tar.enc -out app/build/resources/certs.tar -d;
   - mkdir app/build/resources/certs;
@@ -72,7 +86,7 @@ before_install:
 install: PATH=$(echo "$PATH" | sed 's/.\/node_modules\/.bin://') npm ci
 
 before_script:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export DISPLAY=:99.0; sh -e /etc/init.d/xvfb start; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then Xvfb :99 & export DISPLAY=:99.0; fi
 
 script:
   - npm run ci-setup-mac-keychain

--- a/snap/.snapcraft/state
+++ b/snap/.snapcraft/state
@@ -1,3 +1,0 @@
-!GlobalState
-assets:
-  build-packages: []

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,32 +1,17 @@
 name: mailspring
 adopt-info: mailspring
-description: |
-  An extensible desktop mail app built on the modern web.
 
 confinement: strict
+base: core18
 
 architectures:
   - build-on: amd64
-
-plugs:
-  gtk-3-themes:
-    interface: content
-    target: $SNAP/share/themes
-    default-provider: gtk-common-themes:gtk-3-themes
-  icon-themes:
-    interface: content
-    target: $SNAP/share/icons
-    default-provider: gtk-common-themes:icon-themes
-  sound-themes:
-    interface: content
-    target: $SNAP/share/sounds
-    default-provider: gtk-common-themes:sounds-themes
 
 parts:
   mailspring:
     plugin: nil
     override-pull: |
-      deb="$(ls $SNAPCRAFT_STAGE/../app/dist/mailspring-*.deb)"
+      deb="$(ls $SNAPCRAFT_PROJECT_DIR/app/dist/mailspring-*.deb)"
       snapcraftctl set-version "$(basename "$deb" | grep -Eo "[0-9]+.[0-9]+.[0-9]+")"
       dpkg -x "$deb" "$SNAPCRAFT_PART_SRC"
     override-build: |
@@ -34,39 +19,25 @@ parts:
       snapcraftctl build
       sed -i 's|Icon=mailspring|Icon=/usr/share/pixmaps/mailspring\.png|' \
         $SNAPCRAFT_PART_INSTALL/usr/share/applications/Mailspring.desktop
-      mkdir -p $SNAPCRAFT_PART_INSTALL/share/themes
-      mkdir -p $SNAPCRAFT_PART_INSTALL/share/icons
-      mkdir -p $SNAPCRAFT_PART_INSTALL/share/sounds
+    prime:
+      - -usr/share/mailspring/chrome-sandbox
     parse-info: [usr/share/appdata/mailspring.appdata.xml]
-    after:
-      - desktop-gtk3
     stage-packages:
-      - gir1.2-gnomekeyring-1.0
-      - libcanberra-gtk-module
-      - libasound2
-      - libcurl3
-      - libgconf2-4
-      - libgcrypt20
-      - libsecret-1-0
-      - libnotify4
       - libnspr4
       - libnss3
-      - libpulse0
-      - libpcre3
       - libxkbfile1
       - libxss1
-      - libxtst6
-      - python
 
 apps:
   mailspring:
-    command: desktop-launch $SNAP/usr/share/mailspring/mailspring --no-sandbox
+    command: usr/bin/mailspring --no-sandbox
     common-id: mailspring
     desktop: usr/share/applications/Mailspring.desktop
+    extensions: [gnome-3-34]
     environment:
+      HOME: $SNAP_USER_COMMON
       # Correct the TMPDIR path for Chromium Framework/Electron to
       # ensure libappindicator has readable resources.
-      HOME: $SNAP_USER_COMMON
       TMPDIR: $XDG_RUNTIME_DIR
       # Fallback to XWayland if running in a Wayland session.
       DISABLE_WAYLAND: 1

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,4 @@
 name: mailspring
-summary: The best email app for people and teams at work
 adopt-info: mailspring
 description: |
   An extensible desktop mail app built on the modern web.
@@ -38,6 +37,7 @@ parts:
       mkdir -p $SNAPCRAFT_PART_INSTALL/share/themes
       mkdir -p $SNAPCRAFT_PART_INSTALL/share/icons
       mkdir -p $SNAPCRAFT_PART_INSTALL/share/sounds
+    parse-info: [usr/share/appdata/mailspring.appdata.xml]
     after:
       - desktop-gtk3
     stage-packages:
@@ -61,6 +61,7 @@ parts:
 apps:
   mailspring:
     command: desktop-launch $SNAP/usr/share/mailspring/mailspring --no-sandbox
+    common-id: mailspring
     desktop: usr/share/applications/Mailspring.desktop
     environment:
       # Correct the TMPDIR path for Chromium Framework/Electron to

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -68,10 +68,6 @@ apps:
       # ensure libappindicator has readable resources.
       HOME: $SNAP_USER_COMMON
       TMPDIR: $XDG_RUNTIME_DIR
-      # Coerce XDG_CURRENT_DESKTOP to Unity so that App Indicators
-      # are used and do not fall back to Notification Area applets
-      # or disappear completely.
-      XDG_CURRENT_DESKTOP: Unity
       # Fallback to XWayland if running in a Wayland session.
       DISABLE_WAYLAND: 1
     plugs:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -28,6 +28,23 @@ parts:
       - libxkbfile1
       - libxss1
 
+  cleanup:
+    after: [mailspring]
+    plugin: nil
+    build-snaps: [core18, gnome-3-34-1804]
+    override-prime: |
+      set -eux
+      build_snaps="core18 gnome-3-34-1804"
+      for snap in $build_snaps; do
+        cd "/snap/$snap/current" && \
+        find . -type f,l -exec rm -fv "$SNAPCRAFT_PRIME/{}" "$SNAPCRAFT_PRIME/usr/{}" \;
+      done
+      for CRUFT in bug lintian man; do
+        rm -rf $SNAPCRAFT_PRIME/usr/share/$CRUFT
+      done
+      find $SNAPCRAFT_PRIME/usr/share/doc/ -type f -not -name 'copyright' -delete -print
+      find $SNAPCRAFT_PRIME/usr/share -type d -empty -delete -print
+
 apps:
   mailspring:
     command: usr/bin/mailspring --no-sandbox

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,10 +1,13 @@
 name: mailspring
-version: MAILSPRING_VERSION
 summary: The best email app for people and teams at work
+adopt-info: mailspring
 description: |
   An extensible desktop mail app built on the modern web.
 
 confinement: strict
+
+architectures:
+  - build-on: amd64
 
 plugs:
   gtk-3-themes:
@@ -22,12 +25,16 @@ plugs:
 
 parts:
   mailspring:
-    plugin: dump
-    source: ./app/dist/mailspring-MAILSPRING_VERSION-amd64.deb
-    source-type: deb
-    # Correct path to icon.
-    prepare: |
-      sed -i 's|Icon=mailspring|Icon=/usr/share/pixmaps/mailspring\.png|' usr/share/applications/Mailspring.desktop
+    plugin: nil
+    override-pull: |
+      deb="$(ls $SNAPCRAFT_STAGE/../app/dist/mailspring-*.deb)"
+      snapcraftctl set-version "$(basename "$deb" | grep -Eo "[0-9]+.[0-9]+.[0-9]+")"
+      dpkg -x "$deb" "$SNAPCRAFT_PART_SRC"
+    override-build: |
+      cp -a "$SNAPCRAFT_PART_SRC"/* "$SNAPCRAFT_PART_INSTALL"
+      snapcraftctl build
+      sed -i 's|Icon=mailspring|Icon=/usr/share/pixmaps/mailspring\.png|' \
+        $SNAPCRAFT_PART_INSTALL/usr/share/applications/Mailspring.desktop
       mkdir -p $SNAPCRAFT_PART_INSTALL/share/themes
       mkdir -p $SNAPCRAFT_PART_INSTALL/share/icons
       mkdir -p $SNAPCRAFT_PART_INSTALL/share/sounds

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,4 +1,5 @@
 name: mailspring
+license: GPL-3.0
 adopt-info: mailspring
 
 confinement: strict


### PR DESCRIPTION
This is some cleanup work on travis-ci to be used as base for adding further changes to the snap code (as we need newer snapcraft via lxd to do that).

The cleanup eventually allowed to port the snap to use [core18](https://snapcraft.io/core18) and gnome-3.34 as base for the snap content (that reduces space and uses better desktop integration, especially with file picker).

We also may move to core20, but we'd need to build it under focal, and this may be unwanted (unless we do a full snap build alone)

An example run is at: https://travis-ci.com/github/3v1n0/Mailspring/jobs/498546128
While a built snap is: https://transfer.sh/1oyK9/mailspring_1.9.0_amd64.snap