### PR TITLE
Fix SQL generation for multiple ORDER BY clauses

### DIFF
--- a/app/spec/models/query-spec.ts
+++ b/app/spec/models/query-spec.ts
@@ -192,6 +192,31 @@ describe('ModelQuery', function ModelQuerySpecs() {
       });
     });
 
+    it('should correctly generate ORDER BY with single sort order', () => {
+      this.runScenario(Thread, {
+        builder: q => q.where({ accountId: 'abcd' }).order(Thread.attributes.unread.descending()),
+
+        sql:
+          'SELECT `Thread`.`data`  FROM `Thread`  ' +
+          "WHERE `Thread`.`accountId` = 'abcd'  " +
+          'ORDER BY `Thread`.`unread` DESC',
+      });
+    });
+
+    it('should correctly generate ORDER BY with multiple sort orders', () => {
+      this.runScenario(Thread, {
+        builder: q => q.where({ accountId: 'abcd' }).order([
+          Thread.attributes.lastMessageReceivedTimestamp.ascending(),
+          Thread.attributes.unread.descending(),
+        ]),
+
+        sql:
+          'SELECT `Thread`.`data`  FROM `Thread`  ' +
+          "WHERE `Thread`.`accountId` = 'abcd'  " +
+          'ORDER BY `Thread`.`lastMessageReceivedTimestamp` ASC, `Thread`.`unread` DESC',
+      });
+    });
+
     it('should correctly generate `contains` queries using JOINS', () => {
       this.runScenario(Thread, {
         builder: q =>

--- a/app/src/flux/models/query.ts
+++ b/app/src/flux/models/query.ts
@@ -487,9 +487,9 @@ export default class ModelQuery<T extends Model | Model[]> {
     }
 
     let sql = ' ORDER BY ';
-    this._orders.forEach(sort => {
-      sql += sort.orderBySQL(this._klass);
-    });
+    sql += this._orders
+      .map(sort => sort.orderBySQL(this._klass))
+      .join(', ')
     return sql;
   }
 


### PR DESCRIPTION
### Problem

The query builder supports multiple sort orders via `Query.order([...])`, and this behavior is covered by existing in-memory/query-subscription tests. However, when such queries are executed against database, the SQL generator concatenates multiple `ORDER BY` expressions without separators, producing invalid SQL, e.g.:

```sql
ORDER BY `Thread`.`unread` DESC`Thread`.`lastMessageReceivedTimestamp` DESC
```

This results in a SQLite syntax error whenever more than one sort order is used.

### Root cause

`_orderClause()` concatenates rendered `SortOrder` SQL fragments directly instead of separating them with commas.

### Fix

Render multiple sort orders as a comma-separated list:

```sql
ORDER BY col1 DESC, col2 ASC
```

This aligns SQL generation with:

- the documented SQL syntax
- the existing query API (which explicitly supports multiple sort orders)
- current in-memory sorting behavior

### Tests

Added a regression test that asserts correct SQL generation for queries with multiple sort orders.

### Impact

- No behavior change for single-column sorts
- Fixes invalid SQL for all multi-column ORDER BY queries
- No API changes