### PR TITLE
Add Menu action allowing it to be used as AutoSuggest

### DIFF
--- a/app/internal_packages/category-picker/lib/move-picker-popover.tsx
+++ b/app/internal_packages/category-picker/lib/move-picker-popover.tsx
@@ -189,6 +189,10 @@ export default class MovePickerPopover extends Component<
     }
   };
 
+  _onCompleteAutosuggest = item => {
+    this.setState(this._recalculateState(this.props, { searchValue: item.displayName }));
+  };
+
   _onSearchValueChange = event => {
     this.setState(this._recalculateState(this.props, { searchValue: event.target.value }));
   };
@@ -261,6 +265,7 @@ export default class MovePickerPopover extends Component<
           itemKey={item => item.id}
           itemContent={this._renderItem}
           onSelect={this._onSelectCategory}
+          onExpand={this._onCompleteAutosuggest}
           onEscape={this._onEscape}
           defaultSelectedIndex={this.state.searchValue === '' ? -1 : 0}
         />

--- a/app/src/components/menu.tsx
+++ b/app/src/components/menu.tsx
@@ -27,6 +27,7 @@ export interface MenuProps extends HTMLProps<any> {
   itemChecked?: (...args: any[]) => any;
   items: any[];
   onSelect: (item: any) => any;
+  onExpand: (item: any) => any;
   onEscape?: (...args: any[]) => any;
   defaultSelectedIndex?: number;
 }
@@ -175,6 +176,9 @@ export class Menu extends React.Component<MenuProps, MenuState> {
      - `onSelect` A {Function} called with the selected item when the user clicks
        an item in the menu or confirms their selection with the Enter key.
 
+     - `onExpand` A {Function} called with the selected item when the user presses
+       Tab or right arrow.
+
      - `onEscape` A {Function} called when a user presses escape in the input.
 
      - `defaultSelectedIndex` The index of the item first selected if there
@@ -195,6 +199,7 @@ export class Menu extends React.Component<MenuProps, MenuState> {
 
     onSelect: PropTypes.func.isRequired,
 
+    onExpand: PropTypes.func
     onEscape: PropTypes.func,
 
     defaultSelectedIndex: PropTypes.number,
@@ -297,6 +302,12 @@ export class Menu extends React.Component<MenuProps, MenuState> {
     event.stopPropagation();
     if (['Enter', 'Return'].includes(event.key)) {
       this._onEnter();
+    } else {
+      if (this.props.onExpand !== undefined && (event.key === 'Tab' || event.key === 'ArrowRight')) {
+        this._onExpand();
+        event.preventDefault();
+        return;
+      }
     }
     if (event.key === 'Escape') {
       this._onEscape();
@@ -306,6 +317,13 @@ export class Menu extends React.Component<MenuProps, MenuState> {
     } else if (event.key === 'ArrowDown' || event.key === 'Tab') {
       this._onShiftSelectedIndex(1);
       event.preventDefault();
+    }
+  };
+
+  _onExpand = () => {
+    const item = this.props.items[this.state.selectedIndex];
+    if (item != null) {
+      this.props.onExpand(item);
     }
   };
 
@@ -391,6 +409,13 @@ export class Menu extends React.Component<MenuProps, MenuState> {
     const item = this.props.items[this.state.selectedIndex];
     if (item != null) {
       this.props.onSelect(item);
+    }
+  };
+
+  _onExpand = () => {
+    const item = this.props.items[this.state.selectedIndex];
+    if (item != null) {
+      this.props.onExpand(item);
     }
   };
 


### PR DESCRIPTION
The idea was to improve UX when moving emails between folders. Current implementation requires user to correctly type in the whole folder path (including all the parent folders), which can be rather difficult if the folder hierarchy has several layers. My solution was inspired by a Thunderbird plugin "Manage Emails/ Nostalgy++".
On the technical side changes include:
- new optional callback 'onExpand' from 'Menu' component. It is fired if the user has highlighted a folder and pressed 'Tab' or 'ArrowRight' on it (to expand/drill down into);
- 'MovePickerPopover' code to set up the callback on 'Menu' and to handle its response by passing the highlighted folder name to the input field, thus narrowing the search.

I understand that this change could be controversial as it is suddenly introducing new types of behaviour for existing components (AutoSuggest for folder selection and DrillDown for menus) but in my opinion it does improve UX in one very specific area without breaking things around. Also, neither AutoSuggest nor DrillDown are completely foreign concepts, so, maybe, this could be added at least hidden under some "development/experimental" flags.