### PR TITLE
Custom sort functionality - Community#470

### DIFF
--- a/app/internal_packages/thread-list/lib/thread-list-store.ts
+++ b/app/internal_packages/thread-list/lib/thread-list-store.ts
@@ -20,6 +20,8 @@ class ThreadListStore extends MailspringStore {
     super();
     this.listenTo(FocusedPerspectiveStore, this._onPerspectiveChanged);
     this.createListDataSource();
+
+    AppEnv.config.observe('core.lastUsedOrder', () => this.createListDataSource());
   }
 
   dataSource = () => {

--- a/app/internal_packages/thread-search/lib/search-query-subscription.ts
+++ b/app/internal_packages/thread-search/lib/search-query-subscription.ts
@@ -7,6 +7,7 @@ import {
   ComponentRegistry,
   MutableQuerySubscription,
 } from 'mailspring-exports';
+import { SortOrder } from 'src/flux/attributes';
 
 class SearchQuerySubscription extends MutableQuerySubscription<Thread> {
   _searchQuery: string;
@@ -46,9 +47,29 @@ class SearchQuerySubscription extends MutableQuerySubscription<Thread> {
       console.info('Failed to parse local search query, falling back to generic query', e);
       dbQuery = dbQuery.search(this._searchQuery);
     }
+
+    let order = Thread.attributes.lastMessageReceivedTimestamp.descending();
+
+    const orderBy: string | undefined = AppEnv.config.get('core.lastUsedOrder');
+    if (orderBy) {
+      switch (orderBy) {
+        case '2':
+          order = Thread.attributes.subject.ascending();
+          break;
+
+        case '3':
+          order = Thread.attributes.subject.descending();
+          break;
+
+        case '0':
+          order = Thread.attributes.lastMessageReceivedTimestamp.ascending();
+          break;
+      }
+    }
+
     dbQuery = dbQuery
       .background()
-      .order(Thread.attributes.lastMessageReceivedTimestamp.descending())
+      .order(order)
       .limit(1000);
 
     this.replaceQuery(dbQuery);

--- a/app/internal_packages/thread-search/styles/thread-search-bar.less
+++ b/app/internal_packages/thread-search/styles/thread-search-bar.less
@@ -3,9 +3,13 @@
 
 @token-color: @accent-primary;
 
+.thread-search-container {
+  order: -100;
+  width: 100%;
+}
+
 .thread-search-bar {
   position: relative;
-  order: -100;
   overflow: visible;
   z-index: 100;
   width: 450px;
@@ -124,4 +128,12 @@
       color: transparent;
     }
   }
+}
+
+.btn.thread-search-sort {
+  box-shadow: @shadow-border !important;
+  height: 23px;
+  margin-left: 5px;
+  margin-top: 5px;
+  white-space: nowrap;
 }

--- a/app/src/mailbox-perspective.ts
+++ b/app/src/mailbox-perspective.ts
@@ -20,6 +20,7 @@ import { Folder } from './flux/models/folder';
 import { Task } from './flux/tasks/task';
 import * as Actions from './flux/actions';
 import { QuerySubscription } from 'mailspring-exports';
+import { SortOrder } from './flux/attributes';
 
 let WorkspaceStore = null;
 let ChangeStarredTask = null;
@@ -384,7 +385,31 @@ class CategoryMailboxPerspective extends MailboxPerspective {
       .where([Thread.attributes.categories.containsAny(this.categories().map(c => c.id))])
       .limit(0);
 
-    if (this.isSent()) {
+    const orderBy: string | undefined = AppEnv.config.get('core.lastUsedOrder');
+
+    if (orderBy) {
+      let order: SortOrder;
+
+      switch (orderBy) {
+        case '2':
+          order = Thread.attributes.subject.ascending();
+          break;
+
+        case '3':
+          order = Thread.attributes.subject.descending();
+          break;
+
+        case '0':
+          order = Thread.attributes.lastMessageReceivedTimestamp.ascending();
+          break;
+
+        default:
+          order = Thread.attributes.lastMessageReceivedTimestamp.descending();
+          break;
+      }
+
+      query.order(order);
+    } else if (this.isSent()) {
       query.order(Thread.attributes.lastMessageSentTimestamp.descending());
     }
 


### PR DESCRIPTION
This update is a big step towards resolving https://community.getmailspring.com/t/custom-email-sorting/470

----

The update brings some basic sort functionality to the thread (including search results).

As I'm limited by the DB, you only have `date` and `subject`, `from` and `size` would require some extra fields (`unread` is possible, though we already have the unread "folder")

Currently the feature remembers the `order` and implements it when you switch folders or restart the app.

---

This seems almost redundant as, after the first sort swap, it will never be triggered again. Maybe have the new setting set by default? Then this can be removed
