### PR TITLE
Upgrade node-abi to 3.87.0 and improve native build detection

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -3182,9 +3182,9 @@
       "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
     },
     "node_modules/node-abi": {
-      "version": "3.67.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.67.0.tgz",
-      "integrity": "sha512-bLn/fU/ALVBE9wj+p4Y21ZJWYFjUXLXPi/IewyLZkx3ApxKDNBWCKdReeKOtD8dWpOdDCeMyLh6ZewzcLsG2Nw==",
+      "version": "3.87.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.87.0.tgz",
+      "integrity": "sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==",
       "dependencies": {
         "semver": "^7.3.5"
       },
@@ -7523,9 +7523,9 @@
       "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
     },
     "node-abi": {
-      "version": "3.67.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.67.0.tgz",
-      "integrity": "sha512-bLn/fU/ALVBE9wj+p4Y21ZJWYFjUXLXPi/IewyLZkx3ApxKDNBWCKdReeKOtD8dWpOdDCeMyLh6ZewzcLsG2Nw==",
+      "version": "3.87.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.87.0.tgz",
+      "integrity": "sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==",
       "requires": {
         "semver": "^7.3.5"
       },

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -20,7 +20,6 @@ const npmEnvs = {
     npm_config_target_arch: process.env.OVERRIDE_TO_INTEL ? 'x64' : process.arch,
     npm_config_disturl: 'https://electronjs.org/headers',
     npm_config_runtime: 'electron',
-    npm_config_build_from_source: true,
   }),
 };
 
@@ -128,8 +127,13 @@ if (cacheElectronTarget !== npmElectronTarget) {
 async function sqliteMissingNanosleep() {
   return new Promise(resolve => {
     const sqliteLibDir = path.join(appModulesPath, 'better-sqlite3', 'build', 'Release');
+    const staticLib = path.join(sqliteLibDir, 'sqlite3.a');
+    const sharedLib = path.join(sqliteLibDir, 'better_sqlite3.node');
+
+    // Check the static lib first (build-from-source), then the prebuilt .node binary
+    const target = fs.existsSync(staticLib) ? staticLib : sharedLib;
     safeExec(
-      `nm '${sqliteLibDir}/sqlite3.a' | grep nanosleep`,
+      `nm '${target}' | grep nanosleep`,
       { ignoreStderr: true },
       (err, resp) => {
         resolve(resp === '');


### PR DESCRIPTION
## Summary
This PR upgrades the `node-abi` dependency from 3.67.0 to 3.87.0 and improves the native module build detection logic for better-sqlite3.

## Key Changes
- **Dependency Update**: Upgraded `node-abi` to version 3.87.0 in package-lock.json
- **Build Configuration**: Removed `npm_config_build_from_source: true` from the postinstall script's npm environment configuration
- **Build Detection Logic**: Enhanced `sqliteMissingNanosleep()` function to intelligently detect whether better-sqlite3 was built from source or uses a prebuilt binary
  - Now checks for the static library (`sqlite3.a`) first, indicating a source build
  - Falls back to the prebuilt shared library (`better_sqlite3.node`) if static lib doesn't exist
  - Uses the appropriate target for the `nm` command to check for nanosleep symbol

## Implementation Details
The change removes the forced source build requirement and instead allows the build system to use prebuilt binaries when available, while maintaining compatibility with source builds. The updated detection logic ensures the correct binary artifact is inspected regardless of how the native module was compiled.

https://claude.ai/code/session_01TXFueZPdYvdMDJFDBjGMfV