### PR TITLE
Some UX improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,5 +74,6 @@ client_secret.json
 **.tar.gz
 **.dll
 /app/mailsync.exe
+/app/*.pdb
 /app/mailsync.dSYM
 .idea

--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,5 @@ client_secret.json
 **.tar.gz
 **.dll
 /app/mailsync.exe
-/app/*.pdb
 /app/mailsync.dSYM
 .idea

--- a/app/internal_packages/message-list/lib/message-list.tsx
+++ b/app/internal_packages/message-list/lib/message-list.tsx
@@ -374,7 +374,6 @@ class MessageList extends React.Component<Record<string, unknown>, MessageListSt
     );
 
     function _onSubjectContextMenu() {
-      console.log(window.getSelection());
       if (window.getSelection()?.type == 'Range') {
         const menu = new Menu();
         menu.append(new MenuItem({ role: 'copy' }));

--- a/app/internal_packages/message-list/lib/message-list.tsx
+++ b/app/internal_packages/message-list/lib/message-list.tsx
@@ -40,6 +40,7 @@ interface MessageListState {
   minified: boolean;
 }
 
+const { Menu, MenuItem } = require('@electron/remote');
 const PREF_REPLY_TYPE = 'core.sending.defaultReplyType';
 const PREF_RESTRICT_WIDTH = 'core.reading.restrictMaxWidth';
 const PREF_DESCENDING_ORDER = 'core.reading.descendingOrderMessageList';
@@ -351,7 +352,8 @@ class MessageList extends React.Component<Record<string, unknown>, MessageListSt
       <div className="message-subject-wrap">
         <MailImportantIcon thread={this.state.currentThread} />
         <div style={{ flex: 1 }}>
-          <span className="message-subject">{subject}</span>
+          <span className="message-subject"
+            onContextMenu={() => _onSubjectContextMenu()}>{subject}</span>
           <MailLabelSet
             removable
             includeCurrentCategories
@@ -369,6 +371,15 @@ class MessageList extends React.Component<Record<string, unknown>, MessageListSt
         />
       </div>
     );
+    
+    function _onSubjectContextMenu() {
+      console.log(window.getSelection());
+      if (window.getSelection()?.type == "Range") {
+        const menu = new Menu();
+        menu.append(new MenuItem({ role: 'copy' }));
+        menu.popup({});
+      }
+    };
   }
 
   _renderMinifiedBundle(bundle) {

--- a/app/internal_packages/message-list/lib/message-list.tsx
+++ b/app/internal_packages/message-list/lib/message-list.tsx
@@ -352,8 +352,9 @@ class MessageList extends React.Component<Record<string, unknown>, MessageListSt
       <div className="message-subject-wrap">
         <MailImportantIcon thread={this.state.currentThread} />
         <div style={{ flex: 1 }}>
-          <span className="message-subject"
-            onContextMenu={() => _onSubjectContextMenu()}>{subject}</span>
+          <span className="message-subject" onContextMenu={() => _onSubjectContextMenu()}>
+            {subject}
+          </span>
           <MailLabelSet
             removable
             includeCurrentCategories
@@ -371,15 +372,15 @@ class MessageList extends React.Component<Record<string, unknown>, MessageListSt
         />
       </div>
     );
-    
+
     function _onSubjectContextMenu() {
       console.log(window.getSelection());
-      if (window.getSelection()?.type == "Range") {
+      if (window.getSelection()?.type == 'Range') {
         const menu = new Menu();
         menu.append(new MenuItem({ role: 'copy' }));
         menu.popup({});
       }
-    };
+    }
   }
 
   _renderMinifiedBundle(bundle) {

--- a/app/internal_packages/message-list/lib/message-participants.tsx
+++ b/app/internal_packages/message-list/lib/message-participants.tsx
@@ -34,7 +34,7 @@ export default class MessageParticipants extends React.Component<MessageParticip
 
   _shortNames(contacts = [], max = MAX_COLLAPSED) {
     let names = contacts.map((c, i) => (
-      <span>
+      <span key={`contact-${i}`}>
         {i > 0 && ', '}
         <span onContextMenu={() => this._onContactContextMenu(c)}>
           {c.displayName({

--- a/app/internal_packages/message-list/lib/message-participants.tsx
+++ b/app/internal_packages/message-list/lib/message-participants.tsx
@@ -34,18 +34,25 @@ export default class MessageParticipants extends React.Component<MessageParticip
   }
 
   _shortNames(contacts = [], max = MAX_COLLAPSED) {
-    let names = contacts.map(c =>
-      c.displayName({
-        includeAccountLabel: true,
-        compact: !AppEnv.config.get('core.reading.detailedNames'),
-      })
+    let names = contacts.map((c, i) =>
+      <span>
+        {i > 0 && ", "}
+        <span onContextMenu={() => this._onContactContextMenu(c)}>{
+          c.displayName({
+            includeAccountLabel: true,
+            compact: !AppEnv.config.get('core.reading.detailedNames'),
+          })
+        }</span>
+      </span>
     );
+    
     if (names.length > max) {
       const extra = names.length - max;
       names = names.slice(0, max);
-      names.push(`and ${extra} more`);
+      names.push(<span>and ${extra} more</span>);
     }
-    return names.join(', ');
+    
+    return names;
   }
 
   _onSelectText = e => {
@@ -63,10 +70,17 @@ export default class MessageParticipants extends React.Component<MessageParticip
 
   _onContactContextMenu = contact => {
     const menu = new Menu();
-    menu.append(new MenuItem({ role: 'copy' }));
+    menu.append(
+      window.getSelection()?.type == "Range"
+        ? new MenuItem({ role: 'copy' })
+        : new MenuItem({
+          label: `${localized(`Copy`)} "${contact.email}"`,
+          click: () => navigator.clipboard.writeText(contact.email),
+        })
+    );
     menu.append(
       new MenuItem({
-        label: `${localized(`Email`)} ${contact.email}`,
+        label: `${localized(`Email`)} ${contact.name ?? contact.email}`,
         click: () => Actions.composeNewDraftToRecipient(contact),
       })
     );
@@ -83,15 +97,15 @@ export default class MessageParticipants extends React.Component<MessageParticip
       if (c.name && c.name.length > 0 && c.name !== c.email) {
         return (
           <div key={`${c.email}-${i}`} className="participant selectable">
-            <div className="participant-primary" onClick={this._onSelectText}>
+            <div className="participant-primary" 
+              onClick={this._onSelectText}
+              onContextMenu={() => this._onContactContextMenu(c)}
+            >
               {c.fullName()}
             </div>
             <div className="participant-secondary">
               {' <'}
-              <span
-                onClick={this._onSelectText}
-                onContextMenu={() => this._onContactContextMenu(c)}
-              >
+              <span onClick={this._onSelectText}>
                 {c.email}
               </span>
               {`>${comma}`}

--- a/app/internal_packages/message-list/lib/message-participants.tsx
+++ b/app/internal_packages/message-list/lib/message-participants.tsx
@@ -3,7 +3,6 @@ import classnames from 'classnames';
 import React from 'react';
 import { localized, Actions, Contact } from 'mailspring-exports';
 
-
 const { Menu, MenuItem } = require('@electron/remote');
 const MAX_COLLAPSED = 5;
 
@@ -34,24 +33,24 @@ export default class MessageParticipants extends React.Component<MessageParticip
   }
 
   _shortNames(contacts = [], max = MAX_COLLAPSED) {
-    let names = contacts.map((c, i) =>
+    let names = contacts.map((c, i) => (
       <span>
-        {i > 0 && ", "}
-        <span onContextMenu={() => this._onContactContextMenu(c)}>{
-          c.displayName({
+        {i > 0 && ', '}
+        <span onContextMenu={() => this._onContactContextMenu(c)}>
+          {c.displayName({
             includeAccountLabel: true,
             compact: !AppEnv.config.get('core.reading.detailedNames'),
-          })
-        }</span>
+          })}
+        </span>
       </span>
-    );
-    
+    ));
+
     if (names.length > max) {
       const extra = names.length - max;
       names = names.slice(0, max);
       names.push(<span>and ${extra} more</span>);
     }
-    
+
     return names;
   }
 
@@ -71,12 +70,12 @@ export default class MessageParticipants extends React.Component<MessageParticip
   _onContactContextMenu = contact => {
     const menu = new Menu();
     menu.append(
-      window.getSelection()?.type == "Range"
+      window.getSelection()?.type == 'Range'
         ? new MenuItem({ role: 'copy' })
         : new MenuItem({
-          label: `${localized(`Copy`)} "${contact.email}"`,
-          click: () => navigator.clipboard.writeText(contact.email),
-        })
+            label: `${localized(`Copy`)} "${contact.email}"`,
+            click: () => navigator.clipboard.writeText(contact.email),
+          })
     );
     menu.append(
       new MenuItem({
@@ -97,7 +96,8 @@ export default class MessageParticipants extends React.Component<MessageParticip
       if (c.name && c.name.length > 0 && c.name !== c.email) {
         return (
           <div key={`${c.email}-${i}`} className="participant selectable">
-            <div className="participant-primary" 
+            <div
+              className="participant-primary"
               onClick={this._onSelectText}
               onContextMenu={() => this._onContactContextMenu(c)}
             >
@@ -105,7 +105,10 @@ export default class MessageParticipants extends React.Component<MessageParticip
             </div>
             <div className="participant-secondary">
               {' <'}
-              <span onClick={this._onSelectText}>
+              <span
+                onClick={this._onSelectText}
+                onContextMenu={() => this._onContactContextMenu(c)}
+              >
                 {c.email}
               </span>
               {`>${comma}`}

--- a/app/internal_packages/message-list/lib/message-participants.tsx
+++ b/app/internal_packages/message-list/lib/message-participants.tsx
@@ -48,7 +48,7 @@ export default class MessageParticipants extends React.Component<MessageParticip
     if (names.length > max) {
       const extra = names.length - max;
       names = names.slice(0, max);
-      names.push(<span>and ${extra} more</span>);
+      names.push(<span key="contact-more">and ${extra} more</span>);
     }
 
     return names;

--- a/app/internal_packages/undo-redo/styles/index.less
+++ b/app/internal_packages/undo-redo/styles/index.less
@@ -46,10 +46,13 @@
     img {
       background-color: @background-primary;
     }
+
     &:hover {
       background: fade(@black, 30%);
       border: 1px solid fade(@background-primary, 30%);
     }
+
+    .send-action-text,
     .undo-action-text {
       margin-left: 5px;
       color: @background-primary;

--- a/app/lang/en.json
+++ b/app/lang/en.json
@@ -617,6 +617,7 @@
   "Send message": "Send message",
   "Send more than one message using the same %@ or subject line to compare open rates and reply rates.": "Send more than one message using the same %@ or subject line to compare open rates and reply rates.",
   "Send new messages from:": "Send new messages from:",
+  "Send now instead": "Send now instead",
   "Send on your own schedule": "Send on your own schedule",
   "Sender Name": "Sender Name",
   "Sending": "Sending",

--- a/app/src/date-utils.ts
+++ b/app/src/date-utils.ts
@@ -1,5 +1,4 @@
 import moment, { Moment } from 'moment-timezone';
-import { options } from 'optimist';
 
 // Init locale for moment
 moment.locale(navigator.language);
@@ -394,41 +393,36 @@ const DateUtils = {
     const now = moment();
     const diff = now.diff(datetime, 'days', true);
     const isSameDay = now.isSame(datetime, 'days');
-    let format = null;
     const opts: Intl.DateTimeFormatOptions = {
       hour12: !AppEnv.config.get('core.workspace.use24HourClock'),
     };
 
     if (diff <= 1 && isSameDay) {
       // Time if less than 1 day old
-      format = DateUtils.getTimeFormat(null);
       opts.hour = 'numeric';
       opts.minute = '2-digit';
-    } else if (diff < 2 && !isSameDay) {
-      // Month and day with time if up to 2 days ago
-      format = `MMM D, ${DateUtils.getTimeFormat(null)}`;
-      opts.month = 'short';
-      opts.day = 'numeric';
+    } else if (diff < 5 && !isSameDay) {
+      // Weekday with time if up to 2 days ago
+      //opts.month = 'short';
+      //opts.day = 'numeric';
+      opts.weekday = 'short';
       opts.hour = 'numeric';
       opts.minute = '2-digit';
-    } else if (diff >= 2 && diff < 365) {
-      // Month and day up to 1 year old
-      format = 'MMM D';
-      opts.month = 'short';
-      opts.day = 'numeric';
-      return datetime.toLocaleDateString(navigator.language, opts);
     } else {
-      // Month, day and year if over a year old
-      format = 'MMM D YYYY';
-      opts.year = 'numeric';
-      opts.month = 'short';
-      opts.day = 'numeric';
+      if (diff < 365) {
+        // Month and day up to 1 year old
+        opts.month = 'short';
+        opts.day = 'numeric';
+      } else {
+        // Month, day and year if over a year old
+        opts.year = 'numeric';
+        opts.month = 'short';
+        opts.day = 'numeric';
+      }
       return datetime.toLocaleDateString(navigator.language, opts);
     }
 
     return datetime.toLocaleTimeString(navigator.language, opts);
-
-    return moment(datetime).format(format);
   },
 
   /**
@@ -438,9 +432,6 @@ const DateUtils = {
    * @return {String} Formated date/time
    */
   mediumTimeString(datetime: Date) {
-    let format = 'MMMM D, YYYY, ';
-    format += DateUtils.getTimeFormat({ seconds: false, upperCase: true, timeZone: false });
-
     return datetime.toLocaleTimeString(navigator.language, {
       hour12: !AppEnv.config.get('core.workspace.use24HourClock'),
       year: 'numeric',
@@ -448,8 +439,6 @@ const DateUtils = {
       day: 'numeric',
       second: undefined,
     });
-
-    return moment(datetime).format(format);
   },
 
   /**
@@ -472,13 +461,6 @@ const DateUtils = {
       weekday: 'long',
       second: undefined,
     });
-
-    let format = 'dddd, MMMM Do YYYY, ';
-    format += DateUtils.getTimeFormat({ seconds: true, upperCase: true, timeZone: true });
-
-    return moment(datetime)
-      .tz(tz)
-      .format(format);
   },
 };
 

--- a/app/src/flux/stores/database-store.ts
+++ b/app/src/flux/stores/database-store.ts
@@ -156,9 +156,14 @@ class DatabaseStore extends MailspringStore {
   }
 
   _prettyConsoleLog(qa) {
+    const darkTheme =
+        window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches,
+      primaryColor = darkTheme ? 'white' : 'black',
+      purpleColor = darkTheme ? 'pink' : 'purple';
+
     let q = qa.replace(/%/g, '%%');
-    q = `color:black |||%c ${q}`;
-    q = q.replace(/`(\w+)`/g, '||| color:purple |||%c$&||| color:black |||%c');
+    q = `color:${primaryColor} |||%c ${q}`;
+    q = q.replace(/`(\w+)`/g, `||| color:${purpleColor} |||%c$&||| color:${primaryColor} |||%c`);
 
     const colorRules = {
       'color:green': [
@@ -184,7 +189,7 @@ class DatabaseStore extends MailspringStore {
       for (const keyword of colorRules[style]) {
         q = q.replace(
           new RegExp(`\\b${keyword}\\b`, 'g'),
-          `||| ${style} |||%c${keyword}||| color:black |||%c`
+          `||| ${style} |||%c${keyword}||| color:${primaryColor} |||%c`
         );
       }
     }


### PR DESCRIPTION
_Sorry, didn't realise rename would close [original PR](https://github.com/Foundry376/Mailspring/pull/2419)_

---

Made a few UX improvements:
- The send later delay can be skipped by clicking the new `Send now instead` button (localization required)
- If there is a range selection in the subject line then a context menu pops up on right-click (for those that are allergic to keyboard shortcuts 😂)]
- Dates/times used are now in a localised format, rather than the American one
- Message participant tweaks:
  - you can now open the context menu on the name or email, not just the email
  - you don't need to expand the participants to open the context menu
  - name is shown over the email for `Email "Name else Email"` context menu item
  - added `Copy "Email"` to the context menu when nothing is selected/highlighted and just `Copy` when something is
- **for devs:** pretty console messages now consider your device theme and use an appropriate colour