### PR TITLE
Improve password store detection on Linux tiling WMs

### DIFF
--- a/app/src/browser/main.js
+++ b/app/src/browser/main.js
@@ -327,6 +327,33 @@ const start = () => {
   app.commandLine.appendSwitch('autoplay-policy', 'no-user-gesture-required');
   app.commandLine.appendSwitch('js-flags', '--harmony');
 
+  // On Linux, Electron may fail to detect the correct password storage backend
+  // on non-GNOME/KDE desktops (e.g. Hyprland, Sway, i3). If the user hasn't
+  // explicitly set --password-store, check if a Secret Service provider is
+  // available on D-Bus and use gnome-libsecret.
+  if (
+    process.platform === 'linux' &&
+    !process.argv.some(arg => arg.startsWith('--password-store'))
+  ) {
+    try {
+      const { execFileSync } = require('child_process');
+      const output = execFileSync('dbus-send', [
+        '--session',
+        '--dest=org.freedesktop.DBus',
+        '--type=method_call',
+        '--print-reply',
+        '/org/freedesktop/DBus',
+        'org.freedesktop.DBus.NameHasOwner',
+        'string:org.freedesktop.secrets',
+      ], { timeout: 2000, encoding: 'utf8' });
+      if (output.includes('boolean true')) {
+        app.commandLine.appendSwitch('password-store', 'gnome-libsecret');
+      }
+    } catch (e) {
+      // D-Bus query failed — let Electron use its default backend
+    }
+  }
+
   const options = parseCommandLine(process.argv);
   global.errorLogger = setupErrorLogger(options);
   const configDirPath = setupConfigDir(options);


### PR DESCRIPTION
## Summary

On Linux tiling WMs (Hyprland, Sway, i3, etc.), Electron's `safeStorage` API fails to detect the correct password storage backend, even when a keyring like `gnome-keyring` is installed and running. This causes the "Could not store your password securely" error on startup.

The root cause is that Electron selects the backend based on the `XDG_CURRENT_DESKTOP` environment variable. When it doesn't match a known desktop environment, it falls back to `basic_text` and reports `isEncryptionAvailable: false` — despite `org.freedesktop.secrets` being available on D-Bus.

This PR adds a startup check that queries D-Bus for an active Secret Service provider. If one is found and the user hasn't explicitly passed `--password-store`, it sets `--password-store=gnome-libsecret` so Electron uses the correct backend.

## Details

- Only runs on Linux, before the app ready event (where command line switches must be set)
- Uses `execFileSync` to call `dbus-send` — no shell spawned, no new dependencies
- Wrapped in try/catch with a 2s timeout — if D-Bus is unavailable, it's a no-op
- Respects any explicit `--password-store=...` flag the user passes

## Related

- #2444 — This was identified during the keytar-to-safeStorage migration, where it was suggested that `--password-store=gnome-libsecret` should be set automatically for desktop environments that Electron can't recognize. A Sway user on Manjaro confirmed the workaround fixed the issue. This PR implements that suggestion.
- #2477 — Draft PR that applies the same fix specifically for the snap package by forcing `--password-store=gnome-libsecret` in the snap wrapper.

## Tested on

- Gentoo Linux x86_64 (kernel 6.18.12)
- Hyprland 0.54.3
- gnome-keyring-daemon 48.0