### PR TITLE
Change lsb-core-noarch to be an optional dependency in the RPM package.

### DIFF
--- a/app/build/resources/linux/redhat/mailspring.spec.in
+++ b/app/build/resources/linux/redhat/mailspring.spec.in
@@ -6,15 +6,17 @@ License:        GPLv3
 URL:            https://getmailspring.com/
 AutoReqProv:    no # Avoid libchromiumcontent.so missing dependency
 
-%ifarch i386 i486 i586 i686
-Requires: lsb-core-noarch, libXss.so.1, libsecret-1.so.0, ca-certificates
+ifarch i386 i486 i586 i686
+Recommends: lsb-core-noarch
+Requires: libXss.so.1, libsecret-1.so.0, ca-certificates
 %if 0%{?rhel} >= 8
 Requires: libappindicator-gtk3
 %else
 Requires: libappindicator
 %endif
 %else
-Requires: lsb-core-noarch, libXss.so.1()(64bit), libsecret-1.so.0()(64bit), ca-certificates
+Recommends: lsb-core-noarch
+Requires: libXss.so.1()(64bit), libsecret-1.so.0()(64bit), ca-certificates
 %if 0%{?rhel} >= 8
 Requires: libappindicator-gtk3
 %else


### PR DESCRIPTION
Fixes [Unable to install RPM to Fedora 40](https://community.getmailspring.com/t/unable-to-install-rpm-to-fedora-40/8714), [Cannot install on Fedora 42 lsb-core not available](https://community.getmailspring.com/t/cannot-install-on-fedora-42-lsb-core-not-available/9658), [fedora: lsb-core-noarch is not available](https://github.com/Foundry376/Mailspring/issues/2496).

Small PR, probably a big discussion. 

It seems that in recent years there has been a shift in RHEL and LSB, where they seem to have actively removed it, not adhered to it, added WONTFIX, etc. Without getting into too much politics, here are some things on the topic.

https://access.redhat.com/solutions/6973382
https://web.archive.org/web/20240122163643/https://lists.linuxfoundation.org/pipermail/lsb-discuss/2023-February/008278.html
https://bugzilla.redhat.com/show_bug.cgi?id=2012924

For this particular use case, Mailspring on Fedora, some community members offered solutions of patching the RPM, installing other packages (Some of which also got removed) etc. Overall, probably not the best approach. I was debating removing this dependency entirely, but leaving it in for people who have already installed it or have it provided by some other package seemed like a more reasonable approach. 

This approach simply continues the installation silently after it cannot find this package or packages that provide it. 