### PR TITLE
Improve deep-linking to settings for default email app on Windows 11

### DIFF
--- a/app/src/default-client-helper.ts
+++ b/app/src/default-client-helper.ts
@@ -42,20 +42,10 @@ export class DefaultClientHelperWindows implements DCH {
   }
 
   async resetURLScheme() {
-    const { response } = await require('@electron/remote').dialog.showMessageBox({
-      type: 'info',
-      buttons: [localized('Learn More')],
-      message: localized('Visit Windows Settings to change your default mail client'),
-      detail: localized(
-        "You'll find Mailspring, along with other options, listed in Default Apps > Mail."
-      ),
-    });
-
-    if (response === 0) {
-      shell.openExternal(
-        'http://support.getmailspring.com/hc/en-us/articles/115001881412-Choose-Mailspring-as-the-default-mail-client-on-Windows'
-      );
-    }
+    // On Windows 11 21H2+ (with April 2023 update), we can deep link directly to Mailspring's
+    // default app settings page. On older Windows versions, this falls back to the main
+    // Default Apps page, which is still better than opening a web browser.
+    shell.openExternal('ms-settings:defaultapps?registeredAppUser=Mailspring');
   }
 
   registerForURLScheme(scheme: string, callback = (error?: Error) => {}) {
@@ -80,17 +70,19 @@ export class DefaultClientHelperWindows implements DCH {
         if (!didMakeDefault) {
           const { response } = await require('@electron/remote').dialog.showMessageBox({
             type: 'info',
-            buttons: [localized('Learn More')],
-            defaultId: 1,
+            buttons: [localized('Open Settings'), localized('Cancel')],
+            defaultId: 0,
             message: localized(
               'Visit Windows Settings to finish making Mailspring your mail client'
             ),
-            detail: localized("Click 'Learn More' to view instructions in our knowledge base."),
+            detail: localized(
+              "Click 'Open Settings' to open Windows Settings where you can set Mailspring as your default email app."
+            ),
           });
           if (response === 0) {
-            shell.openExternal(
-              'http://support.getmailspring.com/hc/en-us/articles/115001881412-Choose-Mailspring-as-the-default-mail-client-on-Windows'
-            );
+            // On Windows 11 21H2+ (with April 2023 update), this deep links directly to
+            // Mailspring's default app settings. On older versions, falls back to Default Apps.
+            shell.openExternal('ms-settings:defaultapps?registeredAppUser=Mailspring');
           }
         }
         callback(null);


### PR DESCRIPTION
Instead of opening the Zendesk knowledge base article, use the ms-settings:defaultapps URI with the registeredAppUser parameter to open Windows Settings directly to Mailspring's default app page.

On Windows 11 21H2+ (with April 2023 update), this deep links directly to Mailspring's settings. On older Windows versions, it falls back to the main Default Apps page.