### PR TITLE
Sign native .node addon files for Smart App Control compliance

### DIFF
--- a/.github/workflows/build-windows.yaml
+++ b/.github/workflows/build-windows.yaml
@@ -59,7 +59,7 @@ jobs:
           trusted-signing-account-name: ${{ vars.AZURE_TRUSTED_SIGNING_ACCOUNT_NAME }}
           certificate-profile-name: ${{ vars.AZURE_TRUSTED_SIGNING_CERT_PROFILE_NAME }}
           files-folder: ${{ github.workspace }}\app\dist\mailspring-win32-x64
-          files-folder-filter: exe,dll
+          files-folder-filter: exe,dll,node
           files-folder-recurse: true
           file-digest: SHA256
           timestamp-rfc3161: http://timestamp.acs.microsoft.com


### PR DESCRIPTION
The Windows code signing step only signed .exe and .dll files, but native
Node addons (.node files like better_sqlite3.node) were left unsigned.
Smart App Control blocks apps containing unsigned binaries, which explains
reports of Windows refusing to launch Mailspring.

https://claude.ai/code/session_018WKuDzTdpPuJzm1LbVmSjr