### PR TITLE
snap: Force usage of libsecret everywhere and remove password manager service plug

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -69,7 +69,6 @@ apps:
       - network
       - network-bind
       - network-observe
-      - password-manager-service
       - pulseaudio
       - removable-media
       - screen-inhibit-control

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -56,6 +56,9 @@ apps:
       TMPDIR: $XDG_RUNTIME_DIR
       # Fallback to XWayland if running in a Wayland session.
       DISABLE_WAYLAND: 1
+      # Force using the libsecret local backend in all the cases, even if no
+      # portal is detected.
+      SECRET_BACKEND: file
     plugs:
       - avahi-observe
       - browser-support

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -45,7 +45,7 @@ parts:
 
 apps:
   mailspring:
-    command: usr/bin/mailspring --no-sandbox
+    command: usr/bin/mailspring --no-sandbox --password-store=gnome-libsecret
     common-id: mailspring
     desktop: usr/share/applications/Mailspring.desktop
     extensions: [gnome]


### PR DESCRIPTION
See each commit for further explanations.