### PR TITLE
Fix email frame rendering and improve error reporting

### DIFF
--- a/app/internal_packages/message-list/lib/email-frame.tsx
+++ b/app/internal_packages/message-list/lib/email-frame.tsx
@@ -139,6 +139,10 @@ export default class EmailFrame extends React.Component<EmailFrameProps> {
     });
 
     window.requestAnimationFrame(() => {
+      // Guard: component may have unmounted or _writeContent called again (calling
+      // doc.open() a second time), leaving doc.body null until the next doc.write().
+      if (!this._mounted || !doc.body) return;
+
       Autolink(doc.body, {
         async: true,
         telAggressiveMatch: false,
@@ -156,7 +160,8 @@ export default class EmailFrame extends React.Component<EmailFrameProps> {
             iframe: iframeEl,
           });
         } catch (e) {
-          AppEnv.reportError(e);
+          const name = (extension as any).displayName || (extension as any).name || 'unknown';
+          AppEnv.reportError(e, { extensionName: name });
         }
       }
     });


### PR DESCRIPTION
## Summary
This PR improves the robustness of email frame rendering and enhances error reporting with extension context information.

## Key Changes
- **Added safety guard in requestAnimationFrame callback**: Check that the component is still mounted and the document body exists before calling Autolink. This prevents errors when the component unmounts or `_writeContent` is called multiple times in quick succession.
- **Enhanced error reporting**: When an extension throws an error during email processing, the error report now includes the extension's display name (or fallback to name/unknown) to help with debugging and issue tracking.

## Implementation Details
- The guard condition `if (!this._mounted || !doc.body) return;` prevents attempting to access or manipulate a null document body, which can occur if `doc.open()` is called a second time before the next `doc.write()`.
- Error context is extracted from the extension object using optional chaining and type assertion, with graceful fallbacks for missing display names.

https://claude.ai/code/session_01KiEukR8wZNUcMaGgpmAFBA