### PR TITLE
feat(MailRule): add 'forward' action to mail rules

### DIFF
--- a/app/src/components/scenario-editor-models.ts
+++ b/app/src/components/scenario-editor-models.ts
@@ -35,6 +35,7 @@ const Types = {
   None: 'None',
   Enum: 'Enum',
   String: 'String',
+  InputString: 'InputString'
 };
 
 export const Comparators = {

--- a/app/src/components/scenario-editor-row.tsx
+++ b/app/src/components/scenario-editor-row.tsx
@@ -175,7 +175,7 @@ export default class ScenarioEditorRow extends React.Component<ScenarioEditorRow
       );
     }
 
-    if (template.type === Template.Type.String) {
+    if (template.type === Template.Type.String || template.type === Template.Type.InputString) {
       return <input type="text" value={this.props.instance.value} onChange={this._onChangeValue} />;
     }
     return false;

--- a/app/src/flux/actions.ts
+++ b/app/src/flux/actions.ts
@@ -368,6 +368,15 @@ export const composeReply = create('composeReply', ActionScopeWindow);
 export const composeForward = create('composeForward', ActionScopeWindow);
 
 /*
+  Public: Compose and send a new draft for forwarding the provided threadId and messageId. See
+  {::composeReply} for parameters and behavior.
+
+  *Scope: Window*
+  */
+export const composeAndSendForward = create('composeAndSendForward', ActionScopeWindow);
+
+
+/*
   Public: Pop out the draft with the provided ID so the user can edit it in another
   window.
 

--- a/app/src/mail-rules-processor.ts
+++ b/app/src/mail-rules-processor.ts
@@ -5,6 +5,7 @@ import * as Actions from './flux/actions';
 import { Thread } from './flux/models/thread';
 import { Folder } from './flux/models/folder';
 import { Label } from './flux/models/label';
+import { Contact } from './flux/models/contact';
 import CategoryStore from './flux/stores/category-store';
 import DatabaseStore from './flux/stores/database-store';
 import TaskQueue from './flux/stores/task-queue';
@@ -72,6 +73,15 @@ const MailRulesActions: {
       threads: [thread],
       source: 'Mail Rules',
     });
+  },
+
+  forward: (message, thread, value) => {
+    Actions.composeAndSendForward({
+      thread: thread,
+      message: message,
+      to: [new Contact({email: value})]
+    });
+    return undefined;
   },
 
   changeFolder: async (message, thread, value) => {

--- a/app/src/mail-rules-templates.ts
+++ b/app/src/mail-rules-templates.ts
@@ -71,6 +71,7 @@ export const ActionTemplates = [
   new Template('markAsRead', Template.Type.None, { name: localized('Mark as Read') }),
   new Template('moveToTrash', Template.Type.None, { name: localized('Move to Trash') }),
   new Template('star', Template.Type.None, { name: localized('Star') }),
+  new Template('forward', Template.Type.InputString, { name: localized('Forward'), valueLabel: "to:" })
 ];
 
 export const ConditionMode = {


### PR DESCRIPTION
This pr adds a new forward action to the mail rules. I use this functionality a lot to automatically send invoices to my printer & bookkeeper, and needed it before migrating to Mailspring, but I'm not sure if it's actually something that should be in the master build.