### PR TITLE
chore: remove deprecated linux dependency gconf2

### DIFF
--- a/app/build/resources/linux/debian/control.in
+++ b/app/build/resources/linux/debian/control.in
@@ -1,6 +1,6 @@
 Package: <%= name %>
 Version: <%= version %>
-Depends: libsecret-1-dev, gconf2, gconf-service, libgtk2.0-0, libudev0 | libudev1, libgcrypt11 | libgcrypt20, libnotify4, libxtst6, libnss3, gvfs-bin | libglib2.0-bin, xdg-utils
+Depends: libsecret-1-dev, libgtk2.0-0, libudev0 | libudev1, libgcrypt11 | libgcrypt20, libnotify4, libxtst6, libnss3, gvfs-bin | libglib2.0-bin, xdg-utils
 Suggests: gir1.2-gnomekeyring-1.0
 Section: <%= section %>
 Priority: optional


### PR DESCRIPTION
The mailspring debian package cannot be installed on Ubuntu 23.10 anymore due to the dprecated gconf packages being not available anymore. This PR removes this deprecated dependency.

For more information see:

- https://github.com/electron/electron/issues/2727
- https://github.com/mattermost/desktop/issues/2853