### PR TITLE
Fix an async race condition in notification toast display

### DIFF
--- a/app/internal_packages/unread-notifications/lib/main.ts
+++ b/app/internal_packages/unread-notifications/lib/main.ts
@@ -42,7 +42,9 @@ export class Notifier {
     }
 
     if (objectClass === Message.name) {
-      const newIds = objectsRawJSON.filter(json => json.headersSyncComplete).map(json => json.id);
+      const newIds = objectsRawJSON
+        .filter((json) => json.headersSyncComplete)
+        .map((json) => json.id);
       if (!newIds.length) return;
       this._onMessagesChanged(objects, newIds);
     }
@@ -73,7 +75,7 @@ export class Notifier {
     }
 
     if (!AppEnv.inSpecMode()) {
-      await new Promise<void>(resolve => {
+      await new Promise<void>((resolve) => {
         // wait a couple hundred milliseconds and collect any updates to these
         // new messages. This gets us message bodies, messages impacted by mail rules, etc.
         // while ensuring notifications are never too delayed.
@@ -104,7 +106,7 @@ export class Notifier {
     // Ensure notifications are dismissed when the user reads a thread
     threads.forEach(({ id, unread }) => {
       if (!unread && this.activeNotifications[id]) {
-        this.activeNotifications[id].forEach(n => n.close());
+        this.activeNotifications[id].forEach((n) => n.close());
         delete this.activeNotifications[id];
       }
     });
@@ -112,6 +114,7 @@ export class Notifier {
 
   async _notifyAll() {
     // Extract unique sender names from the queue
+    const count = this.unnotifiedQueue.length;
     const senders = [
       ...new Set(
         this.unnotifiedQueue
@@ -121,13 +124,14 @@ export class Notifier {
     ] as string[];
 
     await NativeNotifications.displaySummaryNotification({
-      count: this.unnotifiedQueue.length,
+      count,
       senders,
       onActivate: () => {
         AppEnv.displayWindow();
       },
     });
-    this.unnotifiedQueue = [];
+    // Only remove the items we counted — new items may have been queued during the await
+    this.unnotifiedQueue.splice(0, count);
   }
 
   async _notifyOne({ message, thread }) {
@@ -212,16 +216,21 @@ export class Notifier {
   }
 
   async _notifyMessages() {
+    // Set the guard immediately to prevent concurrent re-entry during async operations.
+    // Without this, a second _onNewMessagesReceived call during the await below would
+    // start a concurrent _notifyMessages, causing duplicate or conflicting notifications.
+    this.hasScheduledNotify = true;
+
     if (this.unnotifiedQueue.length >= 5) {
       await this._notifyAll();
     } else if (this.unnotifiedQueue.length > 0) {
       await this._notifyOne(this.unnotifiedQueue.shift());
     }
 
-    this.hasScheduledNotify = false;
     if (this.unnotifiedQueue.length > 0) {
       setTimeout(() => this._notifyMessages(), 2000);
-      this.hasScheduledNotify = true;
+    } else {
+      this.hasScheduledNotify = false;
     }
   }
 
@@ -254,7 +263,7 @@ export class Notifier {
     return DatabaseStore.findAll<Thread>(
       Thread,
       Thread.attributes.id.in(Object.keys(threadIds))
-    ).then(threadsArray => {
+    ).then((threadsArray) => {
       const threads = {};
       for (const t of threadsArray) {
         threads[t.id] = t;
@@ -262,7 +271,7 @@ export class Notifier {
 
       // Filter new messages to just the ones in the inbox
       const newMessagesInInbox = newMessages.filter(({ threadId }) => {
-        return threads[threadId] && threads[threadId].categories.find(c => c.role === 'inbox');
+        return threads[threadId] && threads[threadId].categories.find((c) => c.role === 'inbox');
       });
 
       if (newMessagesInInbox.length === 0) {

--- a/app/internal_packages/unread-notifications/specs/main-spec.es6
+++ b/app/internal_packages/unread-notifications/specs/main-spec.es6
@@ -177,6 +177,7 @@ describe('UnreadNotifications', function UnreadNotifications() {
 
     this.notification = jasmine.createSpyObj('notification', ['close']);
     spyOn(NativeNotifications, 'displayNotification').andReturn(this.notification);
+    spyOn(NativeNotifications, 'displaySummaryNotification').andReturn(Promise.resolve(null));
 
     spyOn(Promise, 'props').andCallFake(dict => {
       const dictOut = {};
@@ -256,7 +257,7 @@ describe('UnreadNotifications', function UnreadNotifications() {
     });
   });
 
-  it('should create a Notification if there are five or more unread messages', () => {
+  it('should create a summary Notification if there are five or more unread messages', () => {
     waitsForPromise(async () => {
       await this.notifier._onDatabaseChanged({
         objectClass: Message.name,
@@ -264,12 +265,12 @@ describe('UnreadNotifications', function UnreadNotifications() {
         objectsRawJSON: getObjectsRawJson(['1', '2', '3', '4', '5'])
       });
       advanceClock(2000);
-      expect(NativeNotifications.displayNotification).toHaveBeenCalled();
-      const [{ title, tag }] = NativeNotifications.displayNotification.mostRecentCall.args;
-      expect({ title, tag }).toEqual({
-        title: '5 Unread Messages',
-        tag: 'unread-update',
-      });
+      expect(NativeNotifications.displaySummaryNotification).toHaveBeenCalled();
+      expect(NativeNotifications.displayNotification).not.toHaveBeenCalled();
+      const options = NativeNotifications.displaySummaryNotification.mostRecentCall.args[0];
+      expect(options.count).toEqual(5);
+      expect(options.senders).toContain('Ben');
+      expect(options.senders).toContain('Mark');
     });
   });
 

--- a/app/src/native-notifications.ts
+++ b/app/src/native-notifications.ts
@@ -286,10 +286,18 @@ ${actionsXml}
    * @param senders Array of sender names to display
    * @returns Toast XML string
    */
-  private buildWindowsSummaryToastXml(count: number, senders: string[]): string {
+  private buildWindowsSummaryToastXml(id: string, count: number, senders: string[]): string {
     const sendersText = this.formatSenderList(senders);
 
-    return `<toast launch="mailspring:inbox" activationType="protocol">
+    const baseParams = new URLSearchParams({
+      id: id,
+      threadId: '',
+      messageId: '',
+    }).toString();
+
+    const clickUrl = `mailspring://notification-click?${baseParams}`;
+
+    return `<toast launch="${this.escapeXml(clickUrl)}" activationType="protocol">
   <visual>
     <binding template="ToastGeneric">
       <text hint-maxLines="1">${count} new messages</text>
@@ -298,7 +306,7 @@ ${actionsXml}
     </binding>
   </visual>
   <actions>
-    <action content="View Inbox" arguments="mailspring:inbox" activationType="protocol"/>
+    <action content="View Inbox" arguments="${this.escapeXml(clickUrl)}" activationType="protocol"/>
     <action content="Dismiss" arguments="dismiss" activationType="system"/>
   </actions>
 </toast>`;
@@ -417,7 +425,7 @@ ${actionsXml}
 
     // Use special summary toast XML on Windows
     if (platform === 'win32') {
-      options.toastXml = this.buildWindowsSummaryToastXml(count, senders);
+      options.toastXml = this.buildWindowsSummaryToastXml(id, count, senders);
     }
 
     try {


### PR DESCRIPTION
## Summary
This PR fixes critical bugs in the notification system, improves code formatting consistency, and enhances the Windows summary notification implementation with proper click tracking.

## Key Changes

### Bug Fixes
- **Fixed race condition in `_notifyMessages()`**: Move `hasScheduledNotify = true` to the beginning of the function to prevent concurrent re-entry during async operations. This ensures that a second `_onNewMessagesReceived` call during the await won't start a duplicate notification flow.
- **Fixed queue handling in `_notifyAll()`**: Changed from clearing the entire queue (`this.unnotifiedQueue = []`) to removing only the counted items (`splice(0, count)`). This prevents loss of messages that arrive during the async notification display.
- **Added missing spy in tests**: Added spy for `displaySummaryNotification` to properly test the summary notification flow.

### Code Formatting
- Standardized arrow function parameter formatting to use parentheses consistently (e.g., `json =>` to `(json) =>`)
- Applied formatting across multiple files for consistency

### Windows Notification Enhancement
- Updated `buildWindowsSummaryToastXml()` to accept an `id` parameter for proper click tracking
- Modified toast launch URL to use `mailspring://notification-click` protocol with proper parameters (id, threadId, messageId)
- Updated action button to use the same click URL for consistent behavior

### Test Updates
- Updated test description from "should create a Notification" to "should create a summary Notification"
- Modified test assertions to verify `displaySummaryNotification` is called instead of `displayNotification`
- Added assertions for count and senders in the summary notification options

## Implementation Details
The race condition fix ensures that the guard flag is set immediately before any async operations, preventing the scheduler from being triggered multiple times concurrently. The queue handling improvement uses `splice()` to remove only processed items, allowing new messages queued during the notification display to be handled in the next cycle.

https://claude.ai/code/session_01BztSNPXZquyoWFHV34nUkh