### PR TITLE
Fix: Colons are allowed in URL paths.

### DIFF
--- a/app/src/regexp-utils.ts
+++ b/app/src/regexp-utils.ts
@@ -167,7 +167,7 @@ const RegExpUtils = {
       '(',
       // URL components
       // (last character must not be puncation, hence two groups)
-      '(?:[\\+=~%\\/\\.\\w\\-_@]*[\\+~%\\/\\w\\-:_])?',
+      '(?:[\\+=~%\\/\\.\\w\\-_@:]*[\\+~%\\/\\w\\-:_])?',
 
       // optionally followed by one or more query string ?asd=asd&as=asd type sections
       "(?:\\?[\\-\\+=&;:%@$\\(\\)'\\*\\/~\\!\\.,\\w_]*[\\-\\+=&;~%@\\w_\\/])*",


### PR DESCRIPTION
Currently, URLs that look like:

`http://example.com/something:with:colons`

Only parses `http://example.com/something` as a link.  This fixes that, as the URLs above are allowed.

This does not parse a trailing `:`, so that something like this:

`http://example.com/something: This is a link to something`

The link will be parsed to `http://example.com/something` and not to `http://example.com/something:`