### PR TITLE
Make calendar window responsive to screen size

### DIFF
--- a/app/src/browser/window-manager.ts
+++ b/app/src/browser/window-manager.ts
@@ -1,5 +1,5 @@
 import _ from 'underscore';
-import { app, BrowserWindow } from 'electron';
+import { app, BrowserWindow, screen } from 'electron';
 import WindowLauncher from './window-launcher';
 import { localized } from '../intl';
 import MailspringWindow from './mailspring-window';
@@ -260,12 +260,15 @@ export default class WindowManager {
       height: 600,
     };
 
+    const primaryDisplay = screen.getPrimaryDisplay();
+    const { width: screenWidth, height: screenHeight } = primaryDisplay.workAreaSize;
+
     coreWinOpts[WindowManager.CALENDAR_WINDOW] = {
       windowKey: WindowManager.CALENDAR_WINDOW,
       windowType: WindowManager.CALENDAR_WINDOW,
       title: localized('Calendar Preview'),
-      width: 900,
-      height: 600,
+      width: Math.round(screenWidth * 0.75),
+      height: Math.round(screenHeight * 0.75),
       toolbar: false,
       hidden: false,
     };


### PR DESCRIPTION
Set calendar window dimensions to 75% of the user's primary display work area instead of fixed 900x600 pixels.