### PR TITLE
Move appdata.xml to metainfo directory for proper packaging

### DIFF
--- a/app/build/resources/linux/redhat/mailspring.spec.in
+++ b/app/build/resources/linux/redhat/mailspring.spec.in
@@ -37,8 +37,8 @@ chmod 755 %{buildroot}/usr/bin/mailspring
 mkdir -p %{buildroot}/usr/share/applications/
 mv Mailspring.desktop %{buildroot}/usr/share/applications/
 
-mkdir -p %{buildroot}/usr/share/appdata/
-mv mailspring.appdata.xml %{buildroot}/usr/share/appdata/
+mkdir -p %{buildroot}/usr/share/metainfo/
+mv mailspring.appdata.xml %{buildroot}/usr/share/metainfo/
 
 for s in 16 32 64 128 256 512; do
     mkdir -p %{buildroot}/usr/share/icons/hicolor/${s}x${s}/apps
@@ -49,7 +49,7 @@ done
 /usr/bin/mailspring
 /usr/share/mailspring
 /usr/share/applications/Mailspring.desktop
-/usr/share/appdata/mailspring.appdata.xml
+/usr/share/metainfo/mailspring.appdata.xml
 /usr/share/icons/hicolor/16x16/apps/mailspring.png
 /usr/share/icons/hicolor/32x32/apps/mailspring.png
 /usr/share/icons/hicolor/64x64/apps/mailspring.png

--- a/app/script/mkdeb
+++ b/app/script/mkdeb
@@ -37,8 +37,8 @@ chmod +x "$TARGET/usr/bin/mailspring"
 
 mkdir -m $FILE_MODE -p "$TARGET/usr/share/applications"
 cp "$OUTPUT_PATH/Mailspring.desktop" "$TARGET/usr/share/applications"
-mkdir -m $FILE_MODE -p "$TARGET/usr/share/appdata"
-cp "$OUTPUT_PATH/mailspring.appdata.xml" "$TARGET/usr/share/appdata"
+mkdir -m $FILE_MODE -p "$TARGET/usr/share/metainfo"
+cp "$OUTPUT_PATH/mailspring.appdata.xml" "$TARGET/usr/share/metainfo"
 
 mkdir -m $FILE_MODE -p "$TARGET/usr/share/pixmaps"
 cp "$ICON_FILE" "$TARGET/usr/share/pixmaps/mailspring.png"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -24,7 +24,7 @@ parts:
         $CRAFT_PART_INSTALL/usr/share/applications/Mailspring.desktop
     prime:
       - -usr/share/mailspring/chrome-sandbox
-    parse-info: [usr/share/appdata/mailspring.appdata.xml]
+    parse-info: [usr/share/metainfo/mailspring.appdata.xml]
     stage-packages:
       - libxkbfile1
       - libsasl2-2


### PR DESCRIPTION
## Summary

- Install appdata/metainfo XML to `/usr/share/metainfo` instead of the deprecated `/usr/share/appdata` directory, per [freedesktop Appstream metadata guidelines](https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html)
- Updated deb build script, RPM spec template, and snap configuration

## Context

Distro QA tooling (e.g. Gentoo's `install-qa-check`) flags packages that still install metainfo files into `/usr/share/appdata`. The `/usr/share/metainfo` location has been the standard since AppStream 0.10 and the old path should not be used by new software.