### PR TITLE
Adjust account label check

### DIFF
--- a/app/src/flux/models/contact.ts
+++ b/app/src/flux/models/contact.ts
@@ -505,16 +505,10 @@ export class Contact extends Model {
       return null;
     }
 
-    if (includeAccountLabel) {
-      FocusedPerspectiveStore =
-        FocusedPerspectiveStore || require('../stores/focused-perspective-store').default;
-      if (
-        account &&
-        (FocusedPerspectiveStore.current().accountIds.length > 1 || forceAccountLabel)
-      ) {
-        return `You (${account.label})`;
-      }
+    if (includeAccountLabel && account && (AccountStore.accounts().length > 1 || forceAccountLabel)) {
+      return `${localized('You')} (${account.label})`;
     }
+
     return localized('You');
   }
 


### PR DESCRIPTION
Resolves: #2359

Currently, the full E-Mail address as the Sender is only shown in addition to "You" when you are viewing the e-mail in the "Inbox" of all e-mail accounts and not when viewing a single account's inbox. Show this e-mail regardless of the e-mail inbox.