### PR TITLE
Fix null check in parseDateString causing Quick Event error

### DIFF
--- a/app/src/date-utils.ts
+++ b/app/src/date-utils.ts
@@ -288,7 +288,7 @@ const DateUtils = {
     const results = { start: moment(now), end: moment(now), leftoverText: dateLikeString };
     for (const item of parsed) {
       for (const val of ['start', 'end']) {
-        if (!(val in item)) {
+        if (!item[val]) {
           continue;
         }
         const { day: knownDay, weekday: knownWeekday, hour: knownHour } = item[val].knownValues;


### PR DESCRIPTION
The check `!(val in item)` only verified if the key existed, but chrono-node can return results where `end` is explicitly null. Changed to `!item[val]` to properly skip null/undefined values before accessing `.knownValues`.

Fixes TypeError: Cannot read properties of null (reading 'knownValues')