### PR TITLE
Fix Linux tray icon sharing ID with other Electron apps

### DIFF
--- a/app/src/browser/main.js
+++ b/app/src/browser/main.js
@@ -285,6 +285,15 @@ const handleStartupEventWithSquirrel = () => {
 
 const start = () => {
   app.setAppUserModelId('com.squirrel.mailspring.mailspring');
+
+  // Set the app name explicitly for Linux to ensure the system tray icon
+  // gets a unique ID. Without this, all Electron apps share the same
+  // StatusNotifierItem ID on Linux, causing their tray visibility settings
+  // to be synchronized. See: https://github.com/electron/electron/issues/40936
+  if (process.platform === 'linux') {
+    app.setName('Mailspring');
+  }
+
   if (handleStartupEventWithSquirrel()) {
     return;
   }


### PR DESCRIPTION
Set app.setName('Mailspring') explicitly on Linux to ensure the system tray icon gets a unique StatusNotifierItem ID. Without this, all Electron applications share the same ID, causing KDE Plasma and other desktop environments to synchronize tray visibility settings across different apps.

Fixes: https://community.getmailspring.com/t/tray-icon-share-id-with-different-apps-particularly-electron/14000
See: https://github.com/electron/electron/issues/40936