### PR TITLE
Intuitive Time Parsing for Email Scheduling

### DIFF
--- a/app/src/date-utils.ts
+++ b/app/src/date-utils.ts
@@ -131,6 +131,12 @@ function getChronoPast() {
 }
 
 function expandDateLikeString(dateLikeString: string) {
+  // Short format: 123 => 1:23 or 1234 => 12:34
+  if (/^\d{3,4}$/.test(dateLikeString)) {
+    const len = dateLikeString.length;
+    dateLikeString = dateLikeString.slice(0, len - 2) + ':' + dateLikeString.slice(len - 2); // Insert colon
+  }
+
   // Short format: 2h
   if (/^\d+h$/.test(dateLikeString)) {
     const numHours = dateLikeString.match(/^\d+/)[0]; // Extract number
@@ -309,7 +315,7 @@ const DateUtils = {
           results[val].month(month - 1); // moment zero-indexes month
           results[val].date(day);
 
-          if (!gotTime) {
+          if (!gotTime[val]) {
             results[val].hour(hour);
             results[val].minute(minute);
           }


### PR DESCRIPTION
The issue addressed here is the inability of the current scheduling feature to interpret strings like "123" or "1234" as a valid time for scheduling emails.

Feature Proposal: https://community.getmailspring.com/t/intuitive-time-parsing-for-email-scheduling/6991

To resolve this, I updated the date parsing logic to handle both 3 and 4 digit time input strings. The added logic will check the length of the string before slicing and inserting a colon to separate the hours and minutes if present.

For example, it will interpret "123" as "1:23" and "1234" as "12:34".

closes #2462