### PR TITLE
rpm: do not generate build_id links

### DIFF
--- a/app/build/resources/linux/redhat/mailspring.spec.in
+++ b/app/build/resources/linux/redhat/mailspring.spec.in
@@ -25,6 +25,10 @@ Requires: libappindicator
 %description
 <%= description %>
 
+# Don't generate build_id links to prevent conflicts when installing multiple
+# versions of electron apps (`code`, `slack`, etc).
+%define _build_id_links none
+
 %install
 mkdir -p %{buildroot}/usr/share/mailspring
 cp -r <%= contentsDir %>/* %{buildroot}/usr/share/mailspring


### PR DESCRIPTION
Fixes https://community.getmailspring.com/t/rpm-1-15-conflicts-with-slack/9167
Based on https://github.com/microsoft/vscode/pull/116105