### PR TITLE
chore: Drop .map files from distribution

### DIFF
--- a/app/build/tasks/package-task.js
+++ b/app/build/tasks/package-task.js
@@ -204,6 +204,7 @@ module.exports = grunt => {
         /\.gyp/,
         /\.mk/,
         /\.dYSM$/,
+        /\.map$/,
 
         // specific (large) module bits we know we don't need
         /node_modules[/]+less[/]+dist$/,


### PR DESCRIPTION
Noticed while working on fixing the Wayland app_id, `.map` files aren't useful without debug tools and so can be removed to shrink the production image.