### PR TITLE
Replace LESS variable with CSS custom property for font weight

### DIFF
--- a/app/internal_packages/ui-less-is-more/styles/index.less
+++ b/app/internal_packages/ui-less-is-more/styles/index.less
@@ -179,7 +179,7 @@
   .item.selected {
     background: transparent;
     color: @less-text;
-    font-weight: @font-weight-semi-bold;
+    font-weight: var(--font-weight-semi-bold);
   }
 }
 


### PR DESCRIPTION
## Summary
Updated the selected item styling in the ui-less-is-more package to use CSS custom properties instead of LESS variables for the font-weight property.

## Key Changes
- Changed `@font-weight-semi-bold` LESS variable to `var(--font-weight-semi-bold)` CSS custom property in the `.item.selected` selector

## Implementation Details
This change modernizes the styling approach by migrating from LESS variable syntax to CSS custom properties (CSS variables), which provides better runtime flexibility and improved compatibility with dynamic theming systems. The visual appearance remains unchanged as the CSS custom property should be defined with the same value as the original LESS variable.

https://claude.ai/code/session_01EC6xETRFgv45S8sZhKEkTM