### PR TITLE
Remove node-fetch dependency in favor of native fetch

### DIFF
--- a/app/internal_packages/onboarding/lib/onboarding-helpers.ts
+++ b/app/internal_packages/onboarding/lib/onboarding-helpers.ts
@@ -12,7 +12,6 @@ import {
 import MailspringProviderSettings from './mailspring-provider-settings.json';
 import MailcoreProviderSettings from './mailcore-provider-settings.json';
 import dns from 'dns';
-import fetch from 'node-fetch';
 import {
   GMAIL_CLIENT_ID,
   GMAIL_CLIENT_SECRET,

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -45,7 +45,6 @@
         "moment-timezone": "^0.6.0",
         "mousetrap": "^1.6.5",
         "node-emoji": "^1.2.1",
-        "node-fetch": "^2.6.0",
         "optimist": "0.4.0",
         "pick-react-known-prop": "0.x.x",
         "proxyquire": "1.3.1",

--- a/app/package.json
+++ b/app/package.json
@@ -47,7 +47,6 @@
     "moment-timezone": "^0.6.0",
     "mousetrap": "^1.6.5",
     "node-emoji": "^1.2.1",
-    "node-fetch": "^2.6.0",
     "optimist": "0.4.0",
     "pick-react-known-prop": "0.x.x",
     "proxyquire": "1.3.1",


### PR DESCRIPTION
Node.js 18+ includes native fetch, and Electron 39 uses Node.js 22+. The node-fetch package is no longer needed.