### PR TITLE
Fix screenshot reference

### DIFF
--- a/app/build/resources/linux/mailspring.appdata.xml.in
+++ b/app/build/resources/linux/mailspring.appdata.xml.in
@@ -29,7 +29,10 @@
   <project_license>GPL-3.0+</project_license>
 
   <screenshots>
-    <screenshot type="default">https://getmailspring.com/static/img/hero_graphic_linux@2x.png</screenshot>
+    <screenshot type="default">
+      <caption>Mailspring Hero</caption>
+      <image type="source">https://getmailspring.com/static/img/hero_graphic_linux@2x.png</image>
+    </screenshot>
   </screenshots>
 
   <releases>


### PR DESCRIPTION
to conform to AppStream metainfo standard
See https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-screenshots

This also allows creating Flatpaks for Flathub without having to unduly modify the metainfo file. See ugly `sed` hack currently needed in https://github.com/flathub/com.getmailspring.Mailspring/pull/43