### PR TITLE
Fix "and X more" display in message contacts

### DIFF
--- a/app/internal_packages/message-list/lib/message-participants.tsx
+++ b/app/internal_packages/message-list/lib/message-participants.tsx
@@ -48,7 +48,7 @@ export default class MessageParticipants extends React.Component<MessageParticip
     if (names.length > max) {
       const extra = names.length - max;
       names = names.slice(0, max);
-      names.push(<span key="contact-more">and ${extra} more</span>);
+      names.push(<span key="contact-more"> and {extra} more</span>);
     }
 
     return names;


### PR DESCRIPTION
This was changed from a template string to JSX, but the escape format was not updated. There is also now a missing space before the word "and".

Before:

![image](https://user-images.githubusercontent.com/17882/201769889-95239a0a-b753-457d-b73b-3c8370b68115.png)

After: 

![image](https://user-images.githubusercontent.com/17882/201769906-836a1a85-198f-40a3-bc5d-460472d15509.png)
