### PR TITLE
Add error handling for PDF generation in print window

### DIFF
--- a/app/internal_packages/print/lib/print-window.ts
+++ b/app/internal_packages/print/lib/print-window.ts
@@ -94,13 +94,24 @@ export default class PrintWindow {
       if (!filePath) {
         return;
       }
-      const data = await this.browserWin.webContents.printToPDF({
-        margins: { marginType: 'none' },
-        pageSize: 'Letter',
-        printBackground: true,
-        landscape: false,
-      });
-      fs.writeFileSync(filePath, data);
+
+      try {
+        const data = await this.browserWin.webContents.printToPDF({
+          margins: { marginType: 'none' },
+          pageSize: 'Letter',
+          printBackground: true,
+          landscape: false,
+        });
+        fs.writeFileSync(filePath, data);
+      } catch (err) {
+        dialog.showErrorBox(
+          localized('Save as PDF Failed'),
+          localized(
+            'Mailspring could not generate the PDF. Please try again. If the problem persists, try printing to a PDF printer instead.\n\nError: %@',
+            err.message
+          )
+        );
+      }
     });
 
     this.browserWin.removeMenu();


### PR DESCRIPTION
## Summary
Added try-catch error handling around the PDF generation and file writing logic in the print window to gracefully handle failures and provide user feedback.

## Key Changes
- Wrapped `printToPDF()` and `fs.writeFileSync()` calls in a try-catch block
- Added user-facing error dialog that displays when PDF generation fails
- Error message includes localized text with the underlying error details to help users troubleshoot

## Implementation Details
- When an error occurs during PDF generation or file writing, users now see a clear error dialog with the message: "Mailspring could not generate the PDF. Please try again. If the problem persists, try printing to a PDF printer instead."
- The actual error message is appended to provide technical context for debugging
- Uses the existing `dialog.showErrorBox()` and `localized()` utilities for consistency with the rest of the application

https://claude.ai/code/session_01NhSUaZyEZin4CYWChgUiTu