### PR TITLE
Composer image resize - Community#729

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mailspring",
-  "version": "1.10.5",
+  "version": "1.10.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mailspring",
-      "version": "1.10.5",
+      "version": "1.10.7",
       "license": "GPL-3.0",
       "dependencies": {
         "@bengotow/slate-edit-list": "github:bengotow/slate-edit-list#b868e108",

--- a/app/src/components/composer-editor/inline-attachment-plugins.tsx
+++ b/app/src/components/composer-editor/inline-attachment-plugins.tsx
@@ -3,17 +3,18 @@ import { ImageAttachmentItem } from 'mailspring-component-kit';
 import { AttachmentStore } from 'mailspring-exports';
 import { isQuoteNode } from './base-block-plugins';
 import { ComposerEditorPlugin } from './types';
-import { Editor, Node } from 'slate';
+import { Editor, Inline, Node } from 'slate';
 import { schema } from './conversion';
 
 export const IMAGE_TYPE = 'image';
 
 function ImageNode(props) {
   const { attributes, node, editor, targetIsHTML, isFocused } = props;
-  const contentId = node.data.get ? node.data.get('contentId') : node.data.contentId;
+  const contentId = node.data.get ? node.data.get('contentId') : node.data.contentId,
+    imgProps = node.data.get ? node.data.get('imgProps') : node.data.imgProps;
 
   if (targetIsHTML) {
-    return <img alt="" src={`cid:${contentId}`} />;
+    return <img alt="" src={`cid:${contentId}`} width={imgProps?.width} height={imgProps?.height} />;
   }
 
   const { draft } = editor.props.propsForPlugins;
@@ -29,6 +30,22 @@ function ImageNode(props) {
       filePath={AttachmentStore.pathForFile(file)}
       displayName={file.filename}
       onRemoveAttachment={() => editor.removeNodeByKey(node.key)}
+      imgProps={imgProps}
+      onResized={(width, height) => {
+        const e = editor as Editor,
+          n = node as Inline,
+          newN = {
+            key: n.key,
+            object: n.object,
+            data: n.data.asMutable(),
+            type: n.type,
+            nodes: n.nodes.asMutable(),
+          };
+
+        newN.data = newN.data.set('imgProps', { width: width, height: height });
+
+        e.setNodeByKey(n.key, newN);
+      }}
     />
   );
 }
@@ -42,20 +59,25 @@ function renderNode(props, editor: Editor = null, next = () => {}) {
 
 const rules = [
   {
-    deserialize(el, next) {
-      if (el.tagName.toLowerCase() === 'img' && (el.getAttribute('src') || '').startsWith('cid:')) {
-        return {
-          object: 'inline',
-          nodes: [],
-          type: IMAGE_TYPE,
-          data: {
-            contentId: el
-              .getAttribute('src')
-              .split('cid:')
-              .pop(),
-          },
-        };
-      }
+    deserialize(el: HTMLElement, next) {
+      if (el.tagName.toLowerCase() === 'img')
+        if ((el.getAttribute('src') || '').startsWith('cid:')) {
+          return {
+            object: 'inline',
+            nodes: [],
+            type: IMAGE_TYPE,
+            data: {
+              contentId: el
+                .getAttribute('src')
+                .split('cid:')
+                .pop(),
+              imgProps: {
+                width: Number.parseInt(el.getAttribute('width')),
+                height: Number.parseInt(el.getAttribute('height')),
+              },
+            },
+          };
+        }
     },
     serialize(obj, children) {
       if (obj.object !== 'inline') return;

--- a/app/static/style/components/attachment-items.less
+++ b/app/static/style/components/attachment-items.less
@@ -277,4 +277,52 @@ body.platform-win32 {
       background-size: 8px;
     }
   }
+
+  .resizer {
+    align-items: center;
+    bottom: 0;
+    background: #000;
+    color: #fff;
+    cursor: nwse-resize;
+    display: flex;
+    height: 20px;
+    justify-content: center;
+    opacity: .3;
+    position: absolute;
+    right: 0;
+    width: 20px;
+    z-index: 9;
+
+    // Thanks: https://css.gg/arrows-expand-left
+    .gg-arrows-expand-left {
+      box-sizing: border-box;
+      position: relative;
+      display: block;
+      transform: scale(0.9);
+      width: 14px;
+      height: 14px;
+      box-shadow:
+          6px 6px 0 -4px,
+          -6px -6px 0 -4px
+    }
+    .gg-arrows-expand-left::before {
+      content: "";
+      display: block;
+      box-sizing: border-box;
+      position: absolute;
+      width: 2px;
+      height: 22px;
+      top: -4px;
+      left: 6px;
+      transform: rotate(-45deg);
+      border-top: 9px solid;
+      border-bottom: 9px solid
+    }
+  }
+
+  &:hover, &[data-resizing] {
+    .resizer {
+      opacity: 1;
+    }
+  }
 }

--- a/app/static/style/components/attachment-items.less
+++ b/app/static/style/components/attachment-items.less
@@ -185,10 +185,7 @@ body.platform-win32 {
   position: relative;
   text-align: center;
   display: inline-block;
-  vertical-align: top;
-  margin-bottom: @spacing-standard;
-  margin-right: @spacing-standard;
-  margin-left: @spacing-standard;
+  margin: 0;
   width: initial;
   max-width: calc(~'100% - 30px');
 


### PR DESCRIPTION
Add image resizing to the composer - closes [Community#729](https://community.getmailspring.com/t/resizing-image-in-composer/729)

---

- You can now resize images within the composer
  - by default, it will retain the original ratio (holding <kbd>Shift</kbd> = freeform)
- Adjusted the margins and positions of the image in the composer so it matches the email viewer  
_before it was padded and top-aligned then, in the viewer, it would have no padding and be base-aligned - meaning what you see is not what they get 😉_