### PR TITLE
Handle stdin errors when child process exits unexpectedly

### DIFF
--- a/app/src/mailsync-process.ts
+++ b/app/src/mailsync-process.ts
@@ -323,6 +323,20 @@ export class MailsyncProcess extends EventEmitter {
     });
 
     let cleanedUp = false;
+
+    // Handle EPIPE and other stdin errors that occur when the child process
+    // exits while we're still trying to write to it. These errors are emitted
+    // asynchronously as 'error' events on stdin rather than thrown from write(),
+    // so the try/catch in sendMessage() does not catch them.
+    if (this._proc.stdin) {
+      this._proc.stdin.on('error', err => {
+        if (cleanedUp) return;
+        cleanedUp = true;
+        this._proc.kill();
+        this.emit('close', { code: -2, error: err, signal: null });
+      });
+    }
+
     const onStreamCloseOrExit = (code: number, signal: string) => {
       if (cleanedUp) {
         return;
@@ -379,7 +393,10 @@ export class MailsyncProcess extends EventEmitter {
     try {
       this._proc.stdin.write(msg, 'utf-8');
     } catch (error) {
-      if (error && error.message.includes('socket has been ended')) {
+      if (
+        error &&
+        (error.message.includes('socket has been ended') || error.code === 'EPIPE')
+      ) {
         // The process probably already exited and we missed it somehow,
         // but try to kill it anyway and then force-emit a 'close' to trigger
         // the bridge to restart us.


### PR DESCRIPTION
## Summary
Improved error handling in the mailsync process to properly handle EPIPE and other stdin errors that occur when the child process exits while we're still trying to write to it.

## Key Changes
- Added an 'error' event listener on stdin to catch asynchronous errors that aren't thrown from `write()` calls
- The stdin error handler kills the process and emits a 'close' event with error details to trigger proper cleanup and restart
- Updated the `sendMessage()` catch block to also handle EPIPE errors (in addition to 'socket has been ended' errors)
- Added guard logic using the `cleanedUp` flag to prevent duplicate cleanup attempts

## Implementation Details
The issue was that EPIPE errors are emitted asynchronously as 'error' events on the stdin stream rather than being thrown synchronously from `write()`. This meant the existing try/catch in `sendMessage()` couldn't catch them. The new stdin error listener ensures these errors are properly handled and trigger the same cleanup and restart flow as other process exit scenarios.

https://claude.ai/code/session_01MhP9UUtRWtrJTVnyqHEf3g