### PR TITLE
FIx ability to declare platform-specific options via config-schema

### DIFF
--- a/app/internal_packages/preferences/lib/tabs/config-schema-item.tsx
+++ b/app/internal_packages/preferences/lib/tabs/config-schema-item.tsx
@@ -29,7 +29,7 @@ class ConfigSchemaItem extends React.Component<ConfigSchemaItemProps> {
   };
 
   _appliesToPlatform() {
-    if (!this.props.configSchema.platform) {
+    if (!this.props.configSchema.platforms) {
       return true;
     } else if (this.props.configSchema.platforms.indexOf(process.platform) !== -1) {
       return true;

--- a/app/internal_packages/preferences/lib/types.ts
+++ b/app/internal_packages/preferences/lib/types.ts
@@ -14,6 +14,5 @@ export interface ConfigSchemaLike {
   title?: string;
   enum?: string;
   enumLabels: string;
-  platforms: string[];
-  platform: string;
+  platforms?: string[];
 }

--- a/app/src/config-schema.ts
+++ b/app/src/config-schema.ts
@@ -274,9 +274,7 @@ export default {
               'Vietnamese',
             ],
             title: localized('Spellcheck language'),
-            note: localized(
-              'Windows and Linux only - on macOS, the spellcheck language is detected by the system as you type.'
-            ),
+            platforms: ['win32', 'linux'],
           },
         },
       },

--- a/app/src/config-schema.ts
+++ b/app/src/config-schema.ts
@@ -36,9 +36,12 @@ export default {
             type: 'boolean',
             default: true,
             title: localized('Show icon in menu bar / system tray'),
-            note: localized(
-              'On Linux you need to restart Mailspring for the tray icon to disappear.'
-            ),
+            note:
+              process.platform === 'linux'
+                ? localized(
+                    'On Linux you need to restart Mailspring for the tray icon to disappear.'
+                  )
+                : undefined,
           },
           trayIconStyle: {
             type: 'string',


### PR DESCRIPTION
## Summary
This PR refactors how platform-specific configuration options are handled in the preferences system. Instead of using conditional note text, platform restrictions are now declared declaratively using a `platforms` field in the config schema.

## Key Changes
- **config-schema.ts**: 
  - Converted the tray icon note to conditionally render only on Linux using `process.platform` check
  - Replaced the spellcheck language note with a `platforms: ['win32', 'linux']` declaration, removing the macOS-specific note text
  
- **types.ts**: 
  - Made `platforms` field optional (`platforms?: string[]`)
  - Removed unused `platform` field from the `ConfigSchemaLike` interface

- **config-schema-item.tsx**: 
  - Updated `_appliesToPlatform()` method to check `platforms` instead of `platform`
  - Maintains existing logic for filtering config items by platform

## Implementation Details
The changes move toward a more declarative approach where platform applicability is specified in the schema itself rather than embedded in note text. This makes it easier to:
- Programmatically determine which platforms a setting applies to
- Hide irrelevant settings on unsupported platforms
- Maintain cleaner separation between schema metadata and UI text

https://claude.ai/code/session_01C2FVd2MHHHBHciy6rWjX9U