### PR TITLE
Fix Download All changing filenames with hyphen-number patterns

### DIFF
--- a/app/src/flux/stores/attachment-store.ts
+++ b/app/src/flux/stores/attachment-store.ts
@@ -273,13 +273,15 @@ class AttachmentStore extends MailspringStore {
     const ext = path.extname(attemptedPath);
     const dir = path.dirname(attemptedPath);
     let name = path.basename(attemptedPath, ext);
-    const match = /-(\d+)$/.exec(name);
+    // Use " (N)" format for collision counters to avoid conflicts with filenames
+    // that end with hyphen-number patterns (like dates: "report-2023.pdf")
+    const match = / \((\d+)\)$/.exec(name);
     let counter = 0;
     if (match) {
       counter = Number(match[1]);
       name = name.substr(0, match.index);
     }
-    return `${dir}/${name}-${counter + 1}${ext}`;
+    return path.join(dir, `${name} (${counter + 1})${ext}`);
   }
 
   _defaultSaveDir() {


### PR DESCRIPTION
The _incrementPathToAvoidCollision function was using a regex /-(\d+)$/
to detect existing collision counters. This incorrectly matched any
trailing hyphen-number pattern, causing filenames like "report-2023.pdf"
to be modified to "report-2024.pdf" when a collision was detected.

Changed collision counter format from "-N" to " (N)" which is the
standard format used by most operating systems and is much less likely
to conflict with actual filenames. Also switched to using path.join()
for proper cross-platform path handling.

Fixes: https://community.getmailspring.com/t/download-all-feature-changes-attachments-names/14015