### PR TITLE
Upgrade electron to 19.0.12

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mailspring",
-  "version": "1.10.4",
+  "version": "1.10.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mailspring",
-      "version": "1.10.4",
+      "version": "1.10.5",
       "license": "GPL-3.0",
       "dependencies": {
         "@bengotow/slate-edit-list": "github:bengotow/slate-edit-list#b868e108",

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "@typescript-eslint/parser": "^4.7.0",
         "chalk": "1.x.x",
         "devtron": "^1.4.0",
-        "electron": "17.4.0",
+        "electron": "19.0.12",
         "electron-installer-dmg": "^4.0.0",
         "electron-packager": "15.5.x",
         "electron-winstaller": "2.x.x",
@@ -181,9 +181,9 @@
       }
     },
     "node_modules/@electron/get": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@electron/get/-/get-1.13.1.tgz",
-      "integrity": "sha512-U5vkXDZ9DwXtkPqlB45tfYnnYBN8PePp1z/XDCupnSpdrxT8/ThCv9WCwPLf9oqiSGZTkH6dx2jDUPuoXpjkcA==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-1.14.1.tgz",
+      "integrity": "sha512-BrZYyL/6m0ZXz/lDxy/nlVhQz+WF+iPS6qXolEU8atw7h6v1aYkjwJZ63m+bJMBTxDE66X+r2tPS4a/8C82sZw==",
       "dependencies": {
         "debug": "^4.1.1",
         "env-paths": "^2.2.0",
@@ -2228,13 +2228,13 @@
       }
     },
     "node_modules/electron": {
-      "version": "17.4.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-17.4.0.tgz",
-      "integrity": "sha512-eMuCOZMB9qsY63qzxEkyyqM09qs6mrbPBBDJJZgd8pnPWftE4zKmFp3B1vdHzjQ+1c1r/siigxbWTrpDNNri0A==",
+      "version": "19.0.12",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-19.0.12.tgz",
+      "integrity": "sha512-GOvG0t2NCeJYIfmC3g/dnEAQ71k3nQDbRVqQhpi2YbsYMury0asGJwqnVAv2uZQEwCwSx4XOwOQARTFEG/msWw==",
       "hasInstallScript": true,
       "dependencies": {
-        "@electron/get": "^1.13.0",
-        "@types/node": "^14.6.2",
+        "@electron/get": "^1.14.1",
+        "@types/node": "^16.11.26",
         "extract-zip": "^1.0.3"
       },
       "bin": {
@@ -2506,11 +2506,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-    },
-    "node_modules/electron/node_modules/@types/node": {
-      "version": "14.18.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.13.tgz",
-      "integrity": "sha512-Z6/KzgyWOga3pJNS42A+zayjhPbf2zM3hegRQaOPnLOzEi86VV++6FLDWgR1LGrVCRufP/ph2daa3tEa5br1zA=="
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -12411,9 +12406,9 @@
       }
     },
     "@electron/get": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@electron/get/-/get-1.13.1.tgz",
-      "integrity": "sha512-U5vkXDZ9DwXtkPqlB45tfYnnYBN8PePp1z/XDCupnSpdrxT8/ThCv9WCwPLf9oqiSGZTkH6dx2jDUPuoXpjkcA==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-1.14.1.tgz",
+      "integrity": "sha512-BrZYyL/6m0ZXz/lDxy/nlVhQz+WF+iPS6qXolEU8atw7h6v1aYkjwJZ63m+bJMBTxDE66X+r2tPS4a/8C82sZw==",
       "requires": {
         "debug": "^4.1.1",
         "env-paths": "^2.2.0",
@@ -14007,20 +14002,13 @@
       }
     },
     "electron": {
-      "version": "17.4.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-17.4.0.tgz",
-      "integrity": "sha512-eMuCOZMB9qsY63qzxEkyyqM09qs6mrbPBBDJJZgd8pnPWftE4zKmFp3B1vdHzjQ+1c1r/siigxbWTrpDNNri0A==",
+      "version": "19.0.12",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-19.0.12.tgz",
+      "integrity": "sha512-GOvG0t2NCeJYIfmC3g/dnEAQ71k3nQDbRVqQhpi2YbsYMury0asGJwqnVAv2uZQEwCwSx4XOwOQARTFEG/msWw==",
       "requires": {
-        "@electron/get": "^1.13.0",
-        "@types/node": "^14.6.2",
+        "@electron/get": "^1.14.1",
+        "@types/node": "^16.11.26",
         "extract-zip": "^1.0.3"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "14.18.13",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.13.tgz",
-          "integrity": "sha512-Z6/KzgyWOga3pJNS42A+zayjhPbf2zM3hegRQaOPnLOzEi86VV++6FLDWgR1LGrVCRufP/ph2daa3tEa5br1zA=="
-        }
       }
     },
     "electron-installer-dmg": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@typescript-eslint/parser": "^4.7.0",
     "chalk": "1.x.x",
     "devtron": "^1.4.0",
-    "electron": "17.4.0",
+    "electron": "19.0.12",
     "electron-installer-dmg": "^4.0.0",
     "electron-packager": "15.5.x",
     "electron-winstaller": "2.x.x",


### PR DESCRIPTION
This PR upgrades Electron to v19.0.12. Luckily, no API changes affected Mailspring :tada: