### PR TITLE
Filter out invalid categories in MailboxPerspective.forCategories

### DIFF
--- a/app/src/mailbox-perspective.ts
+++ b/app/src/mailbox-perspective.ts
@@ -46,7 +46,8 @@ export class MailboxPerspective {
   }
 
   static forCategories(categories) {
-    return categories.length > 0 ? new CategoryMailboxPerspective(categories) : this.forNothing();
+    const valid = _.compact(categories);
+    return valid.length > 0 ? new CategoryMailboxPerspective(valid) : this.forNothing();
   }
 
   static forStandardCategories(accountsOrIds, ...names) {


### PR DESCRIPTION
## Summary
Updated the `forCategories` method to filter out null/undefined/falsy values from the categories array before processing, ensuring only valid categories are used to create a CategoryMailboxPerspective.

## Changes
- Added `_.compact()` call to remove falsy values (null, undefined, false, etc.) from the categories array
- Pass the filtered `valid` array to `CategoryMailboxPerspective` instead of the original array
- Maintain the same logic: return a CategoryMailboxPerspective if valid categories exist, otherwise return `forNothing()`

## Implementation Details
This change prevents potential issues that could arise from passing invalid category values downstream. By using lodash's `compact()` utility, the method now gracefully handles cases where the categories array may contain null or undefined entries, which could occur from upstream filtering or data processing operations.

https://claude.ai/code/session_01M2BP3CUSB7hMTiXCXeJkG3