### PR TITLE
WIP: Enable longer-alive refresh token from o365

### DIFF
--- a/app/internal_packages/onboarding/lib/onboarding-helpers.ts
+++ b/app/internal_packages/onboarding/lib/onboarding-helpers.ts
@@ -7,6 +7,7 @@ import { Account, AccountStore, IdentityStore, MailsyncProcess, localized } from
 import MailspringProviderSettings from './mailspring-provider-settings.json';
 import MailcoreProviderSettings from './mailcore-provider-settings.json';
 import dns from 'dns';
+import fetch from 'node-fetch';
 
 export const LOCAL_SERVER_PORT = 12141;
 


### PR DESCRIPTION
## Update "MailSpring" type in App registration (SPA => Native App)

### Step 1 - add native app support
- Add a platform
![image](https://user-images.githubusercontent.com/5433815/170312307-aff4a14a-6333-4559-a6d2-7f1eaa46a66d.png)
- Choose "Mobile and desktop applications"

### Step 2 - add redirect uri like before
![image](https://user-images.githubusercontent.com/5433815/170313220-3c9862f3-2247-4034-a228-f24b410fbc3d.png)

### Step 3 - remove "Origin" header in node api call
- use 'node-fetch' instead of 'fetch' package
![image](https://user-images.githubusercontent.com/5433815/170313728-9168b715-0370-45de-808a-c266a796799a.png)

### Step 4 - remove "Origin" header in c++ api call
![image](https://user-images.githubusercontent.com/5433815/170314632-3d47ecd7-a60a-473f-bc11-62451a64b148.png)

---
### Remark: one redirect uri could only belong to SPA or Native App, thus new redirect uri maybe needed for old version support.

[💕](https://emojipedia.org/symbols/) Love to use MailSpring so much [🫶](https://emojipedia.org/heart-hands/) Nice App [🥹](https://emojipedia.org/face-holding-back-tears/)