### PR TITLE
Migrate Windows builds to Azure Trusted Signing

### DIFF
--- a/.github/workflows/build-windows.yaml
+++ b/.github/workflows/build-windows.yaml
@@ -32,16 +32,6 @@ jobs:
           node-version: '20'
           cache: 'npm'
 
-      - name: Setup Codesigning Certificate
-        shell: pwsh
-        run: |
-          $certBytes = [Convert]::FromBase64String($env:CERT_BASE64)
-          $certPath = "app\build\resources\certs\win\win-codesigning.p12"
-          New-Item -ItemType Directory -Force -Path "app\build\resources\certs\win"
-          [IO.File]::WriteAllBytes($certPath, $certBytes)
-        env:
-          CERT_BASE64: ${{ secrets.WINDOWS_CODESIGN_CERT_BASE64 }}
-
       - name: Install Dependencies
         run: npm ci
 
@@ -59,16 +49,41 @@ jobs:
         run: npm run build
         env:
           DEBUG: electron-packager
-          SIGN_BUILD: true
-          WINDOWS_CODESIGN_CERT: app\build\resources\certs\win\win-codesigning.p12
-          WINDOWS_CODESIGN_CERT_PASSWORD: ${{ secrets.WINDOWS_CODESIGN_CERT_PASSWORD }}
 
-      - name: Create Signed Windows Installer
+      - name: Sign Application Files with Azure Trusted Signing
+        uses: azure/trusted-signing-action@v0
+        with:
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
+          endpoint: ${{ secrets.AZURE_TRUSTED_SIGNING_ENDPOINT }}
+          trusted-signing-account-name: ${{ secrets.AZURE_TRUSTED_SIGNING_ACCOUNT_NAME }}
+          certificate-profile-name: ${{ secrets.AZURE_TRUSTED_SIGNING_CERT_PROFILE_NAME }}
+          files-folder: ${{ github.workspace }}\app\dist\mailspring-win32-x64
+          files-folder-filter: exe,dll
+          files-folder-recurse: true
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+
+      - name: Create Windows Installer
         run: node app/build/create-signed-windows-installer.js
-        env:
-          SIGN_BUILD: true
-          WINDOWS_CODESIGN_CERT: app\build\resources\certs\win\win-codesigning.p12
-          WINDOWS_CODESIGN_CERT_PASSWORD: ${{ secrets.WINDOWS_CODESIGN_CERT_PASSWORD }}
+
+      - name: Sign Windows Installer with Azure Trusted Signing
+        uses: azure/trusted-signing-action@v0
+        with:
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
+          endpoint: ${{ secrets.AZURE_TRUSTED_SIGNING_ENDPOINT }}
+          trusted-signing-account-name: ${{ secrets.AZURE_TRUSTED_SIGNING_ACCOUNT_NAME }}
+          certificate-profile-name: ${{ secrets.AZURE_TRUSTED_SIGNING_CERT_PROFILE_NAME }}
+          files-folder: ${{ github.workspace }}\app\dist
+          files-folder-filter: exe
+          files-folder-recurse: false
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
 
       - name: Sync Artifacts to S3
         shell: pwsh

--- a/app/build/create-signed-windows-installer.js
+++ b/app/build/create-signed-windows-installer.js
@@ -2,6 +2,10 @@
 /**
  * NOTE: Due to path issues, this script must be run outside of grunt
  * directly from a powershell command.
+ *
+ * Code signing is handled separately by Azure Trusted Signing action in the
+ * GitHub workflow. This script creates an unsigned installer which is then
+ * signed by the workflow after creation.
  */
 const path = require('path');
 const { createWindowsInstaller } = require('electron-winstaller');
@@ -15,7 +19,6 @@ const config = {
   appDirectory: path.join(appDir, 'dist', 'mailspring-win32-x64'),
   loadingGif: path.join(appDir, 'build', 'resources', 'win', 'loading.gif'),
   iconUrl: 'http://mailspring-builds.s3.amazonaws.com/assets/mailspring.ico',
-  certificateFile: process.env.WINDOWS_CODESIGN_CERT,
   description: 'Mailspring',
   version: version,
   title: 'Mailspring',
@@ -28,9 +31,6 @@ const config = {
 
 console.log(config);
 console.log('---> Starting');
-
-// avoid logging the certificate password
-config.certificatePassword = process.env.WINDOWS_CODESIGN_CERT_PASSWORD;
 
 createWindowsInstaller(config)
   .then(() => {


### PR DESCRIPTION
Replace traditional P12 certificate-based signing with Azure Trusted Signing for Windows builds. This provides better security and simplifies certificate management by using Azure's cloud-based signing service.

Changes:
- Remove P12 certificate setup step from workflow
- Add Azure Trusted Signing action to sign application files (exe, dll)
- Add Azure Trusted Signing action to sign the installer after creation
- Update create-signed-windows-installer.js to remove certificate options

Required secrets:
- AZURE_TENANT_ID
- AZURE_CLIENT_ID
- AZURE_CLIENT_SECRET
- AZURE_TRUSTED_SIGNING_ENDPOINT
- AZURE_TRUSTED_SIGNING_ACCOUNT_NAME
- AZURE_TRUSTED_SIGNING_CERT_PROFILE_NAME