### PR TITLE
Prevent strange layout bug for trash / spam folders on vertical layout

### DIFF
--- a/app/internal_packages/thread-list/lib/main.ts
+++ b/app/internal_packages/thread-list/lib/main.ts
@@ -19,6 +19,7 @@ export function activate() {
 
   ComponentRegistry.register(ThreadList, {
     location: WorkspaceStore.Location.ThreadList,
+    role: 'ThreadList',
     modes: ['split', 'list'],
   });
 

--- a/app/internal_packages/thread-list/lib/thread-list-vertical.tsx
+++ b/app/internal_packages/thread-list/lib/thread-list-vertical.tsx
@@ -22,7 +22,7 @@ class ThreadListVertical extends React.Component<
           onResize={h => this._onResize(h)}
         >
           <InjectedComponentSet
-            matching={{ location: WorkspaceStore.Location.ThreadList, modes: ['split'] }}
+            matching={{ role: 'ThreadList' }}
           />
         </ResizableRegion>
         <ResizableRegion>

--- a/app/lang/de.json
+++ b/app/lang/de.json
@@ -171,7 +171,7 @@
   "Delete Draft": "Entwurf löschen",
   "Delete Template?": "Vorlage löschen?",
   "Delete your custom key bindings and reset to the template defaults?": "Benutzerdefinierte Tastenbelegungen löschen und auf die Standardwerte zurücksetzen?",
-  "Deleted": "Gelöscht",
+  "Deleted": "Gelöschten",
   "Deleting %@": "Lösche %@",
   "Deleting all messages in %@": "Lösche alle Nachrichten in %@",
   "Deleting draft": "Lösche Entwurf",


### PR DESCRIPTION
This resolves the issue, as the ThreadListEmptyFolderBar registeres to be displayed at the `WorkspaceStore.Location.ThreadList`, which happened to exist twice in the ThreadListVertical view. This changes removes the duplicate location, so that the ThreadListEmptyFolderBar is only displayed once at the correct location.

Also improve the German translation slightly.