### PR TITLE
Align calendar plus icon with message button style

### DIFF
--- a/app/internal_packages/main-calendar/lib/quick-event-button.tsx
+++ b/app/internal_packages/main-calendar/lib/quick-event-button.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { Actions } from 'mailspring-exports';
+import { Actions, localized } from 'mailspring-exports';
+import { RetinaImg } from 'mailspring-component-kit';
 import { QuickEventPopover } from './quick-event-popover';
 
 export class QuickEventButton extends React.Component<Record<string, unknown>> {
@@ -17,10 +18,11 @@ export class QuickEventButton extends React.Component<Record<string, unknown>> {
       <button
         style={{ order: -50 }}
         tabIndex={-1}
-        className="btn btn-toolbar"
+        className="btn btn-toolbar item-compose"
+        title={localized('Create new event')}
         onClick={this.onClick}
       >
-        +
+        <RetinaImg name="toolbar-compose.png" mode={RetinaImg.Mode.ContentIsMask} />
       </button>
     );
   }


### PR DESCRIPTION
Add a compose-style button to the MiniMonthView header for creating new calendar events. The button uses the same toolbar-compose.png icon and styling as the main compose button - positioned on the right edge with opacity hover effects.