### PR TITLE
Corrected 0pm to 12pm - Community#5936

### DIFF
--- a/app/src/date-utils.ts
+++ b/app/src/date-utils.ts
@@ -394,7 +394,7 @@ const DateUtils = {
     const diff = now.diff(datetime, 'days', true);
     const isSameDay = now.isSame(datetime, 'days');
     const opts: Intl.DateTimeFormatOptions = {
-      hour12: !AppEnv.config.get('core.workspace.use24HourClock'),
+      hourCycle: AppEnv.config.get('core.workspace.use24HourClock') ? 'h23' : 'h12',
     };
 
     if (diff <= 1 && isSameDay) {
@@ -433,7 +433,7 @@ const DateUtils = {
    */
   mediumTimeString(datetime: Date) {
     return datetime.toLocaleTimeString(navigator.language, {
-      hour12: !AppEnv.config.get('core.workspace.use24HourClock'),
+      hourCycle: AppEnv.config.get('core.workspace.use24HourClock') ? 'h23' : 'h12',
       year: 'numeric',
       month: 'long',
       day: 'numeric',
@@ -454,7 +454,7 @@ const DateUtils = {
     // `(?<!\d)${dateTime.getDay()}(?!\d)` replace `$1${localise(ordinal)}`
 
     return datetime.toLocaleTimeString(navigator.language, {
-      hour12: !AppEnv.config.get('core.workspace.use24HourClock'),
+      hourCycle: AppEnv.config.get('core.workspace.use24HourClock') ? 'h23' : 'h12',
       year: 'numeric',
       month: 'long',
       day: 'numeric',


### PR DESCRIPTION
12pm is now shown instead of 0pm

![image](https://user-images.githubusercontent.com/33450392/203656198-e87bab5c-7f0b-4a6c-8241-c4f5366188d7.png)

---

Not I needed to use `h23` instead of `h24` else midnight would have been shown as `24:01` - or similar

![image](https://user-images.githubusercontent.com/33450392/203656514-502dee9b-9efd-4cb6-9fcf-c2cd7d485376.png)
