### PR TITLE
Add ability to create child folders in outline view

### DIFF
--- a/app/internal_packages/account-sidebar/lib/sidebar-item.ts
+++ b/app/internal_packages/account-sidebar/lib/sidebar-item.ts
@@ -1,4 +1,5 @@
 import _ from 'underscore';
+import utf7 from 'utf7';
 
 import _str from 'underscore.string';
 import { OutlineViewItem } from 'mailspring-component-kit';
@@ -107,11 +108,7 @@ const onExportFolder = function (item) {
 };
 
 const detectFolderSeparator = function (category): string {
-  // Check if the displayName already has a separator (nested folder)
-  const sepMatch = /[./\\]/.exec(category.displayName);
-  if (sepMatch) return sepMatch[0];
-
-  // Look at category paths to detect the server's hierarchy separator
+  // Check category paths for known prefixes — most reliable signal
   for (const cat of CategoryStore.categories(category.accountId)) {
     const catPath = cat.path;
     for (const prefix of ['INBOX', '[Gmail]', '[Mailspring]', 'Mailspring']) {
@@ -121,6 +118,10 @@ const detectFolderSeparator = function (category): string {
       }
     }
   }
+
+  // Fallback: check if the displayName has a separator (nested folder)
+  const sepMatch = /[./\\]/.exec(category.displayName);
+  if (sepMatch) return sepMatch[0];
 
   return '/';
 };
@@ -135,7 +136,8 @@ const onCreateChild = function (item, childName) {
   }
 
   const separator = detectFolderSeparator(category);
