### PR TITLE
Fix help menu search

### DIFF
--- a/app/menus/darwin.js
+++ b/app/menus/darwin.js
@@ -262,6 +262,7 @@ module.exports = {
     },
 
     {
+      role: 'help',
       id: 'Help',
       label: localized('Help'),
       submenu: [

--- a/app/menus/linux.js
+++ b/app/menus/linux.js
@@ -226,6 +226,7 @@ module.exports = {
       ],
     },
     {
+      role: 'help',
       id: 'Help',
       label: localized('Help'),
       submenu: [

--- a/app/menus/win32.js
+++ b/app/menus/win32.js
@@ -205,6 +205,7 @@ module.exports = {
     },
     { type: 'separator' },
     {
+      role: 'help',
       label: localized('Help') + '...',
       command: 'application:view-help',
     },


### PR DESCRIPTION
Should fix the help menu search missing
<img width="192" alt="image" src="https://github.com/Foundry376/Mailspring/assets/11315492/5f62d6a6-13d7-4464-87c4-e7be2e1f5386">

I haven't been able to test if because of this error, would be great if someone could let me know how to fix it:
<img width="248" alt="image" src="https://github.com/Foundry376/Mailspring/assets/11315492/19227017-8d19-4da5-8e84-fbbee25288be">
