### PR TITLE
Add "Reply to" filter to email rules 

### DIFF
--- a/app/lang/da.json
+++ b/app/lang/da.json
@@ -506,7 +506,7 @@
   "Reading Pane On": "Læser ruden på",
   "Rebuild": "Genopbygge",
   "Rebuild Cache...": "Genopbyg Cache ...",
-  "Recipient": "Modtager:",
+  "Recipient": "Modtager",
   "Reconnect": "Tilslut",
   "Redo": "Gentag",
   "Relaunch": "relancering",

--- a/app/lang/de.json
+++ b/app/lang/de.json
@@ -513,7 +513,7 @@
   "Vertical Reading Pane": "Vertikales Lesefenster",
   "Rebuild": "Wiederherstellen",
   "Rebuild Cache...": "Cache neu erstellen...",
-  "Recipient": "Empfänger:",
+  "Recipient": "Empfänger",
   "Reconnect": "Erneut verbinden",
   "Redo": "Wiederholen",
   "Relaunch": "Neu starten",

--- a/app/lang/lt.json
+++ b/app/lang/lt.json
@@ -506,7 +506,7 @@
   "Reading Pane On": "Skaitymas",
   "Rebuild": "Atkurti",
   "Rebuild Cache...": "Atkurti talpyklą ...",
-  "Recipient": "Gavėjas:",
+  "Recipient": "Gavėjas",
   "Reconnect": "Pakartotinai prijunkite",
   "Redo": "Atstatyti",
   "Relaunch": "Iš naujo paleiskite",

--- a/app/lang/pl.json
+++ b/app/lang/pl.json
@@ -506,7 +506,7 @@
   "Reading Pane On": "Panel podglądu wiadomości",
   "Rebuild": "Przeładuj",
   "Rebuild Cache...": "Przeładuj pamięć podręczną",
-  "Recipient": "Adresat:",
+  "Recipient": "Adresat",
   "Reconnect": "Połącz ponownie",
   "Redo": "Wykonaj ponownie",
   "Relaunch": "Wznowienie",

--- a/app/src/mail-rules-templates.ts
+++ b/app/src/mail-rules-templates.ts
@@ -35,6 +35,11 @@ export const ConditionTemplates = [
     },
   }),
 
+  new Template('replyTo', Template.Type.String, {
+    name: localized('Reply to'),
+    valueForMessage: message => [].concat(message.replyTo.map(c => c.email), message.to.map(c => c.name)),
+  }),
+
   new Template('anyAttachmentName', Template.Type.String, {
     name: localized('Attachment name'),
     valueForMessage: message => message.files.map(f => f.filename),


### PR DESCRIPTION
This PR adds a "Reply to" filter to the email rules. In additions, the localization for the recipient filter is slightly adjusted (colons removed) in some languages to match the label in all other languages. Otherwise this filter label is the only one with a colon in the filter view which looks very strange.

The filter rule is successfully tested. :)

This will resolve https://community.getmailspring.com/t/reply-to-as-a-filter-rule-option/967