### PR TITLE
Improve password storage error handling and reporting

### DIFF
--- a/app/src/app-env.ts
+++ b/app/src/app-env.ts
@@ -201,6 +201,11 @@ export default class AppEnvConstructor {
   //
   reportError(error, extra: any = {}) {
     // Check if this error should be ignored and not reported to Sentry
+    // Errors marked noSentry have already been displayed to the user via a dialog.
+    if (error && error.noSentry) {
+      return;
+    }
+
     const errorMessage = `${error}`.toLowerCase();
 
     // ResizeObserver errors happen infrequently but spam Sentry with thousands of reports

--- a/app/src/key-manager.ts
+++ b/app/src/key-manager.ts
@@ -109,6 +109,13 @@ class KeyManager {
   }
 
   async _writeKeyHash(keys: KeySet) {
+    if (!safeStorage.isEncryptionAvailable()) {
+      throw new Error(
+        localized(
+          `Mailspring could not store your password securely because encryption is not available on this system. On Linux, Mailspring requires a secret service such as GNOME Keyring or KWallet. Please ensure one is installed and running, then restart Mailspring.`
+        )
+      );
+    }
     const enrcyptedCredentials = await safeStorage.encryptString(JSON.stringify(keys));
     AppEnv.config.set(configCredentialsKey, enrcyptedCredentials);
   }
@@ -117,7 +124,7 @@ class KeyManager {
     const clickedButton = require('@electron/remote').dialog.showMessageBoxSync({
       type: 'error',
       buttons: [localized('Mailspring Help'), localized('Quit')],
-      message: localized(
+      message: err.message || localized(
         `Mailspring could not store your password securely. For more information, visit %@`,
         'https://community.getmailspring.com/t/password-management-error/199'
       ),
@@ -129,7 +136,10 @@ class KeyManager {
     }
 
     // tell the app to exit and rethrow the error to ensure code relying
-    // on the passwords being saved never runs (saving identity for example)
+    // on the passwords being saved never runs (saving identity for example).
+    // Mark as user-visible so the global error handler does not also report
+    // it to Sentry — the user has already been informed via the dialog above.
+    (err as any).noSentry = true;
     require('@electron/remote').app.quit();
     throw err;
   }

--- a/app/src/key-manager.ts
+++ b/app/src/key-manager.ts
@@ -110,10 +110,16 @@ class KeyManager {
 
   async _writeKeyHash(keys: KeySet) {
     if (!safeStorage.isEncryptionAvailable()) {
+      const platformHint =
+        process.platform === 'linux'
+          ? localized(
+              ' On Linux, Mailspring requires a secret service such as GNOME Keyring or KWallet. Please ensure one is installed and running, then restart Mailspring.'
+            )
+          : '';
       throw new Error(
         localized(
-          `Mailspring could not store your password securely because encryption is not available on this system. On Linux, Mailspring requires a secret service such as GNOME Keyring or KWallet. Please ensure one is installed and running, then restart Mailspring.`
-        )
+          `Mailspring could not store your password securely because encryption is not available on this system.`
+        ) + platformHint
       );
     }
     const enrcyptedCredentials = await safeStorage.encryptString(JSON.stringify(keys));


### PR DESCRIPTION
## Summary
This PR improves error handling for password storage failures by providing more specific error messages to users and preventing duplicate error reporting to Sentry.

## Key Changes
- **Enhanced encryption availability check**: Added validation in `_writeKeyHash()` to detect when system encryption is unavailable (particularly on Linux without GNOME Keyring or KWallet) and provide a clear, actionable error message to the user
- **Improved error messaging**: Modified the error dialog to display the specific error message when available, falling back to the generic message if needed
- **Prevent duplicate error reporting**: Added `noSentry` flag to errors that have already been displayed to the user via dialog, preventing the global error handler from also reporting them to Sentry
- **Updated error handler logic**: Modified `AppEnv.reportError()` to skip Sentry reporting for errors marked with `noSentry`, with clarifying comments about why certain errors are excluded

## Implementation Details
- The encryption availability check happens before attempting to encrypt credentials, providing early failure with helpful guidance
- Error messages are localized for international users
- The `noSentry` flag is a simple property added to the error object to communicate between the key manager and global error handler
- Comments were added to clarify the intent of error suppression for future maintainers

https://claude.ai/code/session_01Fu95vZbEopwD7vTDhdGLbq