### PR TITLE
Upgrade snarkdown module to latest version

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -68,7 +68,7 @@
         "slate-react": "github:bengotow/slate#0.45.1-react",
         "slate-soft-break": "^0.9.0",
         "slate-when": "^0.2.0",
-        "snarkdown": "1.2.2",
+        "snarkdown": "2.0.0",
         "source-map-support": "^0.5.21",
         "temp": "^0.8",
         "tld": "^0.0.2",
@@ -4361,9 +4361,10 @@
       }
     },
     "node_modules/snarkdown": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/snarkdown/-/snarkdown-1.2.2.tgz",
-      "integrity": "sha512-vKTmaRB1evbqK+PXiBhXlvTYx5m1eHJHvYF/xWFkqS5a/2afTAJOoiZoVUDXEvMkpm3c+HkNJaxdO3zBFDaCPA=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/snarkdown/-/snarkdown-2.0.0.tgz",
+      "integrity": "sha512-MgL/7k/AZdXCTJiNgrO7chgDqaB9FGM/1Tvlcenenb7div6obaDATzs16JhFyHHBGodHT3B7RzRc5qk8pFhg3A==",
+      "license": "MIT"
     },
     "node_modules/source-map": {
       "version": "0.6.1",
@@ -8357,9 +8358,9 @@
       "integrity": "sha512-4qdtOGcBjral6YIBCWJ0ljFSKNLz9KkhbWtuGvUyRowl1kxfuE1x/Z/aJcaiilpb3do9bl5K7/1h9XC5wWpY/A=="
     },
     "snarkdown": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/snarkdown/-/snarkdown-1.2.2.tgz",
-      "integrity": "sha512-vKTmaRB1evbqK+PXiBhXlvTYx5m1eHJHvYF/xWFkqS5a/2afTAJOoiZoVUDXEvMkpm3c+HkNJaxdO3zBFDaCPA=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/snarkdown/-/snarkdown-2.0.0.tgz",
+      "integrity": "sha512-MgL/7k/AZdXCTJiNgrO7chgDqaB9FGM/1Tvlcenenb7div6obaDATzs16JhFyHHBGodHT3B7RzRc5qk8pFhg3A=="
     },
     "source-map": {
       "version": "0.6.1",

--- a/app/package.json
+++ b/app/package.json
@@ -70,7 +70,7 @@
     "slate-react": "github:bengotow/slate#0.45.1-react",
     "slate-soft-break": "^0.9.0",
     "slate-when": "^0.2.0",
-    "snarkdown": "1.2.2",
+    "snarkdown": "2.0.0",
     "source-map-support": "^0.5.21",
     "temp": "^0.8",
     "tld": "^0.0.2",


### PR DESCRIPTION
Update the snarkdown Markdown parser dependency to latest version. v2.0.0 includes bug fixes for link parsing, fenced code blocks, strikethrough support, TypeScript typings, and code block HTML structure.

The API remains compatible - CommonJS require() returns the function directly, so no code changes were needed.