### PR TITLE
Handle null values in draft field change detection

### DIFF
--- a/app/src/flux/stores/draft-editing-session.ts
+++ b/app/src/flux/stores/draft-editing-session.ts
@@ -456,7 +456,7 @@ export class DraftEditingSession extends MailspringStore {
     let changed = false;
     for (const [key] of Object.entries(Message.attributes)) {
       if (key === 'headerMessageId') continue;
-      if (nextDraft[key] === undefined) continue;
+      if (nextDraft[key] == null) continue;
       if (lockedFields.includes(key)) continue;
       if (this._draft[key] === nextDraft[key]) continue;
 

--- a/app/src/flux/stores/draft-editing-session.ts
+++ b/app/src/flux/stores/draft-editing-session.ts
@@ -456,7 +456,7 @@ export class DraftEditingSession extends MailspringStore {
     let changed = false;
     for (const [key] of Object.entries(Message.attributes)) {
       if (key === 'headerMessageId') continue;
-      if (nextDraft[key] == null) continue;
+      if (nextDraft[key] === undefined || nextDraft[key] === null) continue;
       if (lockedFields.includes(key)) continue;
       if (this._draft[key] === nextDraft[key]) continue;
 


### PR DESCRIPTION
## Summary
Updated the draft field change detection logic to properly handle null values in addition to undefined values.

## Key Changes
- Modified the condition in `DraftEditingSession.ts` to skip processing when a draft field is either `undefined` or `null`
- This ensures that null values are treated the same as undefined values when determining if a field has changed

## Implementation Details
The change was made in the draft comparison loop where fields are checked for modifications. Previously, only `undefined` values were skipped, but null values could still be processed. This update treats both null and undefined as "no value" states, preventing unnecessary field updates and potential issues with null field assignments.

https://claude.ai/code/session_01UGSRmVW3bt91KrrPFgK393