### PR TITLE
snap: Run as native wayland client if possible

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -eu
+
+wayland_native="$(snapctl get wayland-native)"
+if [[ -z "$wayland_native" ]]; then
+    snapctl set wayland-native=false
+fi

--- a/snap/launcher
+++ b/snap/launcher
@@ -1,8 +1,8 @@
 #!/bin/sh
 
-if [ -n "$WAYLAND_DISPLAY" ] && \
-   [ "${DISABLE_WAYLAND:-0}" = 0 ] && \
-   [ "${GDK_BACKEND:-wayland}" = "wayland" ]; then
+if [ "${DISABLE_WAYLAND:-0}" = 0 ] && \
+   [ "${GDK_BACKEND:-wayland}" = "wayland" ] && \
+   [ "$(snapctl get wayland-native)" = "true" ]; then
   args="--enable-features=WaylandWindowDecorations --ozone-platform=wayland"
 fi
 

--- a/snap/launcher
+++ b/snap/launcher
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+if [ -n "$WAYLAND_DISPLAY" ] && \
+   [ "${DISABLE_WAYLAND:-0}" = 0 ] && \
+   [ "${GDK_BACKEND:-wayland}" = "wayland" ]; then
+  args="--enable-features=WaylandWindowDecorations --ozone-platform=wayland"
+fi
+
+exec "$SNAP/usr/bin/mailspring" $args "${@}"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -19,6 +19,8 @@ parts:
     override-build: |
       cp -a "$CRAFT_PART_SRC"/* "$CRAFT_PART_INSTALL"
       craftctl default
+      install -m 755 ${CRAFT_PROJECT_DIR}/snap/launcher \
+        -D ${CRAFT_PART_INSTALL}/bin/mailspring.launcher -v
       sed -i 's|Icon=mailspring|Icon=/usr/share/pixmaps/mailspring\.png|' \
         $CRAFT_PART_INSTALL/usr/share/applications/Mailspring.desktop
     prime:
@@ -44,7 +46,7 @@ parts:
 
 apps:
   mailspring:
-    command: usr/bin/mailspring --no-sandbox
+    command: bin/mailspring.launcher --no-sandbox
     common-id: mailspring
     desktop: usr/share/applications/Mailspring.desktop
     extensions: [gnome]
@@ -53,8 +55,6 @@ apps:
       # Correct the TMPDIR path for Chromium Framework/Electron to
       # ensure libappindicator has readable resources.
       TMPDIR: $XDG_RUNTIME_DIR
-      # Fallback to XWayland if running in a Wayland session.
-      DISABLE_WAYLAND: '1'
     plugs:
       - avahi-observe
       - browser-support
@@ -69,3 +69,4 @@ apps:
       - pulseaudio
       - unity7
       - x11
+      - wayland


### PR DESCRIPTION
The new electron versions support wayland natively, this implies that mailspring can use the native rendering when in a wayland desktop environment, bringing various benefits including a better rendering in high DPI displays.

To enable this electron still requires some flags, so add a wrapper launcher that is used to enable them unless wayland isn't explicitly disabled.