### PR TITLE
Move Azure signing config to repository variables

### DIFF
--- a/.github/workflows/build-windows.yaml
+++ b/.github/workflows/build-windows.yaml
@@ -56,8 +56,8 @@ jobs:
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
           azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
           endpoint: ${{ secrets.AZURE_TRUSTED_SIGNING_ENDPOINT }}
-          trusted-signing-account-name: ${{ secrets.AZURE_TRUSTED_SIGNING_ACCOUNT_NAME }}
-          certificate-profile-name: ${{ secrets.AZURE_TRUSTED_SIGNING_CERT_PROFILE_NAME }}
+          trusted-signing-account-name: ${{ vars.AZURE_TRUSTED_SIGNING_ACCOUNT_NAME }}
+          certificate-profile-name: ${{ vars.AZURE_TRUSTED_SIGNING_CERT_PROFILE_NAME }}
           files-folder: ${{ github.workspace }}\app\dist\mailspring-win32-x64
           files-folder-filter: exe,dll
           files-folder-recurse: true
@@ -75,8 +75,8 @@ jobs:
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
           azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
           endpoint: ${{ secrets.AZURE_TRUSTED_SIGNING_ENDPOINT }}
-          trusted-signing-account-name: ${{ secrets.AZURE_TRUSTED_SIGNING_ACCOUNT_NAME }}
-          certificate-profile-name: ${{ secrets.AZURE_TRUSTED_SIGNING_CERT_PROFILE_NAME }}
+          trusted-signing-account-name: ${{ vars.AZURE_TRUSTED_SIGNING_ACCOUNT_NAME }}
+          certificate-profile-name: ${{ vars.AZURE_TRUSTED_SIGNING_CERT_PROFILE_NAME }}
           files-folder: ${{ github.workspace }}\app\dist
           files-folder-filter: exe
           files-folder-recurse: false


### PR DESCRIPTION
Change AZURE_TRUSTED_SIGNING_ACCOUNT_NAME and
AZURE_TRUSTED_SIGNING_CERT_PROFILE_NAME from secrets to vars to prevent unnecessary redaction in logs.