### PR TITLE
Add optional chaining and null safety checks to contacts

### DIFF
--- a/app/internal_packages/contacts/lib/ContactDetail.tsx
+++ b/app/internal_packages/contacts/lib/ContactDetail.tsx
@@ -60,8 +60,8 @@ class ContactDetailWithFocus extends React.Component<ContactDetailProps, Contact
   }
 
   componentDidUpdate(prevProps) {
-    const prevContact = prevProps.contacts.find(c => c.id === prevProps.focusedId);
-    const newContact = this.props.contacts.find(c => c.id === this.props.focusedId);
+    const prevContact = prevProps.contacts?.find(c => c.id === prevProps.focusedId);
+    const newContact = this.props.contacts?.find(c => c.id === this.props.focusedId);
 
     if (isEqual(prevContact, newContact) && prevProps.editing === this.props.editing) return;
     if (newContact && this.props.editing !== newContact.id) Store.setEditing(false);

--- a/app/internal_packages/contacts/lib/Store.ts
+++ b/app/internal_packages/contacts/lib/Store.ts
@@ -71,7 +71,7 @@ class ContactsWindowStore extends MailspringStore {
   }
 
   filteredContacts() {
-    return this._filtered;
+    return this._filtered || [];
   }
 
   editing() {


### PR DESCRIPTION
## Summary
This PR improves null safety in the contacts module by adding optional chaining operators and a fallback empty array, preventing potential runtime errors when accessing undefined properties.

## Key Changes
- **ContactDetail.tsx**: Added optional chaining (`?.`) when accessing the `find()` method on `contacts` arrays in `componentDidUpdate()`. This prevents errors if `prevProps.contacts` or `this.props.contacts` are undefined.
- **Store.ts**: Added a fallback empty array (`|| []`) to the `filteredContacts()` method return value, ensuring the method always returns an array instead of potentially returning undefined.

## Implementation Details
These changes follow defensive programming practices to handle edge cases where:
- Contact arrays might be undefined during component lifecycle transitions
- The filtered contacts collection might not be initialized

The optional chaining and null coalescing operators ensure graceful handling of these scenarios without breaking component rendering or store operations.

https://claude.ai/code/session_01CkSdkGE69KcBaMpiAexAaG