-  const fullName = category.displayName + separator + childName;
+  const decodedPath = utf7.imap.decode(category.path);
+  const fullName = decodedPath + separator + childName;
 
   Actions.queueTask(
     SyncbackCategoryTask.forCreating({

--- a/app/internal_packages/account-sidebar/lib/sidebar-item.ts
+++ b/app/internal_packages/account-sidebar/lib/sidebar-item.ts
@@ -106,6 +106,45 @@ const onExportFolder = function (item) {
   );
 };
 
+const detectFolderSeparator = function (category): string {
+  // Check if the displayName already has a separator (nested folder)
+  const sepMatch = /[./\\]/.exec(category.displayName);
+  if (sepMatch) return sepMatch[0];
+
+  // Look at category paths to detect the server's hierarchy separator
+  for (const cat of CategoryStore.categories(category.accountId)) {
+    const catPath = cat.path;
+    for (const prefix of ['INBOX', '[Gmail]', '[Mailspring]', 'Mailspring']) {
+      if (catPath.startsWith(prefix) && catPath.length > prefix.length) {
+        const ch = catPath[prefix.length];
+        if (ch === '.' || ch === '/' || ch === '\\') return ch;
+      }
+    }
+  }
+
+  return '/';
+};
+
+const onCreateChild = function (item, childName) {
+  if (!childName) {
+    return;
+  }
+  const category = item.perspective.category();
+  if (!category) {
+    return;
+  }
+
+  const separator = detectFolderSeparator(category);
+  const fullName = category.displayName + separator + childName;
+
+  Actions.queueTask(
+    SyncbackCategoryTask.forCreating({
+      name: fullName,
+      accountId: category.accountId,
+    })
+  );
+};
+
 const onEditItem = function (item, value) {
   let newDisplayName;
   if (!value) {
@@ -167,6 +206,7 @@ export default class SidebarItem {
         onDelete: opts.deletable ? onDeleteItem : undefined,
         onEdited: opts.editable ? onEditItem : undefined,
         onExport: opts.exportable ? onExportFolder : undefined,
+        onCreateChild: opts.editable ? onCreateChild : undefined,
         onCollapseToggled: toggleItemCollapsed,
 
         onDrop(item, event) {

--- a/app/internal_packages/account-sidebar/lib/sidebar-item.ts
+++ b/app/internal_packages/account-sidebar/lib/sidebar-item.ts
@@ -107,9 +107,9 @@ const onExportFolder = function (item) {
   );
 };
 
-const detectFolderSeparator = function (category): string {
+function detectFolderSeparator(accountId: string): string {
   // Check category paths for known prefixes — most reliable signal
-  for (const cat of CategoryStore.categories(category.accountId)) {
+  for (const cat of CategoryStore.categories(accountId)) {
     const catPath = cat.path;
     for (const prefix of ['INBOX', '[Gmail]', '[Mailspring]', 'Mailspring']) {
       if (catPath.startsWith(prefix) && catPath.length > prefix.length) {
@@ -119,32 +119,37 @@ const detectFolderSeparator = function (category): string {
     }
   }
 
-  // Fallback: check if the displayName has a separator (nested folder)
-  const sepMatch = /[./\\]/.exec(category.displayName);
-  if (sepMatch) return sepMatch[0];
-
   return '/';
-};
+}
 
-const onCreateChild = function (item, childName) {
-  if (!childName) {
-    return;
-  }
-  const category = item.perspective.category();
-  if (!category) {
+export function createCategory(accountId: string, name: string, parentCategory?: { path: string }) {
+  if (!name) {
     return;
   }
 
-  const separator = detectFolderSeparator(category);
-  const decodedPath = utf7.imap.decode(category.path);
-  const fullName = decodedPath + separator + childName;
+  let fullName: string;
+  if (parentCategory) {
+    const separator = detectFolderSeparator(accountId);
+    const decodedPath = utf7.imap.decode(parentCategory.path);
+    fullName = decodedPath + separator + name;
+  } else {
+    fullName = name;
+  }
 
   Actions.queueTask(
     SyncbackCategoryTask.forCreating({
       name: fullName,
-      accountId: category.accountId,
+      accountId,
     })
   );
+}
+
+const onCreateChild = function (item, childName) {
+  const category = item.perspective.category();
+  if (!category) {
+    return;
+  }
+  createCategory(category.accountId, childName, category);
 };
 
 const onEditItem = function (item, value) {

--- a/app/internal_packages/account-sidebar/lib/sidebar-section.ts
+++ b/app/internal_packages/account-sidebar/lib/sidebar-section.ts
@@ -6,9 +6,7 @@
  */
 import _ from 'underscore';
 import {
-  Actions,
   Account,
-  SyncbackCategoryTask,
   CategoryStore,
   Label,
   ExtensionRegistry,
@@ -16,7 +14,7 @@ import {
   localized,
 } from 'mailspring-exports';
 
-import SidebarItem from './sidebar-item';
+import SidebarItem, { createCategory } from './sidebar-item';
 import * as SidebarActions from './sidebar-actions';
 import { ISidebarSection, ISidebarItem } from './types';
 
@@ -53,7 +51,7 @@ class SidebarSection {
       return this.empty(account.label);
     }
 
-    const items = _.reject(cats, cat => ['drafts', 'snoozed'].includes(cat.role)).map(cat =>
+    const items = _.reject(cats, (cat) => ['drafts', 'snoozed'].includes(cat.role)).map((cat) =>
       SidebarItem.forCategories([cat], { editable: false, deletable: false })
     );
 
@@ -66,8 +64,8 @@ class SidebarSection {
     items.push(draftsItem);
 
     ExtensionRegistry.AccountSidebar.extensions()
-      .filter(ext => ext.sidebarItem != null)
-      .forEach(ext => {
+      .filter((ext) => ext.sidebarItem != null)
+      .forEach((ext) => {
         const { id, name, iconName, perspective, insertAtTop } = ext.sidebarItem([account.id]);
         const item = SidebarItem.forPerspective(id, perspective, { name, iconName });
         if (insertAtTop) {
@@ -107,9 +105,9 @@ class SidebarSection {
 
       children = [];
       // eslint-disable-next-line
-      accounts.forEach(acc => {
+      accounts.forEach((acc) => {
         const cat = _.first(
-          _.compact((names as string[]).map(name => CategoryStore.getCategoryByRole(acc, name)))
+          _.compact((names as string[]).map((name) => CategoryStore.getCategoryByRole(acc, name)))
         );
         if (!cat) {
           return;
@@ -127,13 +125,13 @@ class SidebarSection {
     const accountIds = _.pluck(accounts, 'id');
 
     const starredItem = SidebarItem.forStarred(accountIds, {
-      children: accounts.map(acc => SidebarItem.forStarred([acc.id], { name: acc.label })),
+      children: accounts.map((acc) => SidebarItem.forStarred([acc.id], { name: acc.label })),
     });
     const unreadItem = SidebarItem.forUnread(accountIds, {
-      children: accounts.map(acc => SidebarItem.forUnread([acc.id], { name: acc.label })),
+      children: accounts.map((acc) => SidebarItem.forUnread([acc.id], { name: acc.label })),
     });
     const draftsItem = SidebarItem.forDrafts(accountIds, {
-      children: accounts.map(acc => SidebarItem.forDrafts([acc.id], { name: acc.label })),
+      children: accounts.map((acc) => SidebarItem.forDrafts([acc.id], { name: acc.label })),
     });
 
     // Order correctly: Inbox, Unread, Starred, rest... , Drafts
@@ -141,13 +139,13 @@ class SidebarSection {
     items.push(draftsItem);
 
     ExtensionRegistry.AccountSidebar.extensions()
-      .filter(ext => ext.sidebarItem != null)
-      .forEach(ext => {
+      .filter((ext) => ext.sidebarItem != null)
+      .forEach((ext) => {
         const { id, name, iconName, perspective, insertAtTop } = ext.sidebarItem(accountIds);
         const item = SidebarItem.forPerspective(id, perspective, {
           name,
           iconName,
-          children: accounts.map(acc => {
+          children: accounts.map((acc) => {
             const subItem = ext.sidebarItem([acc.id]);
             return SidebarItem.forPerspective(subItem.id + `-${acc.id}`, subItem.perspective, {
               name: acc.label,
@@ -242,15 +240,7 @@ class SidebarSection {
       titleColor,
       onCollapseToggled,
       onItemCreated(displayName) {
-        if (!displayName) {
-          return;
-        }
-        Actions.queueTask(
-          SyncbackCategoryTask.forCreating({
-            name: displayName,
-            accountId: account.id,
-          })
-        );
+        createCategory(account.id, displayName);
       },
     };
   }

--- a/app/internal_packages/account-sidebar/lib/types.ts
+++ b/app/internal_packages/account-sidebar/lib/types.ts
@@ -14,6 +14,7 @@ export interface ISidebarItem {
   onDelete?: () => void;
   onEdited?: (item, name: string) => void;
   onExport?: () => void;
+  onCreateChild?: (item, childName: string) => void;
   onCollapseToggled: () => void;
   onDrop: (item, event) => void;
   shouldAcceptDrop: (item, event) => void;

--- a/app/src/components/outline-view-item.tsx
+++ b/app/src/components/outline-view-item.tsx
@@ -405,7 +405,7 @@ class OutlineViewItem extends Component<OutlineViewItemProps, OutlineViewItemSta
       inputPlaceholder: isLabel ? localized('Sublabel name') : localized('Subfolder name'),
       onInputCleared: this._onCreateChildInputCleared,
     };
-    return <OutlineViewItem item={item} />;
+    return <OutlineViewItem item={item} level={(this.props.level || 1) + 1} />;
   }
 
   _renderChildren(item = this.props.item) {

--- a/app/src/components/outline-view-item.tsx
+++ b/app/src/components/outline-view-item.tsx
@@ -30,6 +30,7 @@ type OutlineViewItemProps = {
 type OutlineViewItemState = {
   editing: boolean;
   isDropping: boolean;
+  creatingChild: boolean;
 };
 /*
  * Renders an item that may contain more arbitrarily nested items
@@ -156,6 +157,7 @@ class OutlineViewItem extends Component<OutlineViewItemProps, OutlineViewItemSta
     this.state = {
       isDropping: false,
       editing: props.item.editing || false,
+      creatingChild: false,
     };
   }
 
@@ -196,7 +198,8 @@ class OutlineViewItem extends Component<OutlineViewItemProps, OutlineViewItemSta
     return (
       this.props.item.onDelete != null ||
       this.props.item.onEdited != null ||
-      this.props.item.onExport != null
+      this.props.item.onExport != null ||
+      this.props.item.onCreateChild != null
     );
   };
 
@@ -250,6 +253,24 @@ class OutlineViewItem extends Component<OutlineViewItemProps, OutlineViewItemSta
     }
   };
 
+  _onCreateChildTriggered = () => {
+    if (this.props.item.collapsed) {
+      this._onCollapseToggled();
+    }
+    this.setState({ creatingChild: true });
+  };
+
+  _onChildCreated = (_item, value) => {
+    this.setState({ creatingChild: false });
+    if (value) {
+      this._runCallback('onCreateChild', value);
+    }
+  };
+
+  _onCreateChildInputCleared = () => {
+    this.setState({ creatingChild: false });
+  };
+
   _onInputFocus = (event) => {
     const input = event.target;
     input.selectionStart = input.selectionEnd = input.value.length;
@@ -290,6 +311,15 @@ class OutlineViewItem extends Component<OutlineViewItemProps, OutlineViewItemSta
         new MenuItem({
           label: `${localized(`Delete`)} ${contextMenuLabel}`,
           click: this._onDelete,
+        })
+      );
+    }
+
+    if (this.props.item.onCreateChild) {
+      menu.append(
+        new MenuItem({
+          label: localized(`New Subfolder...`),
+          click: this._onCreateChildTriggered,
         })
       );
     }
@@ -362,14 +392,33 @@ class OutlineViewItem extends Component<OutlineViewItemProps, OutlineViewItemSta
     );
   }
 
+  _renderCreateChildInput() {
+    const item = {
+      id: `create-child-${this.props.item.id}`,
+      name: '',
+      children: [],
+      editing: true,
+      iconName: this.props.item.iconName || 'folder.png',
+      onEdited: this._onChildCreated,
+      inputPlaceholder: localized('Subfolder name'),
+      onInputCleared: this._onCreateChildInputCleared,
+    };
+    return <OutlineViewItem item={item} />;
+  }
+
   _renderChildren(item = this.props.item) {
-    if (item.children.length > 0 && !item.collapsed) {
+    const showRegularChildren = item.children.length > 0 && !item.collapsed;
+    const showCreateChildInput = this.state.creatingChild;
+
+    if (showRegularChildren || showCreateChildInput) {
       const childLevel = (this.props.level || 1) + 1;
       return (
         <div role="group" className="item-children" key={`${item.id}-children`}>
-          {item.children.map((child) => (
-            <OutlineViewItem key={child.id} item={child} level={childLevel} />
-          ))}
+          {showCreateChildInput && this._renderCreateChildInput()}
+          {showRegularChildren &&
+            item.children.map((child) => (
+              <OutlineViewItem key={child.id} item={child} level={childLevel} />
+            ))}
         </div>
       );
     }
@@ -379,6 +428,7 @@ class OutlineViewItem extends Component<OutlineViewItemProps, OutlineViewItemSta
   render() {
     const item = this.props.item;
     const hasChildren = item.children.length > 0;
+    const showAsExpanded = this.state.creatingChild;
     const containerClasses = classnames({
       'item-container': true,
       dropping: this.state.isDropping,
@@ -388,7 +438,9 @@ class OutlineViewItem extends Component<OutlineViewItemProps, OutlineViewItemSta
         role="treeitem"
         aria-level={this.props.level || 1}
         aria-selected={item.selected || false}
-        aria-expanded={hasChildren ? !item.collapsed : undefined}
+        aria-expanded={
+          hasChildren || showAsExpanded ? !(item.collapsed && !showAsExpanded) : undefined
+        }
         aria-label={
           this.props.sectionTitle ? `${this.props.sectionTitle}, ${item.name}` : item.name
         }
@@ -396,8 +448,8 @@ class OutlineViewItem extends Component<OutlineViewItemProps, OutlineViewItemSta
       >
         <span className={containerClasses}>
           <DisclosureTriangle
-            collapsed={item.collapsed}
-            visible={hasChildren}
+            collapsed={item.collapsed && !showAsExpanded}
+            visible={hasChildren || showAsExpanded}
             onCollapseToggled={this._onCollapseToggled}
           />
           {this._renderItem()}

--- a/app/src/components/outline-view-item.tsx
+++ b/app/src/components/outline-view-item.tsx
@@ -290,8 +290,7 @@ class OutlineViewItem extends Component<OutlineViewItemProps, OutlineViewItemSta
     }
   };
 
-  _onShowContextMenu = (event) => {
-    event.stopPropagation();
+  _buildContextMenu = () => {
     const item = this.props.item;
     const contextMenuLabel = item.contextMenuLabel || item.name;
     const { Menu, MenuItem } = require('@electron/remote');
@@ -333,7 +332,18 @@ class OutlineViewItem extends Component<OutlineViewItemProps, OutlineViewItemSta
         })
       );
     }
-    menu.popup({});
+
+    return menu;
+  };
+
+  _onShowContextMenu = (event) => {
+    event.stopPropagation();
+    this._buildContextMenu().popup({});
+  };
+
+  _onMenuButtonClick = (event: React.MouseEvent) => {
+    event.stopPropagation();
+    this._buildContextMenu().popup({});
   };
 
   // Renderers
@@ -387,6 +397,17 @@ class OutlineViewItem extends Component<OutlineViewItemProps, OutlineViewItemSta
         ) : (
           <div className="name" title={item.name}>
             {item.name}
+          </div>
+        )}
+        {this._shouldShowContextMenu() && !state.editing && (
+          <div
+            className="item-action-button"
+            role="button"
+            tabIndex={-1}
+            aria-label={localized('Actions')}
+            onClick={this._onMenuButtonClick}
+          >
+            &middot;&middot;&middot;
           </div>
         )}
       </DropZone>

--- a/app/src/components/outline-view-item.tsx
+++ b/app/src/components/outline-view-item.tsx
@@ -203,11 +203,11 @@ class OutlineViewItem extends Component<OutlineViewItemProps, OutlineViewItemSta
     );
   };
 
-  _shouldAcceptDrop = (event) => {
+  _shouldAcceptDrop = event => {
     return this._runCallback('shouldAcceptDrop', event);
   };
 
-  _clearEditingState = (event) => {
+  _clearEditingState = event => {
     this.setState({ editing: false });
     this._runCallback('onInputCleared', event);
   };
@@ -226,7 +226,7 @@ class OutlineViewItem extends Component<OutlineViewItemProps, OutlineViewItemSta
     }
   };
 
-  _onDrop = (event) => {
+  _onDrop = event => {
     this._runCallback('onDrop', event);
   };
 
@@ -234,7 +234,7 @@ class OutlineViewItem extends Component<OutlineViewItemProps, OutlineViewItemSta
     this._runCallback('onCollapseToggled');
   };
 
-  _onClick = (event) => {
+  _onClick = event => {
     event.preventDefault();
     this._runCallback('onSelect');
   };
@@ -243,7 +243,7 @@ class OutlineViewItem extends Component<OutlineViewItemProps, OutlineViewItemSta
     this._runCallback('onDelete');
   };
 
-  _onEdited = (value) => {
+  _onEdited = value => {
     this._runCallback('onEdited', value);
   };
 
@@ -271,16 +271,16 @@ class OutlineViewItem extends Component<OutlineViewItemProps, OutlineViewItemSta
     this.setState({ creatingChild: false });
   };
 
-  _onInputFocus = (event) => {
+  _onInputFocus = event => {
     const input = event.target;
     input.selectionStart = input.selectionEnd = input.value.length;
   };
 
-  _onInputBlur = (event) => {
+  _onInputBlur = event => {
     this._clearEditingState(event);
   };
 
-  _onInputKeyDown = (event) => {
+  _onInputKeyDown = event => {
     if (event.key === 'Escape') {
       this._clearEditingState(event);
     }
@@ -336,7 +336,7 @@ class OutlineViewItem extends Component<OutlineViewItemProps, OutlineViewItemSta
     return menu;
   };
 
-  _onShowContextMenu = (event) => {
+  _onShowContextMenu = event => {
     event.stopPropagation();
     this._buildContextMenu().popup({});
   };
@@ -399,7 +399,7 @@ class OutlineViewItem extends Component<OutlineViewItemProps, OutlineViewItemSta
             {item.name}
           </div>
         )}
-        {this._shouldShowContextMenu() && !state.editing && (
+        {this._shouldShowContextMenu() && !state.editing && this.props.item.onEdited && (
           <div
             className="item-action-button"
             role="button"
@@ -407,7 +407,7 @@ class OutlineViewItem extends Component<OutlineViewItemProps, OutlineViewItemSta
             aria-label={localized('Actions')}
             onClick={this._onMenuButtonClick}
           >
-            &middot;&middot;&middot;
+            •••
           </div>
         )}
       </DropZone>
@@ -439,7 +439,7 @@ class OutlineViewItem extends Component<OutlineViewItemProps, OutlineViewItemSta
         <div role="group" className="item-children" key={`${item.id}-children`}>
           {showCreateChildInput && this._renderCreateChildInput()}
           {showRegularChildren &&
-            item.children.map((child) => (
+            item.children.map(child => (
               <OutlineViewItem key={child.id} item={child} level={childLevel} />
             ))}
         </div>

--- a/app/src/components/outline-view-item.tsx
+++ b/app/src/components/outline-view-item.tsx
@@ -316,9 +316,10 @@ class OutlineViewItem extends Component<OutlineViewItemProps, OutlineViewItemSta
     }
 
     if (this.props.item.onCreateChild) {
+      const isLabel = contextMenuLabel.toLowerCase() === 'label';
       menu.append(
         new MenuItem({
-          label: localized(`New Subfolder...`),
+          label: isLabel ? localized(`New Sublabel...`) : localized(`New Subfolder...`),
           click: this._onCreateChildTriggered,
         })
       );
@@ -393,6 +394,7 @@ class OutlineViewItem extends Component<OutlineViewItemProps, OutlineViewItemSta
   }
 
   _renderCreateChildInput() {
+    const isLabel = (this.props.item.contextMenuLabel || '').toLowerCase() === 'label';
     const item = {
       id: `create-child-${this.props.item.id}`,
       name: '',
@@ -400,7 +402,7 @@ class OutlineViewItem extends Component<OutlineViewItemProps, OutlineViewItemSta
       editing: true,
       iconName: this.props.item.iconName || 'folder.png',
       onEdited: this._onChildCreated,
-      inputPlaceholder: localized('Subfolder name'),
+      inputPlaceholder: isLabel ? localized('Sublabel name') : localized('Subfolder name'),
       onInputCleared: this._onCreateChildInputCleared,
     };
     return <OutlineViewItem item={item} />;

--- a/app/src/components/outline-view.tsx
+++ b/app/src/components/outline-view.tsx
@@ -256,6 +256,9 @@ export class OutlineView extends Component<OutlineViewProps, OutlineViewState> {
   }
 
   _onTreeKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    // Don't intercept keyboard events when typing in an input (e.g. rename or new folder)
+    if ((event.target as HTMLElement).tagName === 'INPUT') return;
+
     const tree = event.currentTarget;
     const items = Array.from(tree.querySelectorAll<HTMLElement>('[role="treeitem"]')).filter(
       (el) => !el.closest('[aria-expanded="false"] [role="treeitem"]')

--- a/app/src/components/outline-view.tsx
+++ b/app/src/components/outline-view.tsx
@@ -28,6 +28,7 @@ export interface IOutlineViewItem {
   onDelete?: (...args: any[]) => any;
   onEdited?: (...args: any[]) => any;
   onExport?: (...args: any[]) => any;
+  onCreateChild?: (...args: any[]) => any;
 }
 
 interface OutlineViewProps {

--- a/app/static/style/components/outline-view.less
+++ b/app/static/style/components/outline-view.less
@@ -137,11 +137,11 @@
       width: 18px;
       text-align: center;
       border-radius: 3px;
-      color: @text-color-very-subtle !important;
+      color: @text-color-very-subtle;
       display: none;
       &:hover {
-        color: @text-color-subtle !important;
-        background: fade(@text-color-subtle, 15%) !important;
+        color: @text-color-subtle;
+        background: fade(@text-color-subtle, 15%);
       }
     }
 

--- a/app/static/style/components/outline-view.less
+++ b/app/static/style/components/outline-view.less
@@ -131,16 +131,17 @@
       flex-shrink: 0;
       margin-left: auto;
       cursor: pointer;
-      font-size: 10px;
+      font-size: @font-size-base * 0.5;
       letter-spacing: 1px;
-      line-height: 1;
-      padding: 0 2px;
+      line-height: 18px;
+      width: 18px;
+      text-align: center;
       border-radius: 3px;
-      color: @text-color-very-subtle;
+      color: @text-color-very-subtle !important;
       display: none;
       &:hover {
-        color: @text-color-subtle;
-        background: fade(@text-color-subtle, 15%);
+        color: @text-color-subtle !important;
+        background: fade(@text-color-subtle, 15%) !important;
       }
     }
 
@@ -181,7 +182,7 @@
     &:hover {
       cursor: default;
       .item-action-button {
-        display: flex;
+        display: block;
       }
     }
   }

--- a/app/static/style/components/outline-view.less
+++ b/app/static/style/components/outline-view.less
@@ -126,12 +126,36 @@
     .item-count-box.spam {
       display: none;
     }
+    .item-action-button {
+      order: 4;
+      flex-shrink: 0;
+      margin-left: auto;
+      cursor: pointer;
+      font-size: 10px;
+      letter-spacing: 1px;
+      line-height: 1;
+      padding: 0 2px;
+      border-radius: 3px;
+      color: @text-color-very-subtle;
+      display: none;
+      &:hover {
+        color: @text-color-subtle;
+        background: fade(@text-color-subtle, 15%);
+      }
+    }
 
     &.selected {
       background: @source-list-active-bg;
       color: @source-list-active-color;
       img.content-mask {
         background-color: @source-list-active-color;
+      }
+      .item-action-button {
+        color: fadeout(@source-list-active-color, 30%);
+        &:hover {
+          color: @source-list-active-color;
+          background: fade(@source-list-active-color, 15%);
+        }
       }
     }
     &.dropping {
@@ -156,6 +180,9 @@
     }
     &:hover {
       cursor: default;
+      .item-action-button {
+        display: flex;
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
This PR adds the ability to create child folders directly from the outline view component. Users can now right-click on a folder and select "New Subfolder..." to create nested folders with automatic hierarchy detection.

## Key Changes
- **OutlineViewItem component**: Added `creatingChild` state to track when a child creation input is active
  - New methods `_onCreateChildTriggered`, `_onChildCreated`, and `_onCreateChildInputCleared` to manage child creation lifecycle
  - Added "New Subfolder..." menu item when `onCreateChild` callback is available
  - New `_renderCreateChildInput()` method to render an inline input for the new child folder
  - Updated `_renderChildren()` to display the creation input alongside regular children
  - Updated `DisclosureTriangle` visibility and `aria-expanded` logic to account for the creation state

- **SidebarItem**: Implemented `onCreateChild` callback handler
  - Added `detectFolderSeparator()` utility to intelligently detect the folder hierarchy separator (`.`, `/`, or `\`) used by the mail server
  - Implemented folder creation by queuing a `SyncbackCategoryTask` with the full nested path

- **Type definitions**: Added `onCreateChild` optional callback to both `ISidebarItem` and `IOutlineViewItem` interfaces

## Implementation Details
- The folder separator detection examines existing category paths to determine the server's convention, with `/` as the fallback
- When creating a child, the parent folder is automatically expanded if collapsed
- The creation input uses the same editing mechanism as regular item editing, maintaining UI consistency
- The feature is only enabled when the item has an `onCreateChild` callback defined

https://claude.ai/code/session_013obLtecSgbBzk79KLKUTnY