### PR TITLE
Add system accent color support with dynamic theming

### DIFF
--- a/app/internal_packages/activity/styles/dashboard.less
+++ b/app/internal_packages/activity/styles/dashboard.less
@@ -158,7 +158,7 @@
     }
     .column {
       display: inline-block;
-      background: color-mix(in srgb, @accent-primary, transparent 85%);
+      background: rgb(from @accent-primary r g b / 15%);
       border-top: 2px solid @accent-primary;
       transform-origin: bottom;
       transform: scaleY(0.2);

--- a/app/internal_packages/activity/styles/dashboard.less
+++ b/app/internal_packages/activity/styles/dashboard.less
@@ -158,7 +158,7 @@
     }
     .column {
       display: inline-block;
-      background: fadeout(@accent-primary, 85%);
+      background: color-mix(in srgb, @accent-primary, transparent 85%);
       border-top: 2px solid @accent-primary;
       transform-origin: bottom;
       transform: scaleY(0.2);

--- a/app/internal_packages/composer/styles/composer.less
+++ b/app/internal_packages/composer/styles/composer.less
@@ -126,7 +126,7 @@
 
   button {
     cursor: pointer;
-    color: fadeout(mix(@btn-default-text-color, @component-active-color, 88%), 30%);
+    color: color-mix(in srgb, color-mix(in srgb, @btn-default-text-color 88%, @component-active-color), transparent 30%);
     padding: 4px 4.7px;
     border: none;
     background: none;
@@ -136,7 +136,7 @@
     max-width: 32px;
 
     &:hover {
-      color: fadeout(mix(@btn-default-text-color, @component-active-color, 88%), 5%);
+      color: color-mix(in srgb, color-mix(in srgb, @btn-default-text-color 88%, @component-active-color), transparent 5%);
       background: none;
     }
     &.with-select {
@@ -299,11 +299,11 @@ body.platform-win32 {
       white-space: nowrap;
 
       img.content-mask {
-        background-color: fadeout(mix(@btn-default-text-color, @component-active-color, 88%), 30%);
+        background-color: color-mix(in srgb, color-mix(in srgb, @btn-default-text-color 88%, @component-active-color), transparent 30%);
       }
       &:hover {
         img.content-mask {
-          background-color: fadeout(mix(@btn-default-text-color, @component-active-color, 88%), 5%);
+          background-color: color-mix(in srgb, color-mix(in srgb, @btn-default-text-color 88%, @component-active-color), transparent 5%);
         }
       }
       &.btn-enabled {

--- a/app/internal_packages/composer/styles/composer.less
+++ b/app/internal_packages/composer/styles/composer.less
@@ -126,7 +126,7 @@
 
   button {
     cursor: pointer;
-    color: color-mix(in srgb, color-mix(in srgb, @btn-default-text-color 88%, @component-active-color), transparent 30%);
+    color: rgb(from color-mix(in srgb, @btn-default-text-color 88%, @component-active-color) r g b / 70%);
     padding: 4px 4.7px;
     border: none;
     background: none;
@@ -136,7 +136,7 @@
     max-width: 32px;
 
     &:hover {
-      color: color-mix(in srgb, color-mix(in srgb, @btn-default-text-color 88%, @component-active-color), transparent 5%);
+      color: rgb(from color-mix(in srgb, @btn-default-text-color 88%, @component-active-color) r g b / 95%);
       background: none;
     }
     &.with-select {
@@ -299,11 +299,11 @@ body.platform-win32 {
       white-space: nowrap;
 
       img.content-mask {
-        background-color: color-mix(in srgb, color-mix(in srgb, @btn-default-text-color 88%, @component-active-color), transparent 30%);
+        background-color: rgb(from color-mix(in srgb, @btn-default-text-color 88%, @component-active-color) r g b / 70%);
       }
       &:hover {
         img.content-mask {
-          background-color: color-mix(in srgb, color-mix(in srgb, @btn-default-text-color 88%, @component-active-color), transparent 5%);
+          background-color: rgb(from color-mix(in srgb, @btn-default-text-color 88%, @component-active-color) r g b / 95%);
         }
       }
       &.btn-enabled {

--- a/app/internal_packages/main-calendar/styles/main-calendar.less
+++ b/app/internal_packages/main-calendar/styles/main-calendar.less
@@ -193,7 +193,7 @@
 
         &:focus {
           outline: none;
-          box-shadow: 0 0 0 2px fade(@accent-primary, 40%);
+          box-shadow: 0 0 0 2px color-mix(in srgb, transparent, @accent-primary 40%);
         }
       }
 
@@ -308,7 +308,7 @@
 
       &:focus {
         outline: none;
-        box-shadow: 0 0 0 2px fade(@accent-primary, 40%);
+        box-shadow: 0 0 0 2px color-mix(in srgb, transparent, @accent-primary 40%);
       }
     }
   }
@@ -355,7 +355,7 @@
       }
 
       &.active {
-        background-color: fade(@accent-primary, 15%);
+        background-color: color-mix(in srgb, transparent, @accent-primary 15%);
         color: @accent-primary;
       }
 
@@ -467,7 +467,7 @@
       &:focus {
         outline: none;
         border-color: @accent-primary;
-        box-shadow: 0 0 0 2px fade(@accent-primary, 20%);
+        box-shadow: 0 0 0 2px color-mix(in srgb, transparent, @accent-primary 20%);
       }
     }
 

--- a/app/internal_packages/main-calendar/styles/main-calendar.less
+++ b/app/internal_packages/main-calendar/styles/main-calendar.less
@@ -193,7 +193,7 @@
 
         &:focus {
           outline: none;
-          box-shadow: 0 0 0 2px color-mix(in srgb, transparent, @accent-primary 40%);
+          box-shadow: 0 0 0 2px rgb(from @accent-primary r g b / 40%);
         }
       }
 
@@ -308,7 +308,7 @@
 
       &:focus {
         outline: none;
-        box-shadow: 0 0 0 2px color-mix(in srgb, transparent, @accent-primary 40%);
+        box-shadow: 0 0 0 2px rgb(from @accent-primary r g b / 40%);
       }
     }
   }
@@ -355,7 +355,7 @@
       }
 
       &.active {
-        background-color: color-mix(in srgb, transparent, @accent-primary 15%);
+        background-color: rgb(from @accent-primary r g b / 15%);
         color: @accent-primary;
       }
 
