### PR TITLE
Add new email shortcut on MacOS dock icon contextual menu

### DIFF
--- a/app/src/browser/application.ts
+++ b/app/src/browser/application.ts
@@ -542,6 +542,19 @@ export default class Application extends EventEmitter {
       }
     });
 
+    const dockMenu = Menu.buildFromTemplate([
+      {
+        label: localized('Compose New Message'),
+        click: () => global.application.emit('application:new-message'),
+      },
+    ]);
+
+    app.whenReady().then(() => {
+      if (process.platform === 'darwin') {
+        app.dock.setMenu(dockMenu)
+      }
+    })
+
     ipcMain.on('new-window', (event, options) => {
       const win = options.windowKey ? this.windowManager.get(options.windowKey) : null;
       if (win) {


### PR DESCRIPTION
This pull request adds a "New email" quick action on the contextual menu of the dock icon on MacOS.

This is how it would look (here Mailspring is in Spanish):

<img width="274" alt="image" src="https://user-images.githubusercontent.com/2976270/219247613-bf2e7edd-6686-426b-9ea1-ef6294c629ca.png">
