### PR TITLE
Queue launch options and URLs until app initialization completes

### DIFF
--- a/app/src/browser/application.ts
+++ b/app/src/browser/application.ts
@@ -58,6 +58,7 @@ export default class Application extends EventEmitter {
   _resettingAndRelaunching: boolean;
   _initialized: boolean = false;
   _pendingLaunchOptions: any[] = [];
+  _pendingUrls: string[] = [];
 
   async start(options) {
     const { resourcePath, configDirPath, version, devMode, specMode, safeMode } = options;
@@ -157,6 +158,9 @@ export default class Application extends EventEmitter {
     this.handleLaunchOptions(options);
     for (const pendingOpts of this._pendingLaunchOptions.splice(0)) {
       this.handleLaunchOptions(pendingOpts);
+    }
+    for (const pendingUrl of this._pendingUrls.splice(0)) {
+      this.openUrl(pendingUrl);
     }
 
     if (process.platform === 'linux') {
@@ -870,6 +874,11 @@ export default class Application extends EventEmitter {
   // Open a mailto:// url.
   //
   openUrl(urlToOpen) {
+    if (!this._initialized) {
+      this._pendingUrls.push(urlToOpen);
+      return;
+    }
+
     const parts = url.parse(urlToOpen, true);
     const main = this.windowManager.get(WindowManager.MAIN_WINDOW);
 

--- a/app/src/browser/application.ts
+++ b/app/src/browser/application.ts
@@ -56,6 +56,8 @@ export default class Application extends EventEmitter {
 
   _sourceWindows: { [taskId: string]: BrowserWindow } = {};
   _resettingAndRelaunching: boolean;
+  _initialized: boolean = false;
+  _pendingLaunchOptions: any[] = [];
 
   async start(options) {
     const { resourcePath, configDirPath, version, devMode, specMode, safeMode } = options;
@@ -147,7 +149,15 @@ export default class Application extends EventEmitter {
     }
 
     this.handleEvents();
+
+    // Mark initialization complete, then process the initial launch options
+    // followed by any second-instance options that arrived while we were
+    // still awaiting async initialization steps above.
+    this._initialized = true;
     this.handleLaunchOptions(options);
+    for (const pendingOpts of this._pendingLaunchOptions.splice(0)) {
+      this.handleLaunchOptions(pendingOpts);
+    }
 
     if (process.platform === 'linux') {
       const helper = new DefaultClientHelper();
@@ -172,6 +182,15 @@ export default class Application extends EventEmitter {
 
   // Opens a new window based on the options provided.
   handleLaunchOptions(options) {
+    // If start() hasn't finished initializing yet (e.g. a second-instance event
+    // arrives while the async mailsync migration or oneTimeMoveToApplications is
+    // still running), windowManager won't exist yet.  Queue the options and
+    // process them once initialization is complete.
+    if (!this._initialized) {
+      this._pendingLaunchOptions.push(options);
+      return;
+    }
+
     const { specMode, pathsToOpen, urlsToOpen } = options;
 
     if (specMode) {


### PR DESCRIPTION
## Summary
This change adds a queueing mechanism to handle launch options and URLs that arrive before the application has finished its asynchronous initialization. This prevents errors that could occur when second-instance events or URL open requests arrive while the app is still initializing.

## Key Changes
- Added three new instance variables to track initialization state:
  - `_initialized`: boolean flag indicating when async startup is complete
  - `_pendingLaunchOptions`: queue for launch options received during initialization
  - `_pendingUrls`: queue for URLs received during initialization

- Modified `start()` method to:
  - Set `_initialized = true` after `handleEvents()` completes
  - Process any pending launch options and URLs that accumulated during initialization

- Updated `handleLaunchOptions()` to:
  - Check if initialization is complete before processing
  - Queue options if `windowManager` doesn't exist yet (still initializing)

- Updated `openUrl()` to:
  - Check if initialization is complete before processing
  - Queue URLs if the app hasn't finished initializing

## Implementation Details
The queueing happens at the method level rather than at the event listener level, allowing the app to gracefully defer processing of second-instance events and URL open requests until the `windowManager` is available. This handles race conditions where async operations like mailsync migration or application relocation are still in progress when these events arrive.

https://claude.ai/code/session_01EGhUa2Wq5S8xyAfxeL3P7H