@@ -467,7 +467,7 @@
       &:focus {
         outline: none;
         border-color: @accent-primary;
-        box-shadow: 0 0 0 2px color-mix(in srgb, transparent, @accent-primary 20%);
+        box-shadow: 0 0 0 2px rgb(from @accent-primary r g b / 20%);
       }
     }
 

--- a/app/internal_packages/main-calendar/styles/nylas-calendar.less
+++ b/app/internal_packages/main-calendar/styles/nylas-calendar.less
@@ -178,7 +178,7 @@ body.platform-win32 {
         color: @text-color-inverse;
       }
       &:before {
-        background: darken(@accent-primary, 15%);
+        background: color-mix(in srgb, @accent-primary, black 15%);
       }
     }
 
@@ -674,7 +674,7 @@ body.platform-win32 {
         }
 
         &:before {
-          background: darken(@accent-primary, 15%);
+          background: color-mix(in srgb, @accent-primary, black 15%);
         }
       }
 

--- a/app/internal_packages/message-list/styles/message-list.less
+++ b/app/internal_packages/message-list/styles/message-list.less
@@ -584,7 +584,7 @@ body.platform-win32 {
 
 .download-all {
   @download-btn-color: fadeout(#929292, 20%);
-  @download-hover-color: fadeout(@component-active-color, 20%);
+  @download-hover-color: color-mix(in srgb, @component-active-color, transparent 20%);
 
   display: flex;
   align-items: center;

--- a/app/internal_packages/message-list/styles/message-list.less
+++ b/app/internal_packages/message-list/styles/message-list.less
@@ -584,7 +584,7 @@ body.platform-win32 {
 
 .download-all {
   @download-btn-color: fadeout(#929292, 20%);
-  @download-hover-color: color-mix(in srgb, @component-active-color, transparent 20%);
+  @download-hover-color: rgb(from @component-active-color r g b / 80%);
 
   display: flex;
   align-items: center;

--- a/app/internal_packages/preferences/lib/tabs/preferences-appearance.tsx
+++ b/app/internal_packages/preferences/lib/tabs/preferences-appearance.tsx
@@ -369,7 +369,11 @@ class PreferencesAppearance extends React.Component<{ config: ConfigLike; config
         <section>
           <h6 style={{ marginTop: 10 }}>{localized('Theme and Style')}</h6>
           <div style={{ display: 'flex', alignItems: 'center', gap: 20 }}>
-            <button className="btn btn-large" onClick={this.onPickTheme}>
+            <button
+              className="btn btn-large"
+              style={{ flexShrink: 0 }}
+              onClick={this.onPickTheme}
+            >
               {localized('Change Theme...')}
             </button>
             <ConfigSchemaItem

--- a/app/internal_packages/preferences/lib/tabs/preferences-appearance.tsx
+++ b/app/internal_packages/preferences/lib/tabs/preferences-appearance.tsx
@@ -368,18 +368,18 @@ class PreferencesAppearance extends React.Component<{ config: ConfigLike; config
         </section>
         <section>
           <h6 style={{ marginTop: 10 }}>{localized('Theme and Style')}</h6>
-          <div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 20 }}>
             <button className="btn btn-large" onClick={this.onPickTheme}>
               {localized('Change Theme...')}
             </button>
+            <ConfigSchemaItem
+              configSchema={
+                this.props.configSchema.properties.appearance.properties.useSystemAccent
+              }
+              keyPath="core.appearance.useSystemAccent"
+              config={this.props.config}
+            />
           </div>
-          <ConfigSchemaItem
-            configSchema={
-              this.props.configSchema.properties.appearance.properties.useSystemAccent
-            }
-            keyPath="core.appearance.useSystemAccent"
-            config={this.props.config}
-          />
         </section>
         <MenubarStylePicker config={this.props.config} />
         <section>

--- a/app/internal_packages/preferences/lib/tabs/preferences-appearance.tsx
+++ b/app/internal_packages/preferences/lib/tabs/preferences-appearance.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { isWaylandSession } from '../../../../src/browser/is-wayland';
 import SystemTrayIconStore from '../../../system-tray/lib/system-tray-icon-store';
 import { ConfigLike } from '../types';
+import ConfigSchemaItem from './config-schema-item';
 
 class AppearanceScaleSlider extends React.Component<
   { id: string; config: ConfigLike },
@@ -372,6 +373,13 @@ class PreferencesAppearance extends React.Component<{ config: ConfigLike; config
               {localized('Change Theme...')}
             </button>
           </div>
+          <ConfigSchemaItem
+            configSchema={
+              this.props.configSchema.properties.appearance.properties.useSystemAccent
+            }
+            keyPath="core.appearance.useSystemAccent"
+            config={this.props.config}
+          />
         </section>
         <MenubarStylePicker config={this.props.config} />
         <section>

--- a/app/internal_packages/thread-list/styles/thread-list.less
+++ b/app/internal_packages/thread-list/styles/thread-list.less
@@ -383,7 +383,7 @@ body.platform-win32 {
 .thread-list .list-item.selected:hover .list-column-HoverActions .inner {
   background-image: linear-gradient(
     to right,
-    fade(@list-selected-bg, 0%) 0%,
+    rgb(from @list-selected-bg r g b / 0) 0%,
     @list-selected-bg 50%,
     @list-selected-bg 100%
   );
@@ -392,7 +392,7 @@ body.platform-win32 {
 .thread-list .list-item.focused:hover .list-column-HoverActions .inner {
   background-image: linear-gradient(
     to right,
-    fade(@list-focused-bg, 0%) 0%,
+    rgb(from @list-focused-bg r g b / 0) 0%,
     @list-focused-bg 50%,
     @list-focused-bg 100%
   );
@@ -520,7 +520,7 @@ body.platform-win32 {
   .list-item.selected:hover .list-column-HoverActions .inner {
     background-image: linear-gradient(
       to right,
-      fade(@list-focused-bg, 0%) 0%,
+      rgb(from @list-focused-bg r g b / 0) 0%,
       @list-focused-bg 50%,
       @list-focused-bg 100%
     );
@@ -542,8 +542,8 @@ body.is-blurred {
   .thread-list.handler-split {
     .list-item {
       &.selected {
-        background: fadeout(desaturate(@list-focused-bg, 100%), 65%);
-        border-bottom: 1px solid fadeout(desaturate(@list-focused-border, 100%), 65%);
+        background: hsl(from @list-focused-bg h 0% l / 35%);
+        border-bottom: 1px solid hsl(from @list-focused-border h 0% l / 35%);
         color: @text-color;
       }
     }

--- a/app/internal_packages/ui-dark/styles/ui-variables.less
+++ b/app/internal_packages/ui-dark/styles/ui-variables.less
@@ -8,8 +8,10 @@
 @gray-lighter: darken(@gray-base, 92.5%);
 @white: #0a0a0a;
 
-@accent-primary: #58b660;
-@accent-primary-dark: darken(@accent-primary, 10%);
+@accent-primary: var(--system-accent, #58b660);
+// @accent-primary-dark falls through to base/ui-variables.less, which derives
+// it from @accent-primary via color-mix (10% darker). Override here only if
+// a different shade is desired for this theme.
 
 @background-primary: #212121;
 @background-off-primary: #212121;

--- a/app/internal_packages/ui-darkside/styles/ui-variables.less
+++ b/app/internal_packages/ui-darkside/styles/ui-variables.less
@@ -27,7 +27,7 @@
 // @sidebar: #3A1E15;
 // @accent: #F6AA1C;
 
-@accent-primary: @accent;
+@accent-primary: var(--system-accent, @accent);
 @threadlist-bg: #ffffff;
 @messagelist-bg: tint(@sidebar, 95%);
 @active-thread-text: @sidebar;

--- a/app/internal_packages/ui-taiga/styles/ui-variables.less
+++ b/app/internal_packages/ui-taiga/styles/ui-variables.less
@@ -5,8 +5,8 @@
 
 @import 'variables';
 
-@accent-primary: @taiga-light;
-@accent-primary-dark: darken(@taiga-light, 20%);
+@accent-primary: var(--system-accent, @taiga-light);
+@accent-primary-dark: var(--system-accent-dark, color-mix(in srgb, @accent-primary, black 20%));
 
 @background-secondary: @white;
 @text-color: @taiga-dark;

--- a/app/internal_packages/ui-ubuntu/styles/ui-variables.less
+++ b/app/internal_packages/ui-ubuntu/styles/ui-variables.less
@@ -3,8 +3,8 @@
 // `ui-variables` to make their custom CSS react to the current theme.
 @import 'base/ui-variables';
 
-@accent-primary: #f07746;
-@accent-primary-dark: darken(#f07746, 1%);
+@accent-primary: var(--system-accent, #f07746);
+@accent-primary-dark: var(--system-accent-dark, color-mix(in srgb, @accent-primary, black 1%));
 
 @border-color-divider: #e2e2e2;
 @border-color-secondary: lighten(@background-secondary, 10%);

--- a/app/src/browser/application.ts
+++ b/app/src/browser/application.ts
@@ -15,6 +15,7 @@ import ConfigMigrator from './config-migrator';
 import ApplicationMenu from './application-menu';
 import ApplicationTouchBar from './application-touch-bar';
 import AutoUpdateManager from './autoupdate-manager';
+import SystemAccentWatcher from './system-accent-watcher';
 import SystemTrayManager from './system-tray-manager';
 import { DefaultClientHelper } from '../default-client-helper';
 import MailspringProtocolHandler from './mailspring-protocol-handler';
@@ -51,6 +52,7 @@ export default class Application extends EventEmitter {
   mailspringProtocolHandler: MailspringProtocolHandler;
   windowManager: WindowManager;
   autoUpdateManager: AutoUpdateManager;
+  systemAccentWatcher: SystemAccentWatcher;
   systemTrayManager: SystemTrayManager;
   windowsTaskbarManager?: WindowsTaskbarManager;
 
@@ -142,6 +144,10 @@ export default class Application extends EventEmitter {
       initializeInBackground: initializeInBackground,
     });
     this.systemTrayManager = new SystemTrayManager(process.platform, this);
+    this.systemAccentWatcher = new SystemAccentWatcher();
+    this.systemAccentWatcher.on('change', color => {
+      this.windowManager.sendToAllWindows('system-accent-color-changed', {}, color);
+    });
     if (process.platform === 'darwin') {
       this.touchBar = new ApplicationTouchBar(resourcePath);
     }
@@ -598,6 +604,10 @@ export default class Application extends EventEmitter {
     // Theme Error Handling
 
     let userResetTheme = false;
+
+    ipcMain.handle('get-system-accent-color', () => {
+      return this.systemAccentWatcher ? this.systemAccentWatcher.getCurrent() : null;
+    });
 
     ipcMain.on('encountered-theme-error', (event, { message, detail }) => {
       if (userResetTheme) return;

--- a/app/src/browser/system-accent-watcher.ts
+++ b/app/src/browser/system-accent-watcher.ts
@@ -1,0 +1,68 @@
+import { EventEmitter } from 'events';
+import { systemPreferences, nativeTheme } from 'electron';
+
+// macOS posts this Distributed Notification when any of the "color preference"
+// defaults change (accent tint, highlight color). On Win/Linux Electron emits
+// `accent-color-changed` directly on `systemPreferences`.
+const APPLE_COLOR_NOTIFICATION = 'AppleColorPreferencesChangedNotification';
+
+// Normalize Electron's #RRGGBBAA (or platform-specific "rrggbbaa" without #)
+// to #RRGGBB. Returns null when the platform/DE didn't provide a color.
+function normalize(raw: string | null | undefined): string | null {
+  if (!raw) return null;
+  const hex = raw.startsWith('#') ? raw.slice(1) : raw;
+  if (hex.length < 6) return null;
+  return `#${hex.slice(0, 6).toLowerCase()}`;
+}
+
+function readAccent(): string | null {
+  try {
+    return normalize(systemPreferences.getAccentColor());
+  } catch {
+    // getAccentColor throws on platforms (or Linux DEs) where a system accent
+    // isn't exposed. Treat as "no system accent available".
+    return null;
+  }
+}
+
+export default class SystemAccentWatcher extends EventEmitter {
+  private _current: string | null = null;
+  private _macSubscriptionId: number | null = null;
+
+  constructor() {
+    super();
+    this._current = readAccent();
+
+    const refresh = () => {
+      const next = readAccent();
+      if (next === this._current) return;
+      this._current = next;
+      this.emit('change', this._current);
+    };
+
+    // Fires natively on Windows and on Linux (Electron 37+).
+    (systemPreferences as NodeJS.EventEmitter).on('accent-color-changed', refresh);
+
+    if (process.platform === 'darwin') {
+      this._macSubscriptionId = systemPreferences.subscribeNotification(
+        APPLE_COLOR_NOTIFICATION,
+        refresh
+      );
+    }
+
+    // Catch-all: on some desktops accent changes ride along with a theme
+    // change (e.g. switching to dark mode) rather than a dedicated event.
+    nativeTheme.on('updated', refresh);
+  }
+
+  getCurrent(): string | null {
+    return this._current;
+  }
+
+  dispose() {
+    if (this._macSubscriptionId != null) {
+      systemPreferences.unsubscribeNotification(this._macSubscriptionId);
+      this._macSubscriptionId = null;
+    }
+  }
+}

--- a/app/src/config-schema.ts
+++ b/app/src/config-schema.ts
@@ -31,9 +31,6 @@ export default {
             type: 'boolean',
             default: true,
             title: localized('Use system accent color'),
-            note: localized(
-              'Tint the interface with the accent / tint color from your operating system.'
-            ),
           },
         },
       },

--- a/app/src/config-schema.ts
+++ b/app/src/config-schema.ts
@@ -24,6 +24,19 @@ export default {
           },
         },
       },
+      appearance: {
+        type: 'object',
+        properties: {
+          useSystemAccent: {
+            type: 'boolean',
+            default: true,
+            title: localized('Use system accent color'),
+            note: localized(
+              'Tint the interface with the accent / tint color from your operating system.'
+            ),
+          },
+        },
+      },
       workspace: {
         type: 'object',
         properties: {

--- a/app/src/theme-manager.ts
+++ b/app/src/theme-manager.ts
@@ -1,5 +1,5 @@
 import { ipcRenderer } from 'electron';
-import { Emitter } from 'event-kit';
+import { Emitter, Disposable } from 'event-kit';
 import path from 'path';
 import fs from 'fs';
 import { localized } from './intl';
@@ -7,6 +7,15 @@ import LessCompileCache from './less-compile-cache';
 import PackageManager from './package-manager';
 
 const CONFIG_THEME_KEY = 'core.theme';
+const CONFIG_USE_SYSTEM_ACCENT_KEY = 'core.appearance.useSystemAccent';
+const SYSTEM_ACCENT_SOURCE_PATH = 'system-accent:dynamic';
+
+function buildSystemAccentCSS(color: string): string {
+  return `:root {
+  --system-accent: ${color};
+  --system-accent-dark: color-mix(in srgb, ${color}, black 10%);
+}`;
+}
 
 /**
  * The ThemeManager observes the user's theme selection and ensures that
@@ -34,6 +43,9 @@ export default class ThemeManager {
 
   private themeValueCache: { emailTextColor?: string } = {};
 
+  private _systemAccentColor: string | null = null;
+  private _systemAccentDisposable: Disposable | null = null;
+
   constructor({ packageManager, resourcePath, configDirPath, safeMode }) {
     this.packageManager = packageManager;
     this.resourcePath = resourcePath;
@@ -46,6 +58,16 @@ export default class ThemeManager {
     });
 
     AppEnv.config.onDidChange(CONFIG_THEME_KEY, () => this.updateThemePackageAndRecomputeLESS());
+    AppEnv.config.onDidChange(CONFIG_USE_SYSTEM_ACCENT_KEY, () => this.applySystemAccent());
+
+    ipcRenderer.on('system-accent-color-changed', (_event, color: string | null) => {
+      this._systemAccentColor = color;
+      this.applySystemAccent();
+    });
+    ipcRenderer.invoke('get-system-accent-color').then((color: string | null) => {
+      this._systemAccentColor = color;
+      this.applySystemAccent();
+    });
   }
 
   // Called from the onboarding window to disable any custom theme
@@ -153,6 +175,25 @@ export default class ThemeManager {
       paths.unshift(active.getStylesheetsPath());
     }
     return paths;
+  }
+
+  // Writes a <style> tag setting the --system-accent CSS custom properties
+  // when the user opted into system accent and the OS provided a color.
+  // Otherwise removes the tag so per-theme fallbacks in LESS take over.
+  applySystemAccent() {
+    const enabled = AppEnv.config.get(CONFIG_USE_SYSTEM_ACCENT_KEY) !== false;
+    const color = enabled ? this._systemAccentColor : null;
+
+    if (this._systemAccentDisposable) {
+      this._systemAccentDisposable.dispose();
+      this._systemAccentDisposable = null;
+    }
+    if (color) {
+      this._systemAccentDisposable = AppEnv.styles.addStyleSheet(buildSystemAccentCSS(color), {
+        sourcePath: SYSTEM_ACCENT_SOURCE_PATH,
+        priority: 2,
+      });
+    }
   }
 
   // Section: Private

--- a/app/static/style/base/ui-variables.less
+++ b/app/static/style/base/ui-variables.less
@@ -30,8 +30,14 @@
 @blue-light: #009ec4;
 
 //== Color Descriptors
-@accent-primary: @blue;
-@accent-primary-dark: @blue-dark;
+// --system-accent / --system-accent-dark are optionally set at runtime by
+// ThemeManager when the user opts into mirroring the OS tint color. When
+// unset, the fallbacks below are used. We derive @accent-primary-dark from
+// @accent-primary via CSS color-mix() so per-theme overrides of
+// @accent-primary also flow through automatically (LESS resolves @accent-
+// primary lazily to the theme's last declaration).
+@accent-primary: var(--system-accent, @blue);
+@accent-primary-dark: var(--system-accent-dark, color-mix(in srgb, @accent-primary, black 10%));
 
 @background-primary: @white;
 @background-off-primary: #fdfdfd;
@@ -209,8 +215,8 @@
 @list-focused-bg: @component-active-color;
 @list-focused-border: @list-focused-bg;
 @list-selected-color: inherit;
-@list-selected-bg: mix(@component-active-color, @list-bg, 17%);
-@list-selected-border: mix(@component-active-color, @list-bg, 50%);
+@list-selected-bg: color-mix(in srgb, @component-active-color 17%, @list-bg);
+@list-selected-border: color-mix(in srgb, @component-active-color 50%, @list-bg);
 
 //== Notifications
 @background-color-info: @blue-light;

--- a/app/static/style/components/attachment-items.less
+++ b/app/static/style/components/attachment-items.less
@@ -16,7 +16,7 @@
     .file-info-wrap,
     .file-action-icon,
     .file-thumbnail-preview {
-      border-color: lighten(@component-active-color, 10%);
+      border-color: color-mix(in srgb, @component-active-color, white 10%);
     }
     .file-action-icon {
       border-left-color: @attachment-border-color;

--- a/app/static/style/components/contenteditable.less
+++ b/app/static/style/components/contenteditable.less
@@ -111,7 +111,7 @@
       }
       &:hover,
       &:active {
-        color: lighten(@text-color-link, 10%);
+        color: color-mix(in srgb, @text-color-link, white 10%);
         background: transparent;
       }
     }

--- a/app/static/style/components/editable-list.less
+++ b/app/static/style/components/editable-list.less
@@ -16,7 +16,7 @@
     font-size: 0.9em;
 
     .selected {
-      background-color: fade(desaturate(@component-active-color, 100%), 70%);
+      background-color: hsl(from @component-active-color h 0% l / 70%);
       color: @component-active-bg;
     }
 
@@ -33,7 +33,7 @@
         position: absolute;
         top: -1px;
         background-color: @component-active-color;
-        box-shadow: 0 0 1px fade(@component-active-color, 50%);
+        box-shadow: 0 0 1px color-mix(in srgb, transparent, @component-active-color 50%);
       }
     }
 

--- a/app/static/style/components/editable-list.less
+++ b/app/static/style/components/editable-list.less
@@ -33,7 +33,7 @@
         position: absolute;
         top: -1px;
         background-color: @component-active-color;
-        box-shadow: 0 0 1px color-mix(in srgb, transparent, @component-active-color 50%);
+        box-shadow: 0 0 1px rgb(from @component-active-color r g b / 50%);
       }
     }
 

--- a/app/static/style/components/list-tabular.less
+++ b/app/static/style/components/list-tabular.less
@@ -128,14 +128,14 @@ body.is-blurred {
   .list-container {
     .list-item {
       &.selected {
-        background: fadeout(desaturate(@list-selected-bg, 100%), 65%);
-        border-bottom: 1px solid fadeout(desaturate(@list-selected-border, 100%), 65%);
+        background: hsl(from @list-selected-bg h 0% l / 35%);
+        border-bottom: 1px solid hsl(from @list-selected-border h 0% l / 35%);
         color: @text-color;
       }
 
       &.focused {
-        background: fadeout(desaturate(@list-focused-bg, 100%), 65%);
-        border-bottom: 1px solid fadeout(desaturate(@list-focused-border, 100%), 65%);
+        background: hsl(from @list-focused-bg h 0% l / 35%);
+        border-bottom: 1px solid hsl(from @list-focused-border h 0% l / 35%);
         color: @text-color;
       }
     }

--- a/app/static/style/components/mini-month-view.less
+++ b/app/static/style/components/mini-month-view.less
@@ -74,7 +74,7 @@
         background: @accent-primary;
         color: @text-color-inverse;
         &:hover {
-          background: darken(@accent-primary, 5%);
+          background: color-mix(in srgb, @accent-primary, black 5%);
         }
       }
     }

--- a/app/static/style/components/outline-view.less
+++ b/app/static/style/components/outline-view.less
@@ -152,10 +152,10 @@
         background-color: @source-list-active-color;
       }
       .item-action-button {
-        color: fadeout(@source-list-active-color, 30%);
+        color: rgb(from @source-list-active-color r g b / 70%);
         &:hover {
           color: @source-list-active-color;
-          background: fade(@source-list-active-color, 15%);
+          background: rgb(from @source-list-active-color r g b / 15%);
         }
       }
     }

--- a/app/static/style/components/tokenizing-text-field.less
+++ b/app/static/style/components/tokenizing-text-field.less
@@ -107,9 +107,11 @@
     }
     &:hover {
       background: linear-gradient(to bottom, @token-hover-top 0%, @token-hover-bottom 100%);
-      box-shadow: 0 0.5px 0 darken(@token-hover-bottom, 35%),
-        0 -0.5px 0 darken(@token-hover-top, 25%), 0.5px 0 0 darken(@token-hover-bottom, 25%),
-        -0.5px 0 0 darken(@token-hover-bottom, 25%), 0 1px 1px rgba(0, 0, 0, 0.07);
+      box-shadow: 0 0.5px 0 color-mix(in srgb, @token-hover-bottom, black 35%),
+        0 -0.5px 0 color-mix(in srgb, @token-hover-top, black 25%),
+        0.5px 0 0 color-mix(in srgb, @token-hover-bottom, black 25%),
+        -0.5px 0 0 color-mix(in srgb, @token-hover-bottom, black 25%),
+        0 1px 1px rgba(0, 0, 0, 0.07);
       cursor: default;
     }
     &.invalid {
@@ -137,8 +139,8 @@
     &.dragging {
       background: linear-gradient(to bottom, @token-selected-top 0%, @token-selected-bottom 100%);
       box-shadow: inset 0 1.5px 0 rgba(255, 255, 255, 0.3), 0 1px 1px rgba(0, 0, 0, 0.1);
-      border: 1px solid darken(@token-selected-bottom, 8%);
-      border-top: 1px solid darken(@token-selected-top, 10%);
+      border: 1px solid color-mix(in srgb, @token-selected-bottom, black 8%);
+      border-top: 1px solid color-mix(in srgb, @token-selected-top, black 10%);
       border-radius: @border-radius-base;
 
       // Note: we switch from 0.5px borders with box shadows to a real border,

--- a/app/static/style/components/tokenizing-text-field.less
+++ b/app/static/style/components/tokenizing-text-field.less
@@ -3,11 +3,11 @@
 @token-top: lighten(@background-secondary, 0.6%);
 @token-bottom: darken(@background-secondary, 2.5%);
 
-@token-hover-top: mix(@token-top, @component-active-color, 92%);
-@token-hover-bottom: mix(@token-bottom, @component-active-color, 90%);
+@token-hover-top: color-mix(in srgb, @token-top 92%, @component-active-color);
+@token-hover-bottom: color-mix(in srgb, @token-bottom 90%, @component-active-color);
 
-@token-selected-top: mix(@token-top, @component-active-color, 15%);
-@token-selected-bottom: mix(@token-bottom, @component-active-color, 0%);
+@token-selected-top: color-mix(in srgb, @token-top 15%, @component-active-color);
+@token-selected-bottom: color-mix(in srgb, @token-bottom 0%, @component-active-color);
 
 @token-invalid-selected-top: mix(@token-top, red, 60%);
 @token-invalid-selected-bottom: mix(@token-bottom, red, 55%);

--- a/app/static/style/email-frame.less
+++ b/app/static/style/email-frame.less
@@ -126,7 +126,7 @@
   }
 
   a:visited {
-    color: darken(@text-color-link, 10%);
+    color: color-mix(in srgb, @text-color-link, black 10%);
   }
   a img {
     border-bottom: 0;

--- a/app/static/style/mixins/background-variant.less
+++ b/app/static/style/mixins/background-variant.less
@@ -3,6 +3,6 @@
 .bg-variant(@color) {
   background-color: @color;
   &:hover {
-    background-color: darken(@color, 10%);
+    background-color: color-mix(in srgb, @color, black 10%);
   }
 }

--- a/app/static/style/mixins/text-emphasis.less
+++ b/app/static/style/mixins/text-emphasis.less
@@ -3,6 +3,6 @@
 .text-emphasis-variant(@color) {
   color: @color;
   a&:hover {
-    color: darken(@color, 10%);
+    color: color-mix(in srgb, @color, black 10%);
   }
 }


### PR DESCRIPTION
## Summary
This PR adds support for mirroring the operating system's accent/tint color in the application UI. Users can now opt into having the interface automatically tinted with their OS accent color, with fallbacks to per-theme defaults when unavailable.

## Key Changes

- **New SystemAccentWatcher class** (`app/src/browser/system-accent-watcher.ts`): Monitors system accent color changes across platforms
  - Listens to native events on Windows/Linux (`accent-color-changed`)
  - Subscribes to macOS distributed notifications (`AppleColorPreferencesChangedNotification`)
  - Includes fallback theme change detection for edge cases
  - Normalizes platform-specific color formats to consistent `#RRGGBB` format

- **ThemeManager integration**: Dynamically applies system accent colors via CSS custom properties
  - Injects `--system-accent` and `--system-accent-dark` variables when enabled
  - Derives dark variant using `color-mix()` for consistent darkening
  - Respects user preference via new `core.appearance.useSystemAccent` config option (enabled by default)

- **Configuration schema**: Added `useSystemAccent` boolean setting under `core.appearance` with user-facing UI in preferences

- **Preferences UI**: Added toggle in appearance preferences to control system accent usage

- **LESS color function modernization**: Replaced deprecated LESS functions with CSS `color-mix()` equivalents throughout stylesheets
  - `mix()` → `color-mix(in srgb, ...)`
  - `fade()` / `fadeout()` → `color-mix(in srgb, ..., transparent X%)`
  - `darken()` → `color-mix(in srgb, ..., black X%)`
  - `lighten()` → `color-mix(in srgb, ..., white X%)`
  - `desaturate()` → `hsl(from ... h 0% l / ...)`

- **Theme variable updates**: Modified all theme packages to use CSS custom properties for accent colors with fallbacks to theme-specific defaults

## Implementation Details

- System accent color is read on startup and whenever the OS notifies of changes
- The feature gracefully degrades on platforms without system accent support (returns `null`)
- CSS custom properties allow per-theme customization while respecting system preferences
- Priority 2 stylesheet ensures system accent overrides theme defaults but respects user-defined styles
- Proper cleanup via `dispose()` method for macOS notification subscriptions

https://claude.ai/code/session_01APhTLJYGVh6D2FJ9cMown9