### PR TITLE
Handle zypper exit code 107 in Linux build workflow

### DIFF
--- a/.github/workflows/build-linux.yaml
+++ b/.github/workflows/build-linux.yaml
@@ -312,10 +312,22 @@ jobs:
 
             # Install dependencies first
             cd /workspace
-            zypper --non-interactive install xorg-x11-server-Xvfb which alsa-lib
+
+            # Note: zypper exit code 107 (ZYPPER_EXIT_INF_RPM_SCRIPT_FAILED) means
+            # the package installed but an RPM scriptlet failed. This is expected in
+            # Docker containers where PAM/systemd scriptlets cannot run properly.
+            zypper --non-interactive install xorg-x11-server-Xvfb which alsa-lib; ZYPPER_EXIT=\$?
+            if [ \$ZYPPER_EXIT -ne 0 ] && [ \$ZYPPER_EXIT -ne 107 ]; then
+              echo \"zypper install dependencies failed with exit code \$ZYPPER_EXIT\"
+              exit 1
+            fi
 
             # Install the RPM package (zypper will auto-resolve dependencies)
-            zypper --non-interactive --no-gpg-checks install *.rpm
+            zypper --non-interactive --no-gpg-checks install *.rpm; ZYPPER_EXIT=\$?
+            if [ \$ZYPPER_EXIT -ne 0 ] && [ \$ZYPPER_EXIT -ne 107 ]; then
+              echo \"zypper install mailspring failed with exit code \$ZYPPER_EXIT\"
+              exit 1
+            fi
 
             # Verify installation succeeded
             rpm -q mailspring || (echo '✗ Mailspring package not installed' && exit 1)


### PR DESCRIPTION
## Summary
Updated the Linux build workflow to gracefully handle zypper exit code 107 (ZYPPER_EXIT_INF_RPM_SCRIPT_FAILED), which occurs when RPM scriptlets fail in Docker containers but the package installation itself succeeds.

## Changes
- Added exit code checking for both zypper install commands in the openSUSE build job
- Exit code 107 is now treated as a non-fatal condition since it indicates successful package installation despite RPM scriptlet failures
- Only fail the build for actual installation errors (exit codes other than 0 and 107)
- Added descriptive error messages to distinguish between dependency installation and mailspring package installation failures

## Implementation Details
- Captured zypper exit codes using `$?` after each install command
- Implemented conditional logic to allow exit codes 0 (success) and 107 (expected scriptlet failure in containers)
- This prevents false negatives in CI/CD pipelines where PAM/systemd scriptlets cannot execute properly in containerized environments

https://claude.ai/code/session_01Wn3F5VB9xhbQpuViLC3MGp