### PR TITLE
Add releases info and squeeze content_rating to fix flatpak build

### DIFF
--- a/app/build/resources/linux/mailspring.appdata.xml.in
+++ b/app/build/resources/linux/mailspring.appdata.xml.in
@@ -23,7 +23,7 @@
   <url type="homepage">https://getmailspring.com/</url>
   <url type="bugtracker">https://github.com/Foundry376/Mailspring/issues</url>
   <url type="help">http://support.getmailspring.com/</url>
-  <launchable type="desktop-id"><%= name %>.desktop</launchable>
+  <launchable type="desktop-id"><%= productName %>.desktop</launchable>
 
   <developer_name>Mailspring</developer_name>
   <project_license>GPL-3.0+</project_license>

--- a/app/build/resources/linux/mailspring.appdata.xml.in
+++ b/app/build/resources/linux/mailspring.appdata.xml.in
@@ -32,26 +32,11 @@
     <screenshot type="default">https://getmailspring.com/static/img/hero_graphic_linux@2x.png</screenshot>
   </screenshots>
 
-  <content_rating type="oars-1.0">
-    <content_attribute id="violence-cartoon">none</content_attribute>
-    <content_attribute id="violence-fantasy">none</content_attribute>
-    <content_attribute id="violence-realistic">none</content_attribute>
-    <content_attribute id="violence-bloodshed">none</content_attribute>
-    <content_attribute id="violence-sexual">none</content_attribute>
-    <content_attribute id="drugs-alcohol">none</content_attribute>
-    <content_attribute id="drugs-narcotics">none</content_attribute>
-    <content_attribute id="drugs-tobacco">none</content_attribute>
-    <content_attribute id="sex-nudity">none</content_attribute>
-    <content_attribute id="sex-themes">none</content_attribute>
-    <content_attribute id="language-profanity">none</content_attribute>
-    <content_attribute id="language-humor">none</content_attribute>
-    <content_attribute id="language-discrimination">none</content_attribute>
-    <content_attribute id="social-chat">intense</content_attribute>
-    <content_attribute id="social-info">intense</content_attribute>
-    <content_attribute id="social-audio">none</content_attribute>
-    <content_attribute id="social-location">none</content_attribute>
-    <content_attribute id="social-contacts">none</content_attribute>
-    <content_attribute id="money-purchasing">none</content_attribute>
-    <content_attribute id="money-gambling">none</content_attribute>
-  </content_rating>
+  <releases>
+    <release version="1.9.2" date="2021-09-06"/>
+    <release version="1.9.1" date="2021-04-16"/>
+    <release version="1.9.0" date="2021-04-14"/>
+    <release version="1.8.0" date="2021-01-20"/>
+  </releases>
+  <content_rating type="oars-1.0" />
 </component>


### PR DESCRIPTION
This PR solves these Appdata file errors:
- Doesn't contain right name for desktop file
- Doesn't have release tags
  

**NOTE:**
- The release tag needs to be added whenever a new release is created.