### PR TITLE
When opening the full message in a new window, show Chinese and other non-ASCII characters correctly

### DIFF
--- a/app/internal_packages/message-list/lib/message-item-body.tsx
+++ b/app/internal_packages/message-list/lib/message-item-body.tsx
@@ -124,7 +124,9 @@ export default class MessageItemBody extends React.Component<
       require('@electron/remote').app.getPath('temp'),
       `${message.id}.html`
     );
-    fs.writeFileSync(filepath, message.body);
+    // Prepend charset meta tag to ensure proper encoding (fixes garbled text for non-ASCII characters)
+    const htmlWithCharset = `<meta charset="UTF-8">\n${message.body}`;
+    fs.writeFileSync(filepath, htmlWithCharset);
     const win = new BrowserWindow({
       title: `${message.subject}`,
       width: 800,


### PR DESCRIPTION
When opening the full message in a new window via the 'Message Clipped - Show All' link, Chinese and other non-ASCII characters would appear as garbled text. This was because the HTML file was written without a charset declaration, causing the browser to guess the encoding incorrectly.

The fix prepends a UTF-8 charset meta tag to the HTML content before writing it to the temporary file, ensuring the browser correctly interprets the character encoding.

Fixes: https://community.getmailspring.com/t/message-clipped-show-all-has-a-problem-with-encoding/9532