### PR TITLE
Wayland support in Electron has landed in 39, remove DISABLE_WAYLAND flag

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -53,8 +53,6 @@ apps:
       # Correct the TMPDIR path for Chromium Framework/Electron to
       # ensure libappindicator has readable resources.
       TMPDIR: $XDG_RUNTIME_DIR
-      # Fallback to XWayland if running in a Wayland session.
-      DISABLE_WAYLAND: '1'
     plugs:
       - avahi-observe
       - browser-support


### PR DESCRIPTION
Remove DISABLE_WAYLAND environment variable that was forcing XWayland fallback. With Electron 39 (based on Chromium 142), native Wayland support is now enabled by default and works reliably.

<ul class="list-disc list-outside space-y-1 ml-6" node="[object Object]"><li node="[object Object]"></li>
</ul>
<h2 class="font-semibold" node="[object Object]">Background</h2>
<p node="[object Object]">This addresses the issue reported at <a class="text-text-300 underline hover:text-text-100" target="_blank" rel="noopener noreferrer" href="https://community.getmailspring.com/t/cannot-run-on-wayland-1-15-1/9908" node="[object Object]">https://community.getmailspring.com/t/cannot-run-on-wayland-1-15-1/9908</a></p>
<h3 class="font-semibold" node="[object Object]">What is Wayland?</h3>
<p node="[object Object]">Wayland is a modern display server protocol 
designed to replace the 40-year-old X Window System (X11) on Linux. It 
offers better security, improved performance, and a simpler 
architecture. Major distributions have made Wayland the default:</p>
<ul class="list-disc list-outside space-y-1 ml-6" node="[object Object]">
<li node="[object Object]"><strong class="font-semibold" node="[object Object]">Fedora</strong> (since v25, and is dropping X11 support entirely)</li>
<li node="[object Object]"><strong class="font-semibold" node="[object Object]">Ubuntu</strong> (since 21.04)</li>
<li node="[object Object]"><strong class="font-semibold" node="[object Object]">GNOME/KDE</strong> sessions default to Wayland</li>
</ul>
<h3 class="font-semibold" node="[object Object]">The Original Issue</h3>
<p node="[object Object]">The forum post was from Mailspring 1.15.1, which used Electron 33. At that time:</p>
<ul class="list-disc list-outside space-y-1 ml-6" node="[object Object]">
<li node="[object Object]">Electron did <strong class="font-semibold" node="[object Object]">not</strong> enable Wayland by default (used XWayland fallback)</li>
<li node="[object Object]">Users had to manually add flags like <span class="text-text-500 font-mono font-normal text-[13px]">--enable-features=UseOzonePlatform --ozone-platform=wayland</span></li>
<li node="[object Object]">These flags were unreliable and often caused crashes</li>
</ul>
<h3 class="font-semibold" node="[object Object]">What Changed</h3>
<div class="overflow-x-auto mb-2 rounded border border-border-300">
Version | Electron | Wayland Support
-- | -- | --
1.15.1 (forum issue) | 33.x | Manual flags required, often broken
Current (main branch) | 39.2.7 | Enabled by default

</div>
<p node="[object Object]">Key developments:</p>
<ol class="list-decimal list-outside mb-2 space-y-1 ml-6" node="[object Object]">
<li node="[object Object]"><strong class="font-semibold" node="[object Object]">Electron 38.2.0</strong> (October 2025) inherited Chromium's change to enable Wayland by default via <a class="text-text-300 underline hover:text-text-100" target="_blank" rel="noopener noreferrer" href="https://github.com/electron/electron/pull/35630" node="[object Object]">electron/electron#35630</a></li>
<li node="[object Object]"><strong class="font-semibold" node="[object Object]">Mailspring migrated to Electron 39.2.7</strong> on January 1, 2026</li>
<li node="[object Object]">Electron 39 includes specific Wayland fixes:
<ul class="list-disc list-outside space-y-1 ml-6" node="[object Object]">
<li node="[object Object]">Fixed crash when opening DevTools in detached mode on Wayland</li>
<li node="[object Object]">Fixed titlebar button positioning on Ubuntu/Wayland</li>
<li node="[object Object]">Uses <span class="text-text-500 font-mono font-normal text-[13px]">XDG_SESSION_TYPE</span> environment variable for automatic detection</li>
</ul>
</li>
</ol>
<h3 class="font-semibold" node="[object Object]">The Fix</h3>
<p node="[object Object]">The snap configuration had this workaround for older Electron versions:</p>
<div class="relative group !my-3"><div class="border-0.5 border-border-300 bg-bg-100/50 p-2 pr-10 rounded-lg overflow-x-auto text-sm"><pre class="!my-0 !p-0" style="background: transparent; color: rgb(171, 178, 191); text-shadow: rgba(0, 0, 0, 0.3) 0px 1px; font-family: var(--font-mono); direction: ltr; text-align: left; white-space: pre; word-spacing: normal; word-break: normal; line-height: 1.5; tab-size: 2; hyphens: none; padding: 1em; margin: 0.5em 0px; overflow: auto; border-radius: 0.3em; font-size: 13px;"><code class="language-yaml" style="background: transparent; color: rgb(171, 178, 191); text-shadow: rgba(0, 0, 0, 0.3) 0px 1px; font-family: var(--font-mono); direction: ltr; text-align: left; white-space: pre; word-spacing: normal; word-break: normal; line-height: 1.5; tab-size: 2; hyphens: none;"><span class="token key" style="color: rgb(209, 154, 102);">environment</span><span class="token" style="color: rgb(171, 178, 191);">:</span><span>
</span><span>  </span><span class="token" style="color: rgb(92, 99, 112); font-style: italic;"># Fallback to XWayland if running in a Wayland session.</span><span>
</span><span>  </span><span class="token key" style="color: rgb(209, 154, 102);">DISABLE_WAYLAND</span><span class="token" style="color: rgb(171, 178, 191);">:</span><span> </span><span class="token" style="color: rgb(152, 195, 121);">'1'</span><span>
</span></code></pre></div></div><div class="flex flex-col gap-4"><div class="px-3 mb-1"><div class="flex flex-col gap-4"><div class="flex items-start gap-1 text-sm"><div class="break-words min-w-0 flex-1"><div class="space-y-2 "><p node="[object Object]">This
 is no longer needed and actually prevents users from benefiting from 
