### PR TITLE
Fix for start crash - Community#5324

### DIFF
--- a/app/src/mailsync-process.ts
+++ b/app/src/mailsync-process.ts
@@ -105,7 +105,7 @@ export class MailsyncProcess extends EventEmitter {
 
   _showStatusWindow(mode) {
     if (this._win) return;
-    const { BrowserWindow } = require('@electron/remote');
+    const { BrowserWindow } = require('@electron/remote/main');
     this._win = new BrowserWindow({
       width: 350,
       height: 108,


### PR DESCRIPTION
Fixed start crash, caused by incorrect module being referenced

Reference: https://community.getmailspring.com/t/mailspring-1-10-5-crashes-at-start-on-debian-11/5324