### PR TITLE
Set white background color for email frame elements

### DIFF
--- a/app/static/style/email-frame.less
+++ b/app/static/style/email-frame.less
@@ -70,6 +70,7 @@
 
   #inbox-html-wrapper {
     font-family: 'Nylas-Pro', 'Helvetica', 'Lucidia Grande', sans-serif;
+    background-color: white;
   }
 
   #inbox-html-wrapper.platform-win32 {
@@ -80,6 +81,7 @@
     font-family: @font-family-monospace;
     font-size: 14px;
     white-space: pre-line;
+    background-color: white;
   }
 
   strong,


### PR DESCRIPTION
## Summary
This change adds explicit white background colors to email frame styling to ensure consistent visual appearance across different contexts.

## Key Changes
- Added `background-color: white;` to `#inbox-html-wrapper` selector
- Added `background-color: white;` to the monospace/pre-formatted text block within the email frame

## Implementation Details
These background color declarations ensure that the email content wrapper and pre-formatted text areas have a consistent white background, preventing potential transparency or inherited background color issues that could affect readability or visual consistency of email content display.

https://claude.ai/code/session_0122psQodPbcN8Zh2AtFNi1N