### PR TITLE
Fix Windows spellcheck not working for en-US

### DIFF
--- a/app/src/browser/application.ts
+++ b/app/src/browser/application.ts
@@ -137,7 +137,6 @@ export default class Application extends EventEmitter {
       this.touchBar = new ApplicationTouchBar(resourcePath);
     }
 
-    this.setupJavaScriptArguments();
     this.handleEvents();
     this.handleLaunchOptions(options);
 
@@ -255,12 +254,6 @@ export default class Application extends EventEmitter {
     } else {
       fs.unlink(filePath, callback);
     }
-  }
-
-  // Configures required javascript environment flags.
-  setupJavaScriptArguments() {
-    app.commandLine.appendSwitch('autoplay-policy', 'no-user-gesture-required');
-    app.commandLine.appendSwitch('js-flags', '--harmony');
   }
 
   openWindowsForTokenState() {

--- a/app/src/browser/main.js
+++ b/app/src/browser/main.js
@@ -300,6 +300,21 @@ const start = () => {
 
   require('@electron/remote/main').initialize();
 
+  // Configure Chromium command line switches before app ready event.
+  // These must be set before the ready event for them to take effect.
+  // Reference: https://www.electronjs.org/docs/latest/api/command-line-switches
+  app.commandLine.appendSwitch('autoplay-policy', 'no-user-gesture-required');
+  app.commandLine.appendSwitch('js-flags', '--harmony');
+
+  // Disable Windows native spellchecker to force Hunspell dictionary usage.
+  // On Windows 8+, Chromium uses the Windows Spell Check API for en-US which
+  // can fail silently if the language pack is incomplete. This forces the use
+  // of Hunspell dictionaries for reliable spellchecking across all languages.
+  // Reference: https://bitbucket.org/chromiumembedded/cef/issues/3055
+  if (process.platform === 'win32') {
+    app.commandLine.appendSwitch('disable-features', 'WinUseBrowserSpellChecker');
+  }
+
   const options = parseCommandLine(process.argv);
   global.errorLogger = setupErrorLogger(options);
   const configDirPath = setupConfigDir(options);


### PR DESCRIPTION
On Windows 8+, Chromium uses the Windows Spell Check API which can
silently fail for en-US if the language pack is incomplete. This
disables the Windows native spellchecker to force Hunspell dictionary
usage for reliable spellchecking.

Also moves command line switches from Application.start() to main.js
before the app ready event, where they are required to take effect
per Electron documentation.