### PR TITLE
Remove origin header that causes problems with Office365 Oauth

### DIFF
--- a/app/src/browser/main.js
+++ b/app/src/browser/main.js
@@ -366,7 +366,7 @@ const start = () => {
     app.removeListener('open-url', onOpenUrlBeforeReady);
 
     // Remove the Origin header for Microsoft OAuth requests. Native fetch in Electron
-    // adds an Origin header which causes AADSTS9002326 errors because Microsoft treats
+    // adds an Origin header which causes AADSTS90023 errors because Microsoft treats
     // it as a cross-origin request requiring SPA client-type registration. Desktop apps
     // should not send Origin headers for OAuth token exchange.
     const o365Filter = {


### PR DESCRIPTION
The switch from node-fetch to native fetch in commit f1e3b0b caused OAuth authentication to fail for Microsoft accounts. Native fetch in Electron's renderer process automatically adds an Origin header, which Microsoft's OAuth endpoint interprets as a cross-origin request requiring SPA client-type registration.

The previous workaround of setting Origin to 'localhost' was invalid (not a proper URL) and no longer effective. The correct fix for desktop apps is to remove the Origin header entirely from Microsoft OAuth requests.

Fixes: https://community.getmailspring.com/t/outlook-hotmail-will-not-authenticate-after-version-1-17-update/14102