### PR TITLE
Fix event creation to use visible calendars only

### DIFF
--- a/app/internal_packages/main-calendar/lib/quick-event-popover.tsx
+++ b/app/internal_packages/main-calendar/lib/quick-event-popover.tsx
@@ -57,7 +57,8 @@ export class QuickEventPopover extends React.Component<
     end: Moment;
   }) => {
     const allCalendars = await DatabaseStore.findAll<Calendar>(Calendar);
-    const editableCals = allCalendars.filter(c => !c.readOnly);
+    const disabledCalendars: string[] = AppEnv.config.get('mailspring.disabledCalendars') || [];
+    const editableCals = allCalendars.filter(c => !c.readOnly && !disabledCalendars.includes(c.id));
     if (editableCals.length === 0) {
       AppEnv.showErrorDialog(
         localized(


### PR DESCRIPTION
When creating an event via QuickEventPopover, the calendar selection now respects the disabled calendars setting. Previously, it would pick the first editable calendar regardless of visibility. Now it filters out calendars that are in the 'mailspring.disabledCalendars' config, ensuring the new event is created in a visible calendar.