### PR TITLE
Add protonmail.ch domain into onboarding defaults

### DIFF
--- a/app/internal_packages/onboarding/lib/mailspring-provider-settings.json
+++ b/app/internal_packages/onboarding/lib/mailspring-provider-settings.json
@@ -6454,6 +6454,12 @@
     "enable_steps": []
   },
   "protonmail.com": {
+    "alias": "protonmail"
+  },
+  "protonmail.ch": {
+    "alias": "protonmail"
+  },
+  "protonmail": {
     "imap_host": "127.0.0.1",
     "imap_port": "1143",
     "imap_security": "STARTTLS",


### PR DESCRIPTION
Protonmail used to allow `.ch` domain for new users' email domain. I also have one. Without this, no default Folder is chosen when creating protonmail account and protonmail fix [2323](https://github.com/Foundry376/Mailspring/pull/2323) does not work.  