native Wayland support. Electron 39 now auto-detects Wayland via the <span class="text-text-500 font-mono font-normal text-[13px]">XDG_SESSION_TYPE</span> environment variable.</p>
<h2 class="font-semibold" node="[object Object]">References</h2>
<ul class="list-disc list-outside space-y-1 ml-6" node="[object Object]">
<li node="[object Object]"><a class="text-text-300 underline hover:text-text-100" target="_blank" rel="noopener noreferrer" href="https://community.getmailspring.com/t/cannot-run-on-wayland-1-15-1/9908" node="[object Object]">Community Forum: Cannot run on Wayland 1.15.1</a></li>
<li node="[object Object]"><a class="text-text-300 underline hover:text-text-100" target="_blank" rel="noopener noreferrer" href="https://github.com/electron/electron/issues/41551" node="[object Object]">Electron Issue #41551: Feature Request for Wayland by default</a></li>
<li node="[object Object]"><a class="text-text-300 underline hover:text-text-100" target="_blank" rel="noopener noreferrer" href="https://github.com/electron/electron/pull/35630" node="[object Object]">Electron PR #35630: Change default ozone platform hint to auto</a></li>
<li node="[object Object]"><a class="text-text-300 underline hover:text-text-100" target="_blank" rel="noopener noreferrer" href="https://github.com/electron/electron/issues/44607" node="[object Object]">Electron Issue #44607: Native Wayland issues (now resolved)</a></li>
<li node="[object Object]"><a class="text-text-300 underline hover:text-text-100" target="_blank" rel="noopener noreferrer" href="https://releases.electronjs.org/release/v39.0.0" node="[object Object]">Electron v39.0.0 Release Notes</a></li>
</ul>
<h2 class="font-semibold" node="[object Object]">Test plan</h2>
<ul class="contains-task-list" node="[object Object]">
<li class="task-list-item" node="[object Object]"><input disabled="disabled" type="checkbox"> Test Snap package on Wayland session (GNOME on Wayland, KDE Plasma on Wayland)</li>
<li class="task-list-item" node="[object Object]"><input disabled="disabled" type="checkbox"> Verify window decorations render correctly</li>
<li class="task-list-item" node="[object Object]"><input disabled="disabled" type="checkbox"> Verify application launches without crashes</li>
<li class="task-list-item" node="[object Object]"><input disabled="disabled" type="checkbox"> Test on XWayland fallback still works for X11 sessions</li>
</ul></div></div></div></div></div></div><div class="px-3 py-6 min-h-12"></div>Background

This addresses the issue reported at https://community.getmailspring.com/t/cannot-run-on-wayland-1-15-1/9908
What is Wayland?

Wayland is a modern display server protocol designed to replace the 40-year-old X Window System (X11) on Linux. It offers better security, improved performance, and a simpler architecture. Major distributions have made Wayland the default:

    Fedora (since v25, and is dropping X11 support entirely)
    Ubuntu (since 21.04)
    GNOME/KDE sessions default to Wayland

The Original Issue

The forum post was from Mailspring 1.15.1, which used Electron 33. At that time:

    Electron did not enable Wayland by default (used XWayland fallback)
    Users had to manually add flags like --enable-features=UseOzonePlatform --ozone-platform=wayland
    These flags were unreliable and often caused crashes

What Changed
Version	Electron	Wayland Support
1.15.1 (forum issue)	33.x	Manual flags required, often broken
Current (main branch)	39.2.7	Enabled by default

Key developments:

    Electron 38.2.0 (October 2025) inherited Chromium's change to enable Wayland by default via [electron/electron#35630](https://github.com/electron/electron/pull/35630)
    Mailspring migrated to Electron 39.2.7 on January 1, 2026
    Electron 39 includes specific Wayland fixes:
        Fixed crash when opening DevTools in detached mode on Wayland
        Fixed titlebar button positioning on Ubuntu/Wayland
        Uses XDG_SESSION_TYPE environment variable for automatic detection

The Fix

The snap configuration had this workaround for older Electron versions:

environment:
  # Fallback to XWayland if running in a Wayland session.
  DISABLE_WAYLAND: '1'

This is no longer needed and actually prevents users from benefiting from native Wayland support. Electron 39 now auto-detects Wayland via the XDG_SESSION_TYPE environment variable.
References

    [Community Forum: Cannot run on Wayland 1.15.1](https://community.getmailspring.com/t/cannot-run-on-wayland-1-15-1/9908)
    [Electron Issue #41551: Feature Request for Wayland by default](https://github.com/electron/electron/issues/41551)
    [Electron PR #35630: Change default ozone platform hint to auto](https://github.com/electron/electron/pull/35630)
    [Electron Issue #44607: Native Wayland issues (now resolved)](https://github.com/electron/electron/issues/44607)
    [Electron v39.0.0 Release Notes](https://releases.electronjs.org/release/v39.0.0)

Test plan

    Test Snap package on Wayland session (GNOME on Wayland, KDE Plasma on Wayland)
    Verify window decorations render correctly
    Verify application launches without crashes
    Test on XWayland fallback still works for X11 sessions