### PR TITLE
Fix IMAP port field change handler to use correct callback

### DIFF
--- a/app/internal_packages/onboarding/lib/page-account-settings-imap.tsx
+++ b/app/internal_packages/onboarding/lib/page-account-settings-imap.tsx
@@ -143,7 +143,11 @@ class AccountIMAPSettingsForm extends React.Component<AccountIMAPSettingsFormPro
               value={settings[field]}
               disabled={submitting}
               onKeyPress={onFieldKeyPress}
-              onChange={onFieldChange}
+              onChange={e =>
+                onPortChange({
+                  target: { value: e.target.value, id: `settings.${field}` },
+                })
+              }
             />
           </>
         )}


### PR DESCRIPTION
## Summary
Updated the IMAP account settings form to properly handle port field changes by routing them through the `onPortChange` callback instead of the generic `onFieldChange` handler.

## Key Changes
- Modified the `onChange` handler for the port input field in the IMAP settings form
- Changed from calling `onFieldChange` directly to calling `onPortChange` with properly formatted event object
- Ensured the event object includes both the input value and the correct field identifier (`settings.${field}`)

## Implementation Details
The port field now explicitly calls `onPortChange` with a synthetic event object that matches the expected format, including:
- `target.value`: The new port value from the input
- `target.id`: The field identifier in the format `settings.${field}`

This ensures port changes are handled through the appropriate specialized callback rather than the generic field change handler.

https://claude.ai/code/session_016yc4unNkb8msF2khBnWskf