### PR TITLE
Add error handling for ICS parsing in EventHeader

### DIFF
--- a/app/internal_packages/events/lib/event-header.tsx
+++ b/app/internal_packages/events/lib/event-header.tsx
@@ -70,7 +70,13 @@ export class EventHeader extends React.Component<EventHeaderProps, EventHeaderSt
     fs.readFile(AttachmentStore.pathForFile(file), async (err, data) => {
       if (err || !this._mounted) return;
 
-      const { event, root } = CalendarUtils.parseICSString(data.toString());
+      let event, root;
+      try {
+        ({ event, root } = CalendarUtils.parseICSString(data.toString()));
+      } catch (e) {
+        console.warn(`EventHeader: Could not parse ICS data from attachment ${file.filename}: ${e.message}`);
+        return;
+      }
 
       const method = root.getFirstPropertyValue('method');
       const methodLower = (typeof method === 'string' ? method : 'request').toLowerCase();
@@ -90,9 +96,13 @@ export class EventHeader extends React.Component<EventHeaderProps, EventHeaderSt
         })
       ).subscribe(calEvent => {
         if (!this._mounted || !calEvent) return;
-        this.setState({
-          icsEvent: CalendarUtils.parseICSString(calEvent.ics).event,
-        });
+        try {
+          this.setState({
+            icsEvent: CalendarUtils.parseICSString(calEvent.ics).event,
+          });
+        } catch (e) {
+          console.warn(`EventHeader: Could not parse ICS data from calendar event: ${e.message}`);
+        }
       });
     });
   }

--- a/app/internal_packages/events/lib/event-header.tsx
+++ b/app/internal_packages/events/lib/event-header.tsx
@@ -70,13 +70,14 @@ export class EventHeader extends React.Component<EventHeaderProps, EventHeaderSt
     fs.readFile(AttachmentStore.pathForFile(file), async (err, data) => {
       if (err || !this._mounted) return;
 
-      let event, root;
+      let parsed: ReturnType<typeof CalendarUtils.parseICSString>;
       try {
-        ({ event, root } = CalendarUtils.parseICSString(data.toString()));
+        parsed = CalendarUtils.parseICSString(data.toString());
       } catch (e) {
         console.warn(`EventHeader: Could not parse ICS data from attachment ${file.filename}: ${e.message}`);
         return;
       }
+      const { event, root } = parsed;
 
       const method = root.getFirstPropertyValue('method');
       const methodLower = (typeof method === 'string' ? method : 'request').toLowerCase();


### PR DESCRIPTION
## Summary
Added try-catch error handling around ICS (iCalendar) parsing operations in the EventHeader component to gracefully handle malformed or invalid calendar data.

## Key Changes
- Wrapped `CalendarUtils.parseICSString()` call in try-catch block when reading ICS attachment data, with warning logged on parse failure
- Added error handling around `CalendarUtils.parseICSString()` call when processing calendar event data in subscription callback
- Both error cases now log descriptive warning messages with the filename or event context and error details instead of crashing

## Implementation Details
- Parse errors are caught and logged via `console.warn()` with contextual information (filename for attachments, generic message for calendar events)
- Early return on attachment parse failure prevents further processing of invalid data
- Calendar event parse errors are caught but don't prevent state updates from completing (fail-safe approach)
- Maintains existing component behavior for valid ICS data while preventing unhandled exceptions from invalid data

https://claude.ai/code/session_01CE6JB9RdX6YzuHMaKWTRN4