### PR TITLE
Improve plugin activation error handling and TypeScript compilation

### DIFF
--- a/app/src/compile-support/typescript.js
+++ b/app/src/compile-support/typescript.js
@@ -50,7 +50,10 @@ exports.compile = function(sourceCode, filePath) {
     }
   }
   if (TypeScript === 'missing') {
-    return sourceCode;
+    throw new Error(
+      `Cannot compile ${filePath}: Mailspring no longer ships with TypeScript. ` +
+        `Ask the plugin developer to compile the plugin to vanilla JavaScript as a pre-publish step.`
+    );
   }
   return TypeScript.transpileModule(sourceCode, { compilerOptions, fileName: filePath }).outputText;
 };

--- a/app/src/package-manager.ts
+++ b/app/src/package-manager.ts
@@ -130,6 +130,10 @@ export default class PackageManager {
       pkg.activate();
     } catch (err) {
       delete this.active[pkg.name];
+      for (const d of pkg.disposables) {
+        d.dispose();
+      }
+      pkg.disposables = [];
       AppEnv.reportError(
         new Error(
           localized(`Failed to activate plugin %@: %@`, pkg.name, err.message || err.toString())

--- a/app/src/package-manager.ts
+++ b/app/src/package-manager.ts
@@ -125,8 +125,17 @@ export default class PackageManager {
       return;
     }
 
-    this.active[pkg.name] = pkg;
-    pkg.activate();
+    try {
+      this.active[pkg.name] = pkg;
+      pkg.activate();
+    } catch (err) {
+      delete this.active[pkg.name];
+      AppEnv.reportError(
+        new Error(
+          localized(`Failed to activate plugin %@: %@`, pkg.name, err.message || err.toString())
+        )
+      );
+    }
   }
 
   deactivatePackages() {}


### PR DESCRIPTION
## Summary
This PR improves error handling for plugin activation and provides clearer feedback when TypeScript compilation is unavailable.

## Key Changes
- **Plugin Activation Error Handling**: Wrapped the package activation logic in a try-catch block to gracefully handle activation failures. When a plugin fails to activate, it is now removed from the active packages list and a user-friendly error message is reported via `AppEnv.reportError()`.

- **TypeScript Compilation Error**: Changed the TypeScript compiler to throw an informative error instead of silently returning uncompiled source code when TypeScript is unavailable. This helps plugin developers understand that they need to pre-compile their plugins to vanilla JavaScript before publishing.

## Implementation Details
- The error message for failed plugin activation includes both the plugin name and the underlying error details for easier debugging
- The TypeScript error message provides actionable guidance to plugin developers about the pre-publish compilation requirement
- Error handling is localized for the plugin activation message

https://claude.ai/code/session_01CLM7C4P8WgjReQfTjvGEdZ