### PR TITLE
Replace broken utf7 package with custom IMAP UTF-7 implementation

### DIFF
--- a/app/internal_packages/account-sidebar/lib/sidebar-item.ts
+++ b/app/internal_packages/account-sidebar/lib/sidebar-item.ts
@@ -1,5 +1,5 @@
 import _ from 'underscore';
-import utf7 from 'utf7';
+import { imapUtf7 } from 'mailspring-exports';
 
 import _str from 'underscore.string';
 import { OutlineViewItem } from 'mailspring-component-kit';
@@ -130,7 +130,7 @@ export function createCategory(accountId: string, name: string, parentCategory?:
   let fullName: string;
   if (parentCategory) {
     const separator = detectFolderSeparator(accountId);
-    const decodedPath = utf7.imap.decode(parentCategory.path);
+    const decodedPath = imapUtf7.decode(parentCategory.path);
     fullName = decodedPath + separator + name;
   } else {
     fullName = name;

--- a/app/internal_packages/category-mapper/lib/category-selection.tsx
+++ b/app/internal_packages/category-mapper/lib/category-selection.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
-import utf7 from 'utf7';
 import {
   RetinaImg,
   DropdownMenu,
   LabelColorizer,
   BoldedSearchResult,
 } from 'mailspring-component-kit';
-import { localized, Label, Utils, PropTypes } from 'mailspring-exports';
+import { localized, Label, Utils, PropTypes, imapUtf7 } from 'mailspring-exports';
 
 interface CategorySelectionProps {
   allowLabels: boolean;
@@ -46,8 +45,8 @@ export default class CategorySelection extends React.Component<
   _itemsForCategories(): CategoryItem[] {
     return this.props.all
       .sort((a, b) => {
-        const pathA = utf7.imap.decode(a.path).toUpperCase();
-        const pathB = utf7.imap.decode(b.path).toUpperCase();
+        const pathA = imapUtf7.decode(a.path).toUpperCase();
+        const pathB = imapUtf7.decode(b.path).toUpperCase();
         if (pathA < pathB) {
           return -1;
         }
@@ -56,7 +55,7 @@ export default class CategorySelection extends React.Component<
         }
         return 0;
       })
-      .filter(c => Utils.wordSearchRegExp(this.state.searchValue).test(utf7.imap.decode(c.path)))
+      .filter(c => Utils.wordSearchRegExp(this.state.searchValue).test(imapUtf7.decode(c.path)))
       .map(c => {
         c.backgroundColor = LabelColorizer.backgroundColorDark(c);
         return c;
@@ -82,7 +81,7 @@ export default class CategorySelection extends React.Component<
       );
     }
 
-    const displayPath = utf7.imap.decode(item.path);
+    const displayPath = imapUtf7.decode(item.path);
 
     return (
       <div className="category-item">

--- a/app/internal_packages/notifications/lib/sidebar/sync-activity.tsx
+++ b/app/internal_packages/notifications/lib/sidebar/sync-activity.tsx
@@ -1,6 +1,5 @@
-import utf7 from 'utf7';
 import React from 'react';
-import { localized, AccountStore, PropTypes } from 'mailspring-exports';
+import { localized, AccountStore, PropTypes, imapUtf7 } from 'mailspring-exports';
 
 interface SyncActivityProps {
   syncState: {
@@ -31,7 +30,7 @@ export class SyncActivity extends React.Component<SyncActivityProps> {
       }
     }
 
-    const folderDisplayPath = utf7.imap.decode(folderPath);
+    const folderDisplayPath = imapUtf7.decode(folderPath);
 
     return (
       <div className={`folder-progress ${status}`} key={folderPath}>

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -68,7 +68,6 @@
         "tld": "^0.0.2",
         "underscore": "^1.13.7",
         "underscore.string": "^3.3.5",
-        "utf7": "^1.0.1",
         "vcf": "^2.0.5",
         "windows-iana": "^4.2.1",
         "xml2js": "^0.6.2"

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -4259,11 +4259,6 @@
         "node": ">= 4.0.0"
       }
     },
-    "node_modules/utf7": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/utf7/-/utf7-1.0.1.tgz",
-      "integrity": "sha512-uTsJiC86k3pTnrr/SoxEbCMM5dZXfmq+vCN7bZT6P0saKLQIMOz92+nujKIo1zwLbBTXqhSUFSMj2aKa/wkziA=="
-    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",

--- a/app/package.json
+++ b/app/package.json
@@ -70,7 +70,6 @@
     "tld": "^0.0.2",
     "underscore": "^1.13.7",
     "underscore.string": "^3.3.5",
-    "utf7": "^1.0.1",
     "vcf": "^2.0.5",
     "windows-iana": "^4.2.1",
     "xml2js": "^0.6.2"

--- a/app/spec/utils/imap-utf7-spec.ts
+++ b/app/spec/utils/imap-utf7-spec.ts
@@ -1,0 +1,105 @@
+import { imapUtf7 } from '../../src/utils/imap-utf7';
+
+describe('imapUtf7', () => {
+  describe('encode', () => {
+    it('passes through empty string', () => {
+      expect(imapUtf7.encode('')).toEqual('');
+    });
+
+    it('passes through pure printable ASCII unchanged', () => {
+      expect(imapUtf7.encode('Inbox')).toEqual('Inbox');
+      expect(imapUtf7.encode('INBOX/Sent')).toEqual('INBOX/Sent');
+      expect(imapUtf7.encode(' !"#$%\'()*+,-./:;<=>?@[\\]^_`{|}~')).toEqual(
+        ' !"#$%\'()*+,-./:;<=>?@[\\]^_`{|}~'
+      );
+    });
+
+    it('encodes & as &-', () => {
+      expect(imapUtf7.encode('&')).toEqual('&-');
+      expect(imapUtf7.encode('A&B')).toEqual('A&-B');
+      expect(imapUtf7.encode('&&')).toEqual('&-&-');
+    });
+
+    it('encodes accented characters', () => {
+      expect(imapUtf7.encode('Ö')).toEqual('&ANY-');
+      expect(imapUtf7.encode('Küche')).toEqual('K&APw-che');
+      expect(imapUtf7.encode('Öffentlich')).toEqual('&ANY-ffentlich');
+    });
+
+    it('encodes CJK characters', () => {
+      expect(imapUtf7.encode('日本語')).toEqual('&ZeVnLIqe-');
+    });
+
+    it('encodes mixed ASCII and non-ASCII', () => {
+      expect(imapUtf7.encode('INBOX/Küche')).toEqual('INBOX/K&APw-che');
+      expect(imapUtf7.encode('A Ö B')).toEqual('A &ANY- B');
+    });
+
+    it('encodes & followed immediately by non-ASCII', () => {
+      expect(imapUtf7.encode('&Ö')).toEqual('&-&ANY-');
+    });
+
+    it('encodes surrogate pairs (non-BMP characters)', () => {
+      expect(imapUtf7.encode('😀')).toEqual('&2D3eAA-');
+    });
+
+    it('encodes consecutive non-ASCII runs as single escape sequence', () => {
+      // Two adjacent non-ASCII chars form one run, not two separate sequences
+      const encoded = imapUtf7.encode('ÖÄ');
+      expect(encoded).toEqual('&ANYAxA-');
+    });
+  });
+
+  describe('decode', () => {
+    it('passes through empty string', () => {
+      expect(imapUtf7.decode('')).toEqual('');
+    });
+
+    it('passes through pure ASCII unchanged', () => {
+      expect(imapUtf7.decode('Inbox')).toEqual('Inbox');
+      expect(imapUtf7.decode('INBOX/Sent')).toEqual('INBOX/Sent');
+    });
+
+    it('decodes &- as &', () => {
+      expect(imapUtf7.decode('&-')).toEqual('&');
+      expect(imapUtf7.decode('A&-B')).toEqual('A&B');
+      expect(imapUtf7.decode('&-&-')).toEqual('&&');
+    });
+
+    it('decodes accented characters', () => {
+      expect(imapUtf7.decode('&ANY-')).toEqual('Ö');
+      expect(imapUtf7.decode('K&APw-che')).toEqual('Küche');
+      expect(imapUtf7.decode('&ANY-ffentlich')).toEqual('Öffentlich');
+    });
+
+    it('decodes CJK characters', () => {
+      expect(imapUtf7.decode('&ZeVnLIqe-')).toEqual('日本語');
+    });
+
+    it('decodes surrogate pairs', () => {
+      expect(imapUtf7.decode('&2D3eAA-')).toEqual('😀');
+    });
+  });
+
+  describe('round-trip', () => {
+    const cases = [
+      '',
+      'Inbox',
+      '&',
+      'A&B',
+      'Ö',
+      'Küche',
+      '日本語',
+      'INBOX/Küche',
+      '&Ö',
+      '😀',
+      'Mixed: A&B with Ö and 日',
+    ];
+
+    for (const str of cases) {
+      it(`decode(encode(str)) === str for: ${JSON.stringify(str)}`, () => {
+        expect(imapUtf7.decode(imapUtf7.encode(str))).toEqual(str);
+      });
+    }
+  });
+});

--- a/app/src/flux/models/category.ts
+++ b/app/src/flux/models/category.ts
@@ -1,5 +1,5 @@
 /* eslint global-require: 0 */
-import utf7 from 'utf7';
+import { imapUtf7 } from '../../utils/imap-utf7';
 import { Model, AttributeValues } from './model';
 import * as Attributes from '../attributes';
 import { localized } from '../../intl';
@@ -75,7 +75,7 @@ Section: Models
 */
 export class Category extends Model {
   get displayName() {
-    const decoded = utf7.imap.decode(this.path) as string;
+    const decoded = imapUtf7.decode(this.path) as string;
 
     for (const prefix of ['INBOX', '[Gmail]', '[Mailspring]']) {
       if (decoded.startsWith(prefix) && decoded.length > prefix.length + 1) {

--- a/app/src/flux/tasks/destroy-category-task.ts
+++ b/app/src/flux/tasks/destroy-category-task.ts
@@ -1,4 +1,4 @@
-import utf7 from 'utf7';
+import { imapUtf7 } from '../../utils/imap-utf7';
 import { Task } from './task';
 import * as Attributes from '../attributes';
 import { localized } from '../../intl';
@@ -20,6 +20,6 @@ export class DestroyCategoryTask extends Task {
   }
 
   label() {
-    return localized(`Deleting %@`, utf7.imap.decode(this.path));
+    return localized(`Deleting %@`, imapUtf7.decode(this.path));
   }
 }

--- a/app/src/flux/tasks/syncback-category-task.ts
+++ b/app/src/flux/tasks/syncback-category-task.ts
@@ -1,4 +1,4 @@
-import utf7 from 'utf7';
+import { imapUtf7 } from '../../utils/imap-utf7';
 import { Task } from './task';
 import * as Attributes from '../attributes';
 import { localized } from '../../intl';
@@ -25,7 +25,7 @@ export class SyncbackCategoryTask extends Task {
 
   static forCreating({ name, accountId }: { name: string; accountId: string }) {
     return new SyncbackCategoryTask({
-      path: utf7.imap.encode(String(name)),
+      path: imapUtf7.encode(String(name)),
       accountId: accountId,
     });
   }
@@ -41,7 +41,7 @@ export class SyncbackCategoryTask extends Task {
   }) {
     return new SyncbackCategoryTask({
       existingPath: path,
-      path: utf7.imap.encode(String(newName)),
+      path: imapUtf7.encode(String(newName)),
       accountId: accountId,
     });
   }
@@ -52,7 +52,7 @@ export class SyncbackCategoryTask extends Task {
 
   label() {
     return this.existingPath
-      ? localized(`Renaming %@`, utf7.imap.decode(String(this.existingPath)))
-      : localized(`Creating %@`, utf7.imap.decode(String(this.path)));
+      ? localized(`Renaming %@`, imapUtf7.decode(String(this.existingPath)))
+      : localized(`Creating %@`, imapUtf7.decode(String(this.path)));
   }
 }

--- a/app/src/global/mailspring-exports.d.ts
+++ b/app/src/global/mailspring-exports.d.ts
@@ -178,6 +178,8 @@ export type DOMUtils = typeof import('../dom-utils').default;
 export const DOMUtils: DOMUtils;
 export type DateUtils = typeof import('../date-utils').default;
 export const DateUtils: DateUtils;
+export type imapUtf7 = typeof import('../utils/imap-utf7').imapUtf7;
+export const imapUtf7: imapUtf7;
 
 export type CalendarUtils = typeof import('../calendar-utils');
 export const CalendarUtils: CalendarUtils;

--- a/app/src/global/mailspring-exports.js
+++ b/app/src/global/mailspring-exports.js
@@ -181,6 +181,7 @@ lazyLoad(`ComponentRegistry`, 'registries/component-registry');
 lazyLoad(`Utils`, 'flux/models/utils');
 lazyLoad(`DOMUtils`, 'dom-utils');
 lazyLoad(`DateUtils`, 'date-utils');
+lazyLoadWithGetter(`imapUtf7`, () => require('../utils/imap-utf7').imapUtf7);
 lazyLoad(`CalendarUtils`, 'calendar-utils');
 lazyLoad(`ICSEventHelpers`, 'ics-event-helpers');
 lazyLoad(`FsUtils`, 'fs-utils');

--- a/app/src/utils/imap-utf7.ts
+++ b/app/src/utils/imap-utf7.ts
@@ -1,0 +1,62 @@
+/**
+ * RFC 3501 §5.1.3 IMAP modified UTF-7 encode/decode.
+ *
+ * Replaces the 'utf7' npm package (v1.0.1) which has a broken Node.js version
+ * check. It uses a lexicographic string comparison:
+ *
+ *   if (process.version >= 'v6.0.0') { Buffer.alloc(...) }
+ *   else                             { new Buffer(...) }  // deprecated
+ *
+ * Because 'v10.0.0' < 'v6.0.0' lexicographically ('1' < '6'), Electron's
+ * embedded Node.js v10+ always falls into the else-branch. Modern Node.js
+ * then throws: "The 'string' argument must be of type string. Received type
+ * number (N)" when new Buffer(size, encoding) is called with a numeric first
+ * argument — meaning every folder name that contains a non-ASCII character
+ * crashes on create or rename.
+ */
+
+function encodeChunk(chunk: string): string {
+  // Convert to UTF-16BE bytes, then Modified Base64 ('/' → ',', no padding).
+  const buf = Buffer.allocUnsafe(chunk.length * 2);
+  for (let i = 0; i < chunk.length; i++) {
+    const c = chunk.charCodeAt(i);
+    buf[i * 2] = c >> 8;
+    buf[i * 2 + 1] = c & 0xff;
+  }
+  return buf.toString('base64').replace(/\//g, ',').replace(/=+$/, '');
+}
+
+function decodeChunk(b64: string): string {
+  // Swap ',' back to '/', base64-decode to UTF-16BE bytes, build string.
+  const buf = Buffer.from(b64.replace(/,/g, '/'), 'base64');
+  let result = '';
+  for (let i = 0; i + 1 < buf.length; i += 2) {
+    result += String.fromCharCode((buf[i] << 8) | buf[i + 1]);
+  }
+  return result;
+}
+
+export const imapUtf7 = {
+  /**
+   * Encode a Unicode string to IMAP modified UTF-7 (RFC 3501 §5.1.3).
+   * Printable ASCII (0x20–0x7E) passes through unchanged except '&' → '&-'.
+   * Runs of non-representable characters become '&<ModifiedBase64>-'.
+   */
+  encode(str: string): string {
+    return str
+      .replace(/&/g, '&-')
+      .replace(/[^\x20-\x7e]+/g, chunk => `&${encodeChunk(chunk)}-`);
+  },
+
+  /**
+   * Decode an IMAP modified UTF-7 string (RFC 3501 §5.1.3) to Unicode.
+   */
+  decode(str: string): string {
+    return str.replace(/&([^-]*)-/g, (_, chunk) => {
+      if (chunk === '') return '&';
+      return decodeChunk(chunk);
+    });
+  },
+};
+
+export default imapUtf7;


### PR DESCRIPTION
## Summary
Replaces the `utf7` npm package (v1.0.1) with a custom IMAP modified UTF-7 encoder/decoder to fix a critical bug where folder names containing non-ASCII characters crash on create or rename in Electron environments.

## Problem
The `utf7` package has a broken Node.js version check that uses lexicographic string comparison:
```javascript
if (process.version >= 'v6.0.0') { Buffer.alloc(...) }
else { new Buffer(...) }  // deprecated
```

Since 'v10.0.0' < 'v6.0.0' lexicographically, Electron's embedded Node.js v10+ always falls into the deprecated code path, causing crashes when handling non-ASCII folder names.

## Changes
- **New file**: `app/src/utils/imap-utf7.ts` - Custom RFC 3501 §5.1.3 compliant IMAP modified UTF-7 encoder/decoder
- **Updated imports**: Replaced all `utf7` package imports with the new `imapUtf7` utility across 6 files:
  - `category-selection.tsx`
  - `syncback-category-task.ts`
  - `sync-activity.tsx`
  - `sidebar-item.ts`
  - `category.ts`
  - `destroy-category-task.ts`
- **Exports**: Added `imapUtf7` to `mailspring-exports` for convenient access throughout the codebase
- **Dependencies**: Removed `utf7` from `package.json`

## Implementation Details
The custom implementation:
- Encodes Unicode strings to IMAP modified UTF-7 (printable ASCII 0x20–0x7E passes through unchanged except '&' → '&-')
- Decodes IMAP modified UTF-7 back to Unicode
- Uses UTF-16BE byte encoding with Modified Base64 (replacing '/' with ',' and removing padding)
- Properly handles all edge cases per RFC 3501 specification

https://claude.ai/code/session_014RoFa9B4tnG1FXe2cKLQ2r