### PR TITLE
Wait longer when trying to attach metadata to newly sent messages

### DIFF
--- a/app/internal_packages/send-reminders/lib/send-reminders-store.ts
+++ b/app/internal_packages/send-reminders/lib/send-reminders-store.ts
@@ -28,7 +28,7 @@ class SendRemindersStore extends MailspringStore {
   }
 
   deactivate() {
-    this._unsubscribers.forEach(unsub => unsub());
+    this._unsubscribers.forEach((unsub) => unsub());
   }
 
   _sendReminderEmail = async (thread, sentHeaderMessageId) => {
@@ -53,6 +53,13 @@ class SendRemindersStore extends MailspringStore {
     }
 
     if (!AppEnv.isMainWindow()) {
+      return;
+    }
+
+    // If threads with reminders were deleted, there's nothing to clean up — the
+    // metadata is gone with the thread. Just skip processing to avoid operating
+    // on deleted models.
+    if (type === 'unpersist') {
       return;
     }
 

--- a/app/internal_packages/send-reminders/lib/send-reminders-utils.ts
+++ b/app/internal_packages/send-reminders/lib/send-reminders-utils.ts
@@ -90,7 +90,7 @@ export async function findMessage({ accountId, headerMessageId }) {
 
 export async function transferReminderMetadataFromDraftToThread({ accountId, headerMessageId }) {
   let message = await findMessage({ accountId, headerMessageId });
-  const delay = [1500, 1500, 10000, 10000];
+  const delay = [1500, 1500, 10000, 10000, 15000, 22000];
 
   // The sent message should already be synced, but if the send taks was interrupted and completed
   // without finalizing / cleaning up, we may need to go through a sync cycle. Do this before giving up.

--- a/app/internal_packages/send-reminders/lib/send-reminders-utils.ts
+++ b/app/internal_packages/send-reminders/lib/send-reminders-utils.ts
@@ -101,11 +101,7 @@ export async function transferReminderMetadataFromDraftToThread({ accountId, hea
   }
 
   if (!message) {
-    // The message may have been deleted by the user (e.g. they deleted the thread
-    // after sending but before the reminder metadata could be transferred). This is
-    // expected and not an error — the reminder is simply no longer needed.
-    console.log('SendReminders: Message not found, reminder transfer skipped (likely deleted)');
-    return;
+    throw new Error('SendReminders: Could not find message to update');
   }
 
   const metadata = message.metadataForPluginId(PLUGIN_ID) || {};
@@ -115,9 +111,7 @@ export async function transferReminderMetadataFromDraftToThread({ accountId, hea
 
   const thread = await DatabaseStore.find<Thread>(Thread, message.threadId);
   if (!thread) {
-    // Same as above — the thread was deleted, so the reminder is no longer relevant.
-    console.log('SendReminders: Thread not found, reminder transfer skipped (likely deleted)');
-    return;
+    throw new Error('SendReminders: Could not find thread to update');
   }
   updateReminderMetadata(thread, {
     expiration: metadata.expiration,

--- a/app/internal_packages/send-reminders/lib/send-reminders-utils.ts
+++ b/app/internal_packages/send-reminders/lib/send-reminders-utils.ts
@@ -84,7 +84,7 @@ export async function findMessage({ accountId, headerMessageId }) {
   // accounts if you sent it to yourself. To make this more performant, we do a find
   // and then a filter in code.
   return (await DatabaseStore.findAll<Message>(Message, { headerMessageId })).find(
-    m => m.accountId === accountId
+    (m) => m.accountId === accountId
   );
 }
 
@@ -101,7 +101,11 @@ export async function transferReminderMetadataFromDraftToThread({ accountId, hea
   }
 
   if (!message) {
-    throw new Error('SendReminders: Could not find message to update');
+    // The message may have been deleted by the user (e.g. they deleted the thread
+    // after sending but before the reminder metadata could be transferred). This is
+    // expected and not an error — the reminder is simply no longer needed.
+    console.log('SendReminders: Message not found, reminder transfer skipped (likely deleted)');
+    return;
   }
 
   const metadata = message.metadataForPluginId(PLUGIN_ID) || {};
@@ -111,7 +115,9 @@ export async function transferReminderMetadataFromDraftToThread({ accountId, hea
 
   const thread = await DatabaseStore.find<Thread>(Thread, message.threadId);
   if (!thread) {
-    throw new Error('SendReminders: Could not find thread to update');
+    // Same as above — the thread was deleted, so the reminder is no longer relevant.
+    console.log('SendReminders: Thread not found, reminder transfer skipped (likely deleted)');
+    return;
   }
   updateReminderMetadata(thread, {
     expiration: metadata.expiration,


### PR DESCRIPTION
## Summary
Updated the send-reminders plugin to gracefully handle cases where messages or threads are deleted after a reminder is set but before the reminder metadata can be transferred. Instead of throwing errors, the code now logs and returns early, preventing crashes when operating on deleted models.

## Key Changes
- **Error handling in `transferReminderMetadataFromDraftToThread`**: Changed from throwing errors to logging and returning early when a message or thread cannot be found, since deletion is an expected and valid scenario
- **Deletion detection in `SendRemindersStore`**: Added early return for `unpersist` events to skip processing when threads are deleted, avoiding operations on deleted models
- **Code style**: Updated arrow function formatting to use parentheses around single parameters for consistency (e.g., `m =>` to `(m) =>`)

## Implementation Details
The changes recognize that users may delete threads or messages after sending but before reminder metadata is transferred. Rather than treating this as an error condition, the code now:
1. Logs informational messages explaining why processing was skipped
2. Returns gracefully without throwing exceptions
3. Skips metadata operations on unpersisted (deleted) objects

This prevents unnecessary errors in the logs and makes the plugin more resilient to normal user workflows.

https://claude.ai/code/session_01MqBM3umd2hVMihPg6TD2sH