### PR TITLE
Optionally configure gmail client secret with env var

### DIFF
--- a/app/internal_packages/onboarding/lib/onboarding-constants.ts
+++ b/app/internal_packages/onboarding/lib/onboarding-constants.ts
@@ -17,7 +17,7 @@ export const GMAIL_CLIENT_ID =
 // Note: This is not a security risk for the end-user -- it just means someone could "fork" Mailspring and re-use it's
 // Client ID and Secret. For now, it seems we're on the honor code - Please don't do this.
 //
-export const GMAIL_CLIENT_SECRET = crypto
+export const GMAIL_CLIENT_SECRET = process.env.MS_GMAIL_CLIENT_SECRET || crypto
   .createDecipheriv(
     'aes-256-ctr',
     "don't-be-ev1l-thanks--mailspring",


### PR DESCRIPTION
To use the Gmail API, you need both client ID and client secret. Currently, the ID can be configured with an environment variable but the secret cannot, so using Mailspring with different credentials requires recompiling.

This change makes the secret configurable through environment variables as well.