### PR TITLE
feat: Make snooze label unambiguous

### DIFF
--- a/app/internal_packages/thread-snooze/lib/snooze-utils.ts
+++ b/app/internal_packages/thread-snooze/lib/snooze-utils.ts
@@ -19,14 +19,7 @@ export function snoozedUntilMessage(snoozeDate, now = moment()) {
     const date = moment(snoozeDate);
     const hourDifference = moment.duration(date.diff(now)).asHours();
 
-    if (hourDifference < 24) {
-      dateFormat = dateFormat.replace('MMM D, ', '');
-    }
-    if (date.minutes() === 0) {
-      dateFormat = dateFormat.replace(':mm', '');
-    }
-
-    message += ` until ${DateUtils.format(date, dateFormat)}`;
+    message += ` ${DateUtils.format(date, dateFormat)}`;
   }
   return message;
 }


### PR DESCRIPTION
This will ensure that the snooze label is unambiguous with regards to day/year. I also removed the 'until' from the string as it was not properly localized anyways and to ensure that the label does not need too much space.

Current Labels (German date formatting):
<img width="141" alt="Bildschirmfoto 2023-10-03 um 20 50 36" src="https://github.com/Foundry376/Mailspring/assets/587332/6c53c7a1-5966-4dde-92f4-dc3b5d17583f">

New Labels (German date formatting):
<img width="137" alt="Bildschirmfoto 2023-10-03 um 20 49 01" src="https://github.com/Foundry376/Mailspring/assets/587332/cee22a9b-aebb-4c86-9f4a-4d62bd50e42c">


