### PR TITLE
enable support multi o365 account to choose which to auth

### DIFF
--- a/app/internal_packages/onboarding/lib/onboarding-helpers.ts
+++ b/app/internal_packages/onboarding/lib/onboarding-helpers.ts
@@ -322,6 +322,7 @@ export function buildO365AuthURL() {
     response_mode: 'query',
     code_challenge: CODE_CHALLENGE,
     code_challenge_method: 'S256',
+    prompt: 'select_account',
   })}`;
 }
 


### PR DESCRIPTION
## Expect:

![image](https://user-images.githubusercontent.com/5433815/170301948-e69f5ca7-b183-4b5c-9e89-a74c1a399dbe.png)

![image](https://user-images.githubusercontent.com/5433815/170296680-40e48056-c3d6-417a-b003-fd3a634b0eb4.png)

ref: https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow#request-an-authorization-code