### PR TITLE
Ensure that mailspring is correctly started in the background on macos

### DIFF
--- a/app/src/system-start-service.ts
+++ b/app/src/system-start-service.ts
@@ -86,8 +86,7 @@ class SystemStartServiceDarwin extends SystemStartServiceBase {
   _launchdPlist() {
     return {
       Label: 'com.mailspring.mailspring',
-      Program: this._launcherPath(),
-      ProgramArguments: ['--background'],
+      ProgramArguments: [this._launcherPath(), '--background'],
       RunAtLoad: true,
     };
   }


### PR DESCRIPTION
Currently, the `--background` flag of the plist autostart file on macos is ignored as it is treated as the filename of the command to start (which should be mailspring) and not as an argument. Therefore Mailspring is started in foreground mode instead of background mode.

For more information see: https://apple.stackexchange.com/questions/110644/getting-launchd-to-read-program-arguments-correctly