### PR TITLE
Fix deprecated Electron APIs for compatibility with Electron 39

### DIFF
--- a/app/src/browser/main.js
+++ b/app/src/browser/main.js
@@ -3,7 +3,6 @@
 global.shellStartTime = Date.now();
 const util = require('util');
 
-// TODO: Remove when upgrading to Electron 4
 const fs = require('fs');
 fs.statSyncNoException = function(...args) {
   try {
@@ -350,7 +349,7 @@ const start = () => {
       urls: ['*://login.microsoftonline.com/*'],
     };
 
-    session.defaultSession
+    session.defaultSession.extensions
       .loadExtension(
         path
           .join(options.resourcePath, 'static', 'extensions', 'chrome-i18n')

--- a/app/src/quickpreview/index.ts
+++ b/app/src/quickpreview/index.ts
@@ -317,8 +317,8 @@ function _createCaptureWindow() {
     });
   });
 
-  win.webContents.on('crashed', () => {
-    console.warn(`Thumbnail generation webcontents crashed.`);
+  win.webContents.on('render-process-gone', (event, details) => {
+    console.warn(`Thumbnail generation webcontents crashed (reason: ${details.reason}).`);
     if (captureWindow === win) captureWindow = null;
     win.destroy();
   });


### PR DESCRIPTION
- Replace deprecated session.loadExtension() with session.extensions.loadExtension() (deprecated in Electron 36.0)
- Replace deprecated 'crashed' event with 'render-process-gone' event in quickpreview capture window
- Remove outdated TODO comment referencing Electron 4