### PR TITLE
Fix issues with the "Move to Folder" dropdown locking the UI

### DIFF
--- a/app/internal_packages/category-picker/lib/label-picker-popover.tsx
+++ b/app/internal_packages/category-picker/lib/label-picker-popover.tsx
@@ -49,8 +49,10 @@ export default class LabelPickerPopover extends Component<
 
   componentDidUpdate(prevProps: LabelPickerPopoverProps) {
     if (prevProps.account !== this.props.account || prevProps.threads !== this.props.threads) {
+      // Re-register observables when account/threads change.
+      // The subscription callback (_onLabelsChanged) will trigger setState
+      // with the new labels, so we don't need an explicit setState here.
       this._registerObservables();
-      this.setState(this._recalculateState(this.props));
     }
   }
 
@@ -107,7 +109,10 @@ export default class LabelPickerPopover extends Component<
     this._labels = categories.filter(c => {
       return c instanceof Label && !c.role;
     });
-    this.setState(this._recalculateState());
+    // Use functional setState to preserve any pending searchValue updates from user typing
+    this.setState(prevState =>
+      this._recalculateState(this.props, { searchValue: prevState.searchValue })
+    );
   };
 
   _onEscape = () => {

--- a/app/internal_packages/category-picker/lib/move-picker-popover.tsx
+++ b/app/internal_packages/category-picker/lib/move-picker-popover.tsx
@@ -53,8 +53,10 @@ export default class MovePickerPopover extends Component<
 
   componentDidUpdate(prevProps: MovePickerPopoverProps) {
     if (prevProps.account !== this.props.account || prevProps.threads !== this.props.threads) {
+      // Re-register observables when account/threads change.
+      // The subscription callback (_onCategoriesChanged) will trigger setState
+      // with the new categories, so we don't need an explicit setState here.
       this._registerObservables();
-      this.setState(this._recalculateState(this.props));
     }
   }
 
@@ -128,7 +130,10 @@ export default class MovePickerPopover extends Component<
   _onCategoriesChanged = categories => {
     this._standardFolders = categories.filter(c => c.role && c instanceof Folder);
     this._userCategories = categories.filter(c => !c.role || !(c instanceof Folder));
-    this.setState(this._recalculateState());
+    // Use functional setState to preserve any pending searchValue updates from user typing
+    this.setState(prevState =>
+      this._recalculateState(this.props, { searchValue: prevState.searchValue })
+    );
   };
 
   _onEscape = () => {


### PR DESCRIPTION
Two issues were identified and fixed:

1. Race condition with searchValue state: When the sync engine triggers a database change while the user is typing, the _onCategoriesChanged callback could overwrite the pending searchValue state update. This occurred because _recalculateState() read this.state.searchValue via a default parameter, which returned the old value before React applied the pending setState.

   Fix: Use functional setState in _onCategoriesChanged/_onLabelsChanged to ensure the most recent searchValue (including pending updates) is preserved.

2. Double setState in componentDidUpdate: When props changed, componentDidUpdate called _registerObservables() which triggered the subscription callback synchronously, calling setState. Then componentDidUpdate also called setState explicitly. This double setState was redundant and could cause unnecessary re-renders.

   Fix: Remove the explicit setState from componentDidUpdate since the subscription callback already handles the state update.