### PR TITLE
Fix errors in thread list context menu when no threads are present

### DIFF
--- a/app/internal_packages/thread-list/lib/thread-list.tsx
+++ b/app/internal_packages/thread-list/lib/thread-list.tsx
@@ -213,7 +213,7 @@ class ThreadList extends React.Component<
 
   _onShowContextMenu = event => {
     const items = this.refs.list.itemsForMouseEvent(event);
-    if (!items) {
+    if (!items || items.length === 0) {
       event.preventDefault();
       return;
     }


### PR DESCRIPTION
The itemsForMouseEvent method returns an empty array [] when no item is found at the click location, not null. The check `if (!items)` was incorrect because an empty array is truthy in JavaScript. This caused the context menu to be created with no threads when right-clicking on empty space, leading to errors.