### PR TITLE
Run build github actions only on master, use 8-character commit hashes in S3 paths 

### DIFF
--- a/.github/workflows/build-linux.yaml
+++ b/.github/workflows/build-linux.yaml
@@ -67,6 +67,6 @@ jobs:
 
       - name: Sync Artifacts to S3
         run: |
-          aws s3 sync app/dist/ "s3://mailspring-builds/client/$(git rev-parse --short HEAD)/linux" \
+          aws s3 sync app/dist/ "s3://mailspring-builds/client/$(git rev-parse --short=8 HEAD)/linux" \
             --acl public-read \
             --exclude "*" --include *.deb --include *.rpm

--- a/.github/workflows/build-macos.yaml
+++ b/.github/workflows/build-macos.yaml
@@ -67,6 +67,6 @@ jobs:
 
       - name: Sync artifacts to S3 bucket
         run: |
-          aws s3 sync app/dist/ "s3://mailspring-builds/client/$(git rev-parse --short HEAD)/osx" \
+          aws s3 sync app/dist/ "s3://mailspring-builds/client/$(git rev-parse --short=8 HEAD)/osx" \
             --acl public-read \
             --exclude "*" --include *.zip

--- a/.github/workflows/build-windows.yaml
+++ b/.github/workflows/build-windows.yaml
@@ -87,7 +87,7 @@ jobs:
       - name: Sync Artifacts to S3
         shell: pwsh
         run: |
-          $commit = git rev-parse --short HEAD
+          $commit = git rev-parse --short=8 HEAD
           aws s3 sync app/dist/ "s3://mailspring-builds/client/$commit/win-x64" `
             --acl public-read `
             --exclude "*" `


### PR DESCRIPTION
Windows + macOS were already configured correctly, updating Linux to match. 