### PR TITLE
Fix URL scheme registration error detection on Linux

### DIFF
--- a/app/internal_packages/notifications/lib/items/default-client-notif.tsx
+++ b/app/internal_packages/notifications/lib/items/default-client-notif.tsx
@@ -51,7 +51,7 @@ export default class DefaultClientNotification extends React.Component<
   _onAccept = () => {
     this.helper.registerForURLScheme('mailto', err => {
       if (err) {
-        if (err.message && err.message.includes('xdg-mime: command not found')) {
+        if (err.message && err.message.includes('xdg-mime') && err.message.includes('not found')) {
           require('@electron/remote').dialog.showMessageBox({
             type: 'error',
             buttons: [localized('OK')],


### PR DESCRIPTION
## Summary
Improved error message detection for URL scheme registration failures on Linux systems by making the error check more robust.

## Key Changes
- Modified the error message validation in `DefaultClientNotification` to check for both 'xdg-mime' and 'not found' substrings separately instead of matching the exact concatenated string
- This change makes the error detection more resilient to variations in error message formatting

## Implementation Details
The original check `err.message.includes('xdg-mime: command not found')` was replaced with `err.message.includes('xdg-mime') && err.message.includes('not found')`. This approach is more flexible and can handle cases where the error message format might vary slightly while still containing both key indicators that the xdg-mime command is missing.

https://claude.ai/code/session_01GWJ4K5a1iSc6u3krYfzFWK