### PR TITLE
Add syncInit to main-calendar to eliminate 2.5s startup delay

### DIFF
--- a/app/internal_packages/main-calendar/package.json
+++ b/app/internal_packages/main-calendar/package.json
@@ -10,6 +10,7 @@
   "engines": {
     "mailspring": "*"
   },
+  "syncInit": true,
   "windowTypes": {
     "calendar": true
   }


### PR DESCRIPTION
The calendar package was missing the syncInit flag, causing it to be deferred into the 2.5-second waiting queue instead of activating immediately when the calendar window opens.

https://claude.ai/code/session_0187hEp6y59XPYn9mU3bvNhH