### PR TITLE
Use Electron setLoginItemSettings for Windows and macOS startup launch

### DIFF
--- a/app/src/browser/main.js
+++ b/app/src/browser/main.js
@@ -16,7 +16,7 @@ if (typeof process.setFdLimit === 'function') {
   process.setFdLimit(1024);
 }
 
-const setupConfigDir = args => {
+const setupConfigDir = (args) => {
   let dirname = 'Mailspring';
   if (args.devMode) {
     dirname = 'Mailspring-dev';
@@ -24,10 +24,10 @@ const setupConfigDir = args => {
   if (args.specMode) {
     dirname = 'Mailspring-spec';
   }
-  
+
   // Check if a custom config dir was provided via --config-dir-path
   let configDirPath = args.configDirPath || path.join(app.getPath('appData'), dirname);
-  
+
   if (process.platform === 'linux' && process.env.SNAP) {
     // for linux snap, use the sandbox directory that is persisted between snap revisions
     configDirPath = args.configDirPath || process.env.SNAP_USER_COMMON;
@@ -42,7 +42,7 @@ const setupConfigDir = args => {
   return configDirPath;
 };
 
-const setupCompileCache = configDirPath => {
+const setupCompileCache = (configDirPath) => {
   const compileCache = require('../compile-cache');
   return compileCache.setHomeDirectory(configDirPath);
 };
@@ -59,16 +59,13 @@ const setupErrorLogger = (args = {}) => {
   return errorLogger;
 };
 
-const declareOptions = argv => {
+const declareOptions = (argv) => {
   const optimist = require('optimist');
   const options = optimist(argv);
   options.usage(
     `Mailspring\n\nUsage: mailspring [options] [recipient] [attachment]\n\nRun Mailspring: The open source extensible email client\n\n\`mailspring mailto:johndoe@example.com\` to compose an e-mail to johndoe@example.com.\n\`mailspring ./attachment.txt\` to compose an e-mail with a text file attached.\n\`mailspring --dev\` to start the client in dev mode.\n\`mailspring --test\` to run unit tests.`
   );
-  options
-    .alias('d', 'dev')
-    .boolean('d')
-    .describe('d', 'Run in development mode.');
+  options.alias('d', 'dev').boolean('d').describe('d', 'Run in development mode.');
   options
     .alias('t', 'test')
     .boolean('t')
@@ -85,14 +82,8 @@ const declareOptions = argv => {
   options.boolean('enable-crashpad');
   options.boolean('allow-file-access-from-files');
   options.boolean('source-app-id');
-  options
-    .alias('h', 'help')
-    .boolean('h')
-    .describe('h', 'Print this usage message.');
-  options
-    .alias('l', 'log-file')
-    .string('l')
-    .describe('l', 'Log all test output to file.');
+  options.alias('h', 'help').boolean('h').describe('h', 'Print this usage message.');
+  options.alias('l', 'log-file').string('l').describe('l', 'Log all test output to file.');
   options
     .alias('c', 'config-dir-path')
     .string('c')
@@ -108,18 +99,12 @@ const declareOptions = argv => {
       'f',
       'Override the default file regex to determine which tests should run (defaults to "-spec.(js|jsx|es6|es)$" )'
     );
-  options
-    .alias('v', 'version')
-    .boolean('v')
-    .describe('v', 'Print the version.');
-  options
-    .alias('b', 'background')
-    .boolean('b')
-    .describe('b', 'Start Mailspring in the background');
+  options.alias('v', 'version').boolean('v').describe('v', 'Print the version.');
+  options.alias('b', 'background').boolean('b').describe('b', 'Start Mailspring in the background');
   return options;
 };
 
-const parseCommandLine = argv => {
+const parseCommandLine = (argv) => {
   const pkg = require('../../package.json');
   const version = `${pkg.version}-${pkg.commitHash}`;
 
@@ -206,7 +191,7 @@ const parseCommandLine = argv => {
   };
 };
 
-const extractMailtoLink = mailtoLink => {
+const extractMailtoLink = (mailtoLink) => {
   console.log(mailtoLink);
 
   // Handle links in the form mailto:test@example.com?attach=file:///path/to/file.txt
@@ -332,6 +317,15 @@ const start = () => {
   const configDirPath = setupConfigDir(options);
   options.configDirPath = configDirPath;
 
+  // On macOS, setLoginItemSettings doesn't support passing custom args, so we
+  // detect login-item launches via wasOpenedAtLogin and start in background.
+  if (process.platform === 'darwin' && !options.background) {
+    const settings = app.getLoginItemSettings();
+    if (settings.wasOpenedAtLogin) {
+      options.background = true;
+    }
+  }
+
   if (!options.devMode) {
     const gotTheLock = app.requestSingleInstanceLock();
 
@@ -380,7 +374,7 @@ const start = () => {
           .replace('app.asar', 'app.asar.unpacked'),
         { allowFileAccess: true }
       )
-      .catch(err => console.error(`Error loading language detection extension: ${err}`));
+      .catch((err) => console.error(`Error loading language detection extension: ${err}`));
 
     session.defaultSession.webRequest.onBeforeSendHeaders(o365Filter, (details, callback) => {
       delete details.requestHeaders['Origin'];
@@ -405,8 +399,9 @@ const start = () => {
     });
 
     // eslint-disable-next-line
-    const Application = require(path.join(options.resourcePath, 'src', 'browser', 'application'))
-      .default;
+    const Application = require(
+      path.join(options.resourcePath, 'src', 'browser', 'application')
+    ).default;
     global.application = new Application();
     global.application.start(options);
 

--- a/app/src/system-start-service.ts
+++ b/app/src/system-start-service.ts
@@ -68,6 +68,7 @@ class SystemStartServiceWin32 extends SystemStartServiceBase {
     const settings = app.getLoginItemSettings({
       path: this._updateExePath(),
       args: this._loginArgs(),
+      name: app.getName(),
     });
     return Promise.resolve(settings.openAtLogin as boolean);
   }
@@ -78,7 +79,7 @@ class SystemStartServiceWin32 extends SystemStartServiceBase {
       openAtLogin: true,
       path: this._updateExePath(),
       args: this._loginArgs(),
-      name: 'Mailspring',
+      name: app.getName(),
     });
     this._cleanupLegacyShortcut();
   }
@@ -89,7 +90,7 @@ class SystemStartServiceWin32 extends SystemStartServiceBase {
       openAtLogin: false,
       path: this._updateExePath(),
       args: this._loginArgs(),
-      name: 'Mailspring',
+      name: app.getName(),
     });
     this._cleanupLegacyShortcut();
   }

--- a/app/src/system-start-service.ts
+++ b/app/src/system-start-service.ts
@@ -132,7 +132,7 @@ class SystemStartServiceLinux extends SystemStartServiceBase {
   }
 
   doesLaunchOnSystemStart() {
-    return new Promise((resolve) => {
+    return new Promise<boolean>((resolve) => {
       fs.access(this._shortcutPath(), fs.constants.R_OK | fs.constants.W_OK, (err) => {
         if (err) {
           resolve(false);

--- a/app/src/system-start-service.ts
+++ b/app/src/system-start-service.ts
@@ -1,16 +1,13 @@
 import path from 'path';
 import fs from 'fs';
 import os from 'os';
-import { exec } from 'child_process';
-import { shell } from 'electron';
-import { localized } from './intl';
 
 class SystemStartServiceBase {
   checkAvailability(): Promise<boolean> {
     return Promise.resolve(false);
   }
 
-  doesLaunchOnSystemStart() {
+  doesLaunchOnSystemStart(): Promise<boolean> {
     throw new Error('doesLaunchOnSystemStart is not available');
   }
 
@@ -25,134 +22,90 @@ class SystemStartServiceBase {
 
 class SystemStartServiceDarwin extends SystemStartServiceBase {
   checkAvailability() {
-    return new Promise<boolean>(resolve => {
-      fs.access(this._launcherPath(), fs.constants.R_OK | fs.constants.W_OK, err => {
-        if (err) {
-          resolve(false);
-        } else {
-          resolve(true);
-        }
-      });
-    });
+    return Promise.resolve(true);
   }
 
   doesLaunchOnSystemStart() {
-    return new Promise(resolve => {
-      fs.access(this._plistPath(), fs.constants.R_OK | fs.constants.W_OK, err => {
-        if (err) {
-          resolve(false);
-        } else {
-          resolve(true);
-        }
-      });
-    });
+    const app = require('@electron/remote').app;
+    const settings = app.getLoginItemSettings();
+    return Promise.resolve(settings.openAtLogin as boolean);
   }
 
   configureToLaunchOnSystemStart() {
-    fs.mkdir(this._plistDir(), { recursive: true }, err => {
-      if (err) return this._displayError(err);
-
-      fs.writeFile(this._plistPath(), JSON.stringify(this._launchdPlist()), err => {
-        if (err) {
-          this._displayError(err);
-        } else {
-          exec(`plutil -convert xml1 ${this._plistPath()}`);
-        }
-      });
-    });
+    const app = require('@electron/remote').app;
+    app.setLoginItemSettings({ openAtLogin: true });
+    this._cleanupLegacyPlist();
   }
 
   dontLaunchOnSystemStart() {
-    fs.unlink(this._plistPath(), err => {
-      if (err) {
-        this._displayError(err);
-      }
-    });
+    const app = require('@electron/remote').app;
+    app.setLoginItemSettings({ openAtLogin: false });
+    this._cleanupLegacyPlist();
   }
 
-  _displayError(err: Error) {
-    AppEnv.showErrorDialog(
-      localized(
-        'Mailspring was unable to create or delete the LaunchAgent file at %@.',
-        this._plistPath()
-      ) + `\n\n${err.toString()}`
+  _cleanupLegacyPlist() {
+    const plistPath = path.join(
+      process.env.HOME,
+      'Library',
+      'LaunchAgents',
+      'com.mailspring.plist'
     );
-  }
-
-  _launcherPath() {
-    return path.join('/', 'Applications', 'Mailspring.app', 'Contents', 'MacOS', 'Mailspring');
-  }
-
-  _plistPath() {
-    return path.join(process.env.HOME, 'Library', 'LaunchAgents', 'com.mailspring.plist');
-  }
-
-  _plistDir() {
-    return path.join(process.env.HOME, 'Library', 'LaunchAgents');
-  }
-
-  _launchdPlist() {
-    return {
-      Label: 'com.mailspring.mailspring',
-      ProgramArguments: [this._launcherPath(), '--background'],
-      RunAtLoad: true,
-    };
+    fs.unlink(plistPath, () => {});
   }
 }
 
 class SystemStartServiceWin32 extends SystemStartServiceBase {
   checkAvailability() {
-    return new Promise<boolean>(resolve => {
-      fs.access(this._launcherPath(), fs.constants.R_OK | fs.constants.W_OK, err => {
-        if (err) {
-          resolve(false);
-        } else {
-          resolve(true);
-        }
+    return new Promise<boolean>((resolve) => {
+      fs.access(this._updateExePath(), fs.constants.R_OK, (err) => {
+        resolve(!err);
       });
     });
   }
 
   doesLaunchOnSystemStart() {
-    return new Promise(resolve => {
-      fs.access(this._shortcutPath(), fs.constants.R_OK | fs.constants.W_OK, err => {
-        if (err) {
-          resolve(false);
-        } else {
-          resolve(true);
-        }
-      });
+    const app = require('@electron/remote').app;
+    const settings = app.getLoginItemSettings({
+      path: this._updateExePath(),
+      args: this._loginArgs(),
     });
+    return Promise.resolve(settings.openAtLogin as boolean);
   }
 
   configureToLaunchOnSystemStart() {
-    // Use Electron's shell.writeShortcutLink API instead of deprecated windows-shortcuts package
-    // See: https://www.electronjs.org/docs/latest/api/shell#shellwriteshortcutlinkshortcutpath-operation-options-windows
-    try {
-      const success = shell.writeShortcutLink(this._shortcutPath(), 'create', {
-        target: this._launcherPath(),
-        args: '--processStart mailspring.exe --process-start-args "--background"',
-        description: 'An extensible, open-source mail client built on the modern web.',
-        appUserModelId: 'com.squirrel.mailspring.mailspring',
-      });
-      if (!success) {
-        AppEnv.reportError(new Error('Failed to create startup shortcut'));
-      }
-    } catch (err) {
-      AppEnv.reportError(err);
-    }
+    const app = require('@electron/remote').app;
+    app.setLoginItemSettings({
+      openAtLogin: true,
+      path: this._updateExePath(),
+      args: this._loginArgs(),
+      name: 'Mailspring',
+    });
+    this._cleanupLegacyShortcut();
   }
 
   dontLaunchOnSystemStart() {
-    return fs.unlink(this._shortcutPath(), () => {});
+    const app = require('@electron/remote').app;
+    app.setLoginItemSettings({
+      openAtLogin: false,
+      path: this._updateExePath(),
+      args: this._loginArgs(),
+      name: 'Mailspring',
+    });
+    this._cleanupLegacyShortcut();
   }
 
-  _launcherPath() {
-    return path.join(process.env.LOCALAPPDATA, 'mailspring', 'Update.exe');
+  _updateExePath() {
+    const appFolder = path.dirname(process.execPath);
+    return path.resolve(appFolder, '..', 'Update.exe');
   }
 
-  _shortcutPath() {
-    return path.join(
+  _loginArgs() {
+    const exeName = path.basename(process.execPath);
+    return ['--processStart', `"${exeName}"`, '--process-start-args', `"--background"`];
+  }
+
+  _cleanupLegacyShortcut() {
+    const shortcutPath = path.join(
       process.env.APPDATA,
       'Microsoft',
       'Windows',
@@ -161,13 +114,14 @@ class SystemStartServiceWin32 extends SystemStartServiceBase {
       'Startup',
       'Mailspring.lnk'
     );
+    fs.unlink(shortcutPath, () => {});
   }
 }
 
 class SystemStartServiceLinux extends SystemStartServiceBase {
   checkAvailability() {
-    return new Promise<boolean>(resolve => {
-      fs.access(this._launcherPath(), fs.constants.R_OK, err => {
+    return new Promise<boolean>((resolve) => {
+      fs.access(this._launcherPath(), fs.constants.R_OK, (err) => {
         if (err) {
           resolve(false);
         } else {
@@ -178,8 +132,8 @@ class SystemStartServiceLinux extends SystemStartServiceBase {
   }
 
   doesLaunchOnSystemStart() {
-    return new Promise(resolve => {
-      fs.access(this._shortcutPath(), fs.constants.R_OK | fs.constants.W_OK, err => {
+    return new Promise((resolve) => {
+      fs.access(this._shortcutPath(), fs.constants.R_OK | fs.constants.W_OK, (err) => {
         if (err) {
           resolve(false);
         } else {


### PR DESCRIPTION
Replace the fragile Startup-folder .lnk shortcut (Windows) and manual
LaunchAgent plist (macOS) with Electron's built-in setLoginItemSettings API.

Windows: registers via the Registry Run key pointing to Update.exe with
--processStart args, following the documented Electron + Squirrel pattern.
This fixes startup launch failing when the .lnk file is corrupted or
Update.exe cannot be invoked via shortcut, and integrates with Windows 11
Settings > Startup Apps. Uses the `name` parameter so the entry appears as
"Mailspring" in Task Manager instead of "Update".

macOS: uses setLoginItemSettings({ openAtLogin: true }) which integrates
with System Settings > Login Items. Since macOS doesn't support passing
custom args via this API, main.js now checks wasOpenedAtLogin to detect
login-item launches and start in background mode.

Both platforms clean up legacy artifacts (.lnk / plist) on enable/disable
to prevent double-launch on upgrade. Linux is unchanged.

https://claude.ai/code/session_01Sh6QqSZnMxj9YZ4HZyzQ5n