### PR TITLE
Fix OAuth code parsing to handle + characters correctly

### DIFF
--- a/app/internal_packages/onboarding/lib/oauth-signin-page.tsx
+++ b/app/internal_packages/onboarding/lib/oauth-signin-page.tsx
@@ -14,7 +14,7 @@ interface OAuthSignInPageProps {
   buildAccountFromAuthResponse: (rep: any) => Account | Promise<Account>;
   onSuccess: (account: Account) => void;
   onTryAgain: () => void;
-  providerConfig: typeof AccountProviders[0];
+  providerConfig: (typeof AccountProviders)[0];
   serviceName: string;
 }
 
@@ -71,16 +71,26 @@ export default class OAuthSignInPage extends React.Component<
     // launch a web server
     this._server = http.createServer((request, response) => {
       if (!this._mounted) return;
-      const { query } = url.parse(request.url, true);
-      if (query.code) {
-        this._onReceivedCode(query.code);
+      // Parse the query string using decodeURIComponent instead of querystring.parse
+      // (which url.parse with `true` uses internally). querystring.parse decodes `+`
+      // as a space per the application/x-www-form-urlencoded spec, but the OAuth
+      // redirect is a URL query string where `+` is a valid literal character per
+      // RFC 3986. If Google's authorization code contains a `+` that isn't encoded
+      // as %2B, querystring.parse would silently corrupt it into a space, causing
+      // token exchange or downstream XOAuth2 authentication to fail.
+      const parsedUrl = url.parse(request.url);
+      const rawQuery = parsedUrl.query || '';
+      const codeMatch = rawQuery.match(/(?:^|&)code=([^&]*)/);
+      const code = codeMatch ? decodeURIComponent(codeMatch[1]) : null;
+      if (code) {
+        this._onReceivedCode(code);
         response.writeHead(302, { Location: 'https://id.getmailspring.com/oauth/finished' });
         response.end();
       } else {
         response.end('Unknown Request');
       }
     });
-    this._server.once('error', err => {
+    this._server.once('error', (err) => {
       AppEnv.showErrorDialog({
         title: localized('Unable to Start Local Server'),
         message: localized(
@@ -196,7 +206,7 @@ export default class OAuthSignInPage extends React.Component<
             onClick={() =>
               navigator.clipboard
                 .writeText(this.props.providerAuthPageUrl)
-                .catch(err => console.error('Failed to copy to clipboard:', err))
+                .catch((err) => console.error('Failed to copy to clipboard:', err))
             }
             onMouseDown={() => this.setState({ pressed: true })}
             onMouseUp={() => this.setState({ pressed: false })}

--- a/app/internal_packages/onboarding/lib/oauth-signin-page.tsx
+++ b/app/internal_packages/onboarding/lib/oauth-signin-page.tsx
@@ -19,7 +19,12 @@ export function extractOAuthCodeFromUrl(requestUrl: string): string | null {
   const parsedUrl = url.parse(requestUrl);
   const rawQuery = parsedUrl.query || '';
   const codeMatch = rawQuery.match(/(?:^|&)code=([^&]*)/);
-  return codeMatch ? decodeURIComponent(codeMatch[1]) : null;
+  if (!codeMatch) return null;
+  try {
+    return decodeURIComponent(codeMatch[1]);
+  } catch {
+    return null;
+  }
 }
 
 interface OAuthSignInPageProps {

--- a/app/internal_packages/onboarding/lib/oauth-signin-page.tsx
+++ b/app/internal_packages/onboarding/lib/oauth-signin-page.tsx
@@ -9,6 +9,19 @@ import FormErrorMessage from './form-error-message';
 import { LOCAL_SERVER_PORT } from './onboarding-constants';
 import AccountProviders from './account-providers';
 
+/**
+ * Extract the OAuth authorization code from a redirect URL's query string.
+ * Uses decodeURIComponent instead of querystring.parse to preserve `+` as
+ * a literal character (RFC 3986) rather than decoding it as a space
+ * (application/x-www-form-urlencoded).
+ */
+export function extractOAuthCodeFromUrl(requestUrl: string): string | null {
+  const parsedUrl = url.parse(requestUrl);
+  const rawQuery = parsedUrl.query || '';
+  const codeMatch = rawQuery.match(/(?:^|&)code=([^&]*)/);
+  return codeMatch ? decodeURIComponent(codeMatch[1]) : null;
+}
+
 interface OAuthSignInPageProps {
   providerAuthPageUrl: string;
   buildAccountFromAuthResponse: (rep: any) => Account | Promise<Account>;
@@ -71,17 +84,7 @@ export default class OAuthSignInPage extends React.Component<
     // launch a web server
     this._server = http.createServer((request, response) => {
       if (!this._mounted) return;
-      // Parse the query string using decodeURIComponent instead of querystring.parse
-      // (which url.parse with `true` uses internally). querystring.parse decodes `+`
-      // as a space per the application/x-www-form-urlencoded spec, but the OAuth
-      // redirect is a URL query string where `+` is a valid literal character per
-      // RFC 3986. If Google's authorization code contains a `+` that isn't encoded
-      // as %2B, querystring.parse would silently corrupt it into a space, causing
-      // token exchange or downstream XOAuth2 authentication to fail.
-      const parsedUrl = url.parse(request.url);
-      const rawQuery = parsedUrl.query || '';
-      const codeMatch = rawQuery.match(/(?:^|&)code=([^&]*)/);
-      const code = codeMatch ? decodeURIComponent(codeMatch[1]) : null;
+      const code = extractOAuthCodeFromUrl(request.url);
       if (code) {
         this._onReceivedCode(code);
         response.writeHead(302, { Location: 'https://id.getmailspring.com/oauth/finished' });

--- a/app/internal_packages/onboarding/specs/oauth-signin-page-spec.ts
+++ b/app/internal_packages/onboarding/specs/oauth-signin-page-spec.ts
@@ -1,0 +1,33 @@
+import { extractOAuthCodeFromUrl } from '../lib/oauth-signin-page';
+
+describe('extractOAuthCodeFromUrl', function extractOAuthCodeTests() {
+  it('extracts a standard Google OAuth code with a slash', () => {
+    // Google codes typically look like 4/0AX4XfWi... with the slash percent-encoded
+    expect(extractOAuthCodeFromUrl('/?code=4%2F0AX4XfWiTest')).toEqual('4/0AX4XfWiTest');
+  });
+
+  it('preserves a literal + in the authorization code', () => {
+    // This is the key regression test: querystring.parse (used by url.parse with
+    // parseQueryString=true) decodes + as space per application/x-www-form-urlencoded,
+    // but in a URL query string + is a valid literal character per RFC 3986.
+    expect(extractOAuthCodeFromUrl('/?code=4%2F0AeanS0m+test123')).toEqual('4/0AeanS0m+test123');
+  });
+
+  it('decodes %2B as + (percent-encoded plus)', () => {
+    expect(extractOAuthCodeFromUrl('/?code=4%2F0AeanS0m%2Btest123')).toEqual('4/0AeanS0m+test123');
+  });
+
+  it('handles code with other query parameters present', () => {
+    expect(extractOAuthCodeFromUrl('/?state=xyz&code=4%2F0AX4XfWi&scope=email')).toEqual(
+      '4/0AX4XfWi'
+    );
+  });
+
+  it('returns null when no code parameter is present', () => {
+    expect(extractOAuthCodeFromUrl('/?error=access_denied')).toEqual(null);
+  });
+
+  it('returns null for a bare path with no query string', () => {
+    expect(extractOAuthCodeFromUrl('/')).toEqual(null);
+  });
+});

--- a/app/internal_packages/onboarding/specs/oauth-signin-page-spec.ts
+++ b/app/internal_packages/onboarding/specs/oauth-signin-page-spec.ts
@@ -30,4 +30,8 @@ describe('extractOAuthCodeFromUrl', function extractOAuthCodeTests() {
   it('returns null for a bare path with no query string', () => {
     expect(extractOAuthCodeFromUrl('/')).toEqual(null);
   });
+
+  it('returns null for a malformed percent-encoded code instead of throwing', () => {
+    expect(extractOAuthCodeFromUrl('/?code=4%2F0AeanS0m%ZZbad')).toEqual(null);
+  });
 });


### PR DESCRIPTION
## Summary
Fixed a critical bug in OAuth redirect handling where authorization codes containing `+` characters were being silently corrupted during query string parsing.

## Key Changes
- **OAuth code parsing**: Replaced `url.parse()` with manual regex-based query string parsing using `decodeURIComponent()` instead of the built-in `querystring.parse()`. This prevents `+` characters in OAuth codes from being incorrectly decoded as spaces, which would cause token exchange failures.
- **TypeScript type fix**: Corrected the type annotation for `providerConfig` from `typeof AccountProviders[0]` to `(typeof AccountProviders)[0]` for proper type precedence.
- **Code style**: Updated arrow function parameters to use parentheses for consistency (`err =>` to `(err) =>` in two locations).

## Implementation Details
The core issue was that `url.parse(request.url, true)` internally uses `querystring.parse()`, which follows the `application/x-www-form-urlencoded` spec and decodes `+` as a space. However, OAuth redirect URLs use standard RFC 3986 query string encoding where `+` is a literal character. If Google's authorization code contains an unencoded `+`, it would be corrupted into a space, breaking subsequent token exchange or XOAuth2 authentication.

The fix manually parses the query string using a regex pattern and `decodeURIComponent()`, which correctly handles `+` as a literal character per RFC 3986.

https://claude.ai/code/session_011JeebdEGGFApPptuCJ4uih