### PR TITLE
Replace electron remote dialog calls with AppEnv.showErrorDialog

### DIFF
--- a/app/internal_packages/composer-templates/lib/template-store.ts
+++ b/app/internal_packages/composer-templates/lib/template-store.ts
@@ -149,7 +149,7 @@ class TemplateStore extends MailspringStore {
   }
 
   _displayError(message) {
-    require('@electron/remote').dialog.showErrorBox(localized('Template Creation Error'), message);
+    AppEnv.showErrorDialog({ title: localized('Template Creation Error'), message });
   }
 
   _displayDialog(title, message, buttons) {

--- a/app/internal_packages/print/lib/print-window.ts
+++ b/app/internal_packages/print/lib/print-window.ts
@@ -104,13 +104,13 @@ export default class PrintWindow {
         });
         fs.writeFileSync(filePath, data);
       } catch (err) {
-        dialog.showErrorBox(
-          localized('Save as PDF Failed'),
-          localized(
+        AppEnv.showErrorDialog({
+          title: localized('Save as PDF Failed'),
+          message: localized(
             'Mailspring could not generate the PDF. Please try again. If the problem persists, try printing to a PDF printer instead.\n\nError: %@',
             err.message
-          )
-        );
+          ),
+        });
       }
     });
 

--- a/app/internal_packages/translation/lib/service.ts
+++ b/app/internal_packages/translation/lib/service.ts
@@ -247,8 +247,10 @@ export async function translateMessageBody(
     } catch (error) {
       Actions.closePopover();
       if (!silent) {
-        const dialog = require('@electron/remote').dialog;
-        dialog.showErrorBox(localized('Language Conversion Failed'), error.toString());
+        AppEnv.showErrorDialog({
+          title: localized('Language Conversion Failed'),
+          message: error.toString(),
+        });
       }
       return false;
     }


### PR DESCRIPTION
## Summary
Refactored error dialog handling across multiple packages to use a centralized `AppEnv.showErrorDialog()` method instead of directly calling `@electron/remote` dialog APIs.

## Key Changes
- **print-window.ts**: Replaced `dialog.showErrorBox()` with `AppEnv.showErrorDialog()` for PDF save errors, using structured object with `title` and `message` properties
- **translation/service.ts**: Replaced direct `@electron/remote` dialog call with `AppEnv.showErrorDialog()` for language conversion errors, removing unnecessary require statement
- **template-store.ts**: Replaced `@electron/remote` dialog call with `AppEnv.showErrorDialog()` for template creation errors

## Implementation Details
All changes follow the same pattern:
- Old: `dialog.showErrorBox(title, message)`
- New: `AppEnv.showErrorDialog({ title, message })`

This centralizes error dialog handling through the application environment, improving maintainability and reducing direct dependencies on Electron's remote module.

https://claude.ai/code/session_01AnbqFeNC56MFny9d2H5pDR