### PR TITLE
Persist calendar view preference across sessions

### DIFF
--- a/app/internal_packages/main-calendar/lib/core/mailspring-calendar.tsx
+++ b/app/internal_packages/main-calendar/lib/core/mailspring-calendar.tsx
@@ -46,6 +46,7 @@ import { showRecurringEventDialog } from './recurring-event-dialog';
 import { modifyEventWithRecurringSupport, EventTimeChangeOptions } from './recurring-event-actions';
 
 const DISABLED_CALENDARS = 'mailspring.disabledCalendars';
+const CALENDAR_VIEW = 'mailspring.calendarView';
 
 const VIEWS = {
   [CalendarView.DAY]: DayView,
@@ -124,7 +125,7 @@ export class MailspringCalendar extends React.Component<
       calendars: [],
       focusedEvent: null,
       selectedEvents: [],
-      view: CalendarView.WEEK,
+      view: AppEnv.config.get(CALENDAR_VIEW) || CalendarView.WEEK,
       focusedMoment: moment(),
       disabledCalendars: AppEnv.config.get(DISABLED_CALENDARS) || [],
       dragState: null,
@@ -180,6 +181,7 @@ export class MailspringCalendar extends React.Component<
   onChangeView = (view: CalendarView) => {
     // Clear any active drag state when changing views
     this.setState({ view, dragState: null });
+    AppEnv.config.set(CALENDAR_VIEW, view);
   };
 
   onChangeFocusedMoment = (focusedMoment: Moment) => {


### PR DESCRIPTION
## Summary
This change adds persistence for the user's selected calendar view (Day, Week, Month, etc.) so that their preference is remembered when they return to the application.

## Key Changes
- Added `CALENDAR_VIEW` configuration key to store the user's view preference
- Modified the initial state to load the saved view preference from config, defaulting to `CalendarView.WEEK` if not previously set
- Updated the `onChangeView` handler to persist the selected view to config whenever the user switches views

## Implementation Details
The calendar view preference is now stored in the Mailspring config using the same pattern already used for disabled calendars. When the component initializes, it retrieves the saved view preference, and whenever the user changes views, the new selection is immediately saved to persist across sessions.

https://claude.ai/code/session_01Roj2nSjGe59MoKirMmRUbi