### PR TITLE
fix: Fix Wayland app_id after Electron 41

### DIFF
--- a/app/build/resources/linux/Mailspring.desktop.in
+++ b/app/build/resources/linux/Mailspring.desktop.in
@@ -5,8 +5,6 @@ GenericName=Mail Client
 Exec=mailspring %U
 Icon=mailspring
 Type=Application
-StartupNotify=true
-StartupWMClass=<%= productName %>
 Categories=GNOME;GTK;Network;Email;
 Keywords=email;internet;
 MimeType=x-scheme-handler/mailto;x-scheme-handler/mailspring;

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -2495,9 +2495,9 @@
       }
     },
     "node_modules/juice/node_modules/undici": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
-      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
+      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"
@@ -4226,9 +4226,9 @@
       "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
     },
     "node_modules/undici": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.7.tgz",
-      "integrity": "sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/app/package.json
+++ b/app/package.json
@@ -77,7 +77,7 @@
     "xml2js": "^0.6.2"
   },
   "resolutions": {
-    "electron": "41.0.2",
+    "electron": "41.2.1",
     "@types/react": "^16.9.0",
     "@types/react-dom": "^16.9.0"
   },

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,7 @@
 {
   "name": "mailspring",
   "productName": "Mailspring",
+  "desktopName": "Mailspring.desktop",
   "version": "1.19.1",
   "repository": {
     "type": "git",

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "@typescript-eslint/parser": "^5.62.0",
         "chalk": "1.x.x",
         "devtron": "^1.4.0",
-        "electron": "41.0.2",
+        "electron": "41.2.1",
         "electron-winstaller": "5.4.0",
         "eslint": "^7.32.0",
         "eslint-config-prettier": "7.2.0",
@@ -2099,9 +2099,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "41.0.2",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-41.0.2.tgz",
-      "integrity": "sha512-raotm/aO8kOs1jD8SI8ssJ7EKciQOY295AOOprl1TxW7B0At8m5Ae7qNU1xdMxofiHMR8cNEGi9PKD3U+yT/mA==",
+      "version": "41.2.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-41.2.1.tgz",
+      "integrity": "sha512-teeRThiYGTPKf/2yOW7zZA1bhb91KEQ4yLBPOg7GxpmnkLFLugKgQaAKOrCgdzwsXh/5mFIfmkm+4+wACJKwaA==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -8194,9 +8194,9 @@
       }
     },
     "electron": {
-      "version": "41.0.2",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-41.0.2.tgz",
-      "integrity": "sha512-raotm/aO8kOs1jD8SI8ssJ7EKciQOY295AOOprl1TxW7B0At8m5Ae7qNU1xdMxofiHMR8cNEGi9PKD3U+yT/mA==",
+      "version": "41.2.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-41.2.1.tgz",
+      "integrity": "sha512-teeRThiYGTPKf/2yOW7zZA1bhb91KEQ4yLBPOg7GxpmnkLFLugKgQaAKOrCgdzwsXh/5mFIfmkm+4+wACJKwaA==",
       "requires": {
         "@electron/get": "^2.0.0",
         "@types/node": "^24.9.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@typescript-eslint/parser": "^5.62.0",
     "chalk": "1.x.x",
     "devtron": "^1.4.0",
-    "electron": "41.0.2",
+    "electron": "41.2.1",
     "electron-winstaller": "5.4.0",
     "eslint": "^7.32.0",
     "eslint-config-prettier": "7.2.0",


### PR DESCRIPTION
The update to Electron 41 (4f09302) changed the Wayland app_id which broke window associations on some window managers.

I wasn't able to find the Electron 40/41 release note that mentioned that they changed that behavior but forcing the app_id to a specific value is easy enough and should be robust to future Electron changes. Upon startup Electron will read `desktopName` from the package.json and will set the app_id to whatever value is present sans the `.desktop` suffix.

And now since the app_id is guaranteed to be `Mailspring` it will always match a `.desktop` file named `Mailspring.desktop` which means that `StartupWMClass=Mailspring.desktop` is redundant and can be removed.

Also in this PR are updating Electron to v41.2.1 to fix a few things about frameless windows in Wayland and removing `.map` files from production releases.