### PR TITLE
Fix #1960 Bug: Mailspring was unable to create or delete the LaunchAgent file

### DIFF
--- a/app/src/system-start-service.ts
+++ b/app/src/system-start-service.ts
@@ -49,12 +49,16 @@ class SystemStartServiceDarwin extends SystemStartServiceBase {
   }
 
   configureToLaunchOnSystemStart() {
-    fs.writeFile(this._plistPath(), JSON.stringify(this._launchdPlist()), err => {
-      if (err) {
-        this._displayError(err);
-      } else {
-        exec(`plutil -convert xml1 ${this._plistPath()}`);
-      }
+    fs.mkdir(this._plistDir(), { recursive: true }, err => {
+      if (err) return this._displayError(err);
+
+      fs.writeFile(this._plistPath(), JSON.stringify(this._launchdPlist()), err => {
+        if (err) {
+          this._displayError(err);
+        } else {
+          exec(`plutil -convert xml1 ${this._plistPath()}`);
+        }
+      });
     });
   }
 
@@ -81,6 +85,10 @@ class SystemStartServiceDarwin extends SystemStartServiceBase {
 
   _plistPath() {
     return path.join(process.env.HOME, 'Library', 'LaunchAgents', 'com.mailspring.plist');
+  }
+
+  _plistDir() {
+    return path.join(process.env.HOME, 'Library', 'LaunchAgents');
   }
 
   _launchdPlist() {


### PR DESCRIPTION
References: #1960 and this thread -> https://community.getmailspring.com/t/mailspring-was-unable-to-create-or-delete-the-launchagent-file/708/

I've verified this issue is still active even on the latest MacOS. Tahoe 26.1 at the time of writing. 

I got the hint on how to fix the issue from Psylon's comment here -> https://community.getmailspring.com/t/mailspring-was-unable-to-create-or-delete-the-launchagent-file/708/8

The fix uses mkdir with the recursive flag to first create the plist directory, before attempting to create a file in it. Per their docs, https://nodejs.org/api/fs.html#fsmkdirpath-options-callback, fs.mkdir when called with the recursive flag will simply not create the directory if it already exists, no errors will be thrown. 

This still allows EEXIST, EPERM, EACCES and similar errors to be thrown. 

All other functionality remains the same. 