### PR TITLE
Fix the vertical overflow bug (Community - 1677, 3507, 4378 & 4557)

### DIFF
--- a/app/internal_packages/thread-list/lib/thread-list-vertical.tsx
+++ b/app/internal_packages/thread-list/lib/thread-list-vertical.tsx
@@ -21,12 +21,18 @@ class ThreadListVertical extends React.Component<
           handle={ResizableHandle.Bottom}
           onResize={h => this._onResize(h)}
         >
-          <InjectedComponentSet
-            matching={{ role: 'ThreadList' }}
-          />
+          <InjectedComponentSet matching={{ role: 'ThreadList' }} />
         </ResizableRegion>
         <ResizableRegion>
-          <div style={{ height: '100%', width: '100%', borderTop: '0.5px solid #dddddd' }}>
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              height: '100%',
+              width: '100%',
+              borderTop: '0.5px solid #dddddd',
+            }}
+          >
             <div className="sheet-toolbar" style={{ borderBottom: '0' }}>
               <InjectedComponentSet
                 matching={{


### PR DESCRIPTION
There is always overflow, because of the toolbar, at some point the renderer moves it to the top which hides messages.

I have made the area a flexbox to stack the items correctly and prevent the overflow