### PR TITLE
Fix keyboard event handling in tree widgets

### DIFF
--- a/app/src/keymap-manager.ts
+++ b/app/src/keymap-manager.ts
@@ -42,9 +42,14 @@ mousetrap.prototype.stopCallback = (e, element, combo) => {
   if (withinTree) {
     const isPlainKey = !/(mod|command|ctrl)/.test(combo);
     const isArrowKey = /(left|right|up|down)/.test(combo);
-    if (isPlainKey && isArrowKey) {
-      return true;
-    }
+    // Only block plain arrow keys within tree / arrow-key widgets so the
+    // widget's own navigation works. All other keys (Escape, letter keys
+    // for Gmail-style shortcuts, etc.) must pass through – returning false
+    // explicitly so the withinTextInput check below is skipped. Without
+    // the explicit return, non-arrow keys fall through to withinTextInput
+    // and get blocked when focus is on a contentEditable element inside
+    // the widget (e.g. the reply composer within the message list).
+    return isPlainKey && isArrowKey;
   }
 
   const withinTextInput =


### PR DESCRIPTION
## Summary
Fixed keyboard event handling in tree and arrow-key widgets to allow non-arrow keys (like Escape and Gmail-style shortcuts) to pass through to their handlers, while still blocking plain arrow keys to preserve widget navigation.

## Changes
- Modified the `stopCallback` logic in keymap-manager to explicitly return a boolean value instead of conditionally returning `true`
- Changed from blocking all plain arrow keys within trees to only blocking plain arrow keys, allowing other key types to propagate
- This prevents non-arrow keys from being incorrectly blocked when focus is on contentEditable elements (e.g., reply composer) within tree widgets

## Implementation Details
The fix addresses an issue where non-arrow keys were being caught by the `withinTextInput` check below, causing them to be blocked when focus was on contentEditable elements inside tree widgets. By explicitly returning `false` for non-arrow keys, the subsequent `withinTextInput` check is skipped, allowing these keys to reach their intended handlers while maintaining proper arrow key navigation within the widget.

https://claude.ai/code/session_01CrqfjPBGhzAyXEBhRotyEs