### PR TITLE
Default to SSL / TLS on port 465 for SMTP, per RFC 8314

### DIFF
--- a/app/internal_packages/onboarding/lib/onboarding-helpers.ts
+++ b/app/internal_packages/onboarding/lib/onboarding-helpers.ts
@@ -192,10 +192,10 @@ export async function expandAccountWithCommonSettings(account: Account) {
     imap_security: mstemplate.imap_security || 'SSL / TLS',
     imap_allow_insecure_ssl: mstemplate.imap_allow_insecure_ssl || false,
     smtp_host: mstemplate.smtp_host,
-    smtp_port: mstemplate.smtp_port || 587,
+    smtp_port: mstemplate.smtp_port || 465,
     smtp_username: usernameWithFormat(mstemplate.smtp_user_format),
     smtp_password: populated.settings.smtp_password || populated.settings.imap_password,
-    smtp_security: mstemplate.smtp_security || 'STARTTLS',
+    smtp_security: mstemplate.smtp_security || 'SSL / TLS',
     smtp_allow_insecure_ssl: mstemplate.smtp_allow_insecure_ssl || false,
     container_folder: mstemplate.container_folder,
   };

--- a/app/internal_packages/onboarding/lib/page-account-settings-imap.tsx
+++ b/app/internal_packages/onboarding/lib/page-account-settings-imap.tsx
@@ -97,6 +97,9 @@ class AccountIMAPSettingsForm extends React.Component<AccountIMAPSettingsFormPro
             if (port === 25 && settings.smtp_security !== 'none') {
               onFieldChange({ target: { value: 'none', id: 'settings.smtp_security' } });
             }
+            if (port === 465 && settings.smtp_security !== 'SSL / TLS') {
+              onFieldChange({ target: { value: 'SSL / TLS', id: 'settings.smtp_security' } });
+            }
             if (port === 587 && settings.smtp_security !== 'STARTTLS') {
               onFieldChange({ target: { value: 'STARTTLS', id: 'settings.smtp_security' } });
             }


### PR DESCRIPTION
Since [RFC 8314](https://datatracker.ietf.org/doc/html/rfc8314) _Cleartext Considered Obsolete: Use of Transport Layer Security (TLS) Email Submission and Access_, SMTP with Implicit TLS over port 465 is preferred over SMTP with STARTTLS over port 587.

See [Section 3](https://datatracker.ietf.org/doc/html/rfc8314#section-3):

> Previous standards for the use of email protocols with TLS used the STARTTLS mechanism
> (...)
> Although this mechanism has been deployed, an alternate mechanism where TLS is negotiated immediately at connection start on a separate port (referred to in this document as "Implicit TLS") has been deployed more successfully.
> To encourage more widespread use of TLS and to also encourage greater consistency regarding how TLS is used, **this specification now recommends the use of Implicit TLS for POP, IMAP, SMTP Submission**, and all other protocols used  between an MUA and an MSP.

And [Section 3.3](https://datatracker.ietf.org/doc/html/rfc8314#section-3.3):

> It is desirable to migrate core protocols used by MUA software to Implicit TLS over time, for consistency as well as for the additional reasons discussed in Appendix A.  However, to maximize the use of encryption for submission, it is desirable to support both mechanisms for Message Submission over TLS for a transition period of several years.  As a result, clients and servers SHOULD implement both STARTTLS on port 587 and Implicit TLS on port 465 for this transition period.

So it likely that, going forward, more and more mail servers will support SMTP+TLS over port 465 and drop STARTTLS over port 587. So this change helps our users to select the configuration that will most likely work.

Note that this doesn't touch STARTTLS support, just makes the default more future-proof.