### PR TITLE
Remove Windows toast XML implementation in favor of native notif actions in Electron 41

### DIFF
--- a/app/src/browser/application.ts
+++ b/app/src/browser/application.ts
@@ -25,7 +25,6 @@ import { MailsyncProcess } from '../mailsync-process';
 import Config from '../config';
 import { registerQuickpreviewIPCHandlers } from './quickpreview-ipc';
 import {
-  handleWindowsToastXMLProtocolAction,
   registerNotificationIPCHandlers,
 } from './notification-ipc';
 import WindowsTaskbarManager from './windows-taskbar-manager';
@@ -936,12 +935,7 @@ export default class Application extends EventEmitter {
     if (parts.protocol === 'mailto:') {
       main.sendMessage('mailto', urlToOpen);
     } else if (parts.protocol === 'mailspring:') {
-      // Handle notification action URLs from Windows toast notifications
-      // These URLs are triggered when users click buttons on Windows toast notifications
-      // since Windows toast XML with activationType="background" doesn't work reliably with Electron
-      if (parts.host.startsWith('notification-')) {
-        handleWindowsToastXMLProtocolAction(parts);
-      } else if (parts.host === 'open-inbox') {
+      if (parts.host === 'open-inbox') {
         main.show();
         main.focus();
       } else if (parts.host === 'open-preferences') {

--- a/app/src/browser/notification-ipc.ts
+++ b/app/src/browser/notification-ipc.ts
@@ -1,7 +1,6 @@
 import { Notification, IpcMain, IpcMainInvokeEvent, nativeImage } from 'electron';
 import path from 'path';
 import os from 'os';
-import { UrlWithParsedQuery } from 'url';
 
 interface NotificationOptions {
   id: string;
@@ -17,7 +16,6 @@ interface NotificationOptions {
   actions?: Array<{ type: 'button'; text: string }>;
   urgency?: 'low' | 'normal' | 'critical';
   timeoutType?: 'default' | 'never';
-  toastXml?: string;
 }
 
 // Track active notifications by ID, with metadata for thread-based dismissal
@@ -112,12 +110,14 @@ const displayNotification = (
     silent: true, // App handles sounds separately via SoundRegistry
   };
 
-  // macOS-specific options
-  if (platform === 'darwin') {
-    if (options.subtitle && options.body) {
-      notifOptions.subtitle = options.subtitle;
-      notifOptions.body = options.body;
-    }
+  // macOS supports a separate subtitle field distinct from body
+  if (platform === 'darwin' && options.subtitle && options.body) {
+    notifOptions.subtitle = options.subtitle;
+    notifOptions.body = options.body;
+  }
+
+  // macOS and Windows support inline reply and action buttons natively
+  if (platform === 'darwin' || platform === 'win32') {
     if (options.hasReply) {
       notifOptions.hasReply = true;
       notifOptions.replyPlaceholder = options.replyPlaceholder || 'Reply...';
@@ -137,22 +137,9 @@ const displayNotification = (
     }
   }
 
-  // Windows-specific options
-  if (platform === 'win32') {
-    if (options.toastXml) {
-      notifOptions.toastXml = options.toastXml;
-    } else if (options.timeoutType) {
-      notifOptions.timeoutType = options.timeoutType;
-    }
-  }
-
   const notification = new Notification(notifOptions);
 
   // Handle click event
-  // On Windows with toastXml + activationType="protocol", clicks are routed through
-  // the OS protocol handler (mailspring:// URLs) rather than Electron's Activated callback,
-  // so this event won't fire. We register it anyway as a fallback for non-toastXml
-  // notifications or if protocol activation fails.
   notification.on('click', () => {
     sendToAllWindows('notification:clicked', {
       id: options.id,
@@ -167,7 +154,7 @@ const displayNotification = (
     sendToAllWindows('notification:closed', { id: options.id });
   });
 
-  // Handle reply event (macOS only)
+  // Handle inline reply (macOS and Windows)
   notification.on('reply', (replyEvent, reply) => {
     sendToAllWindows('notification:replied', {
       id: options.id,
@@ -177,7 +164,7 @@ const displayNotification = (
     });
   });
 
-  // Handle action button event (macOS only)
+  // Handle action button event (macOS and Windows)
   notification.on('action', (actionEvent, index) => {
     sendToAllWindows('notification:action', {
       id: options.id,
@@ -224,19 +211,4 @@ const closeNotification = (event: IpcMainInvokeEvent, id: string): void => {
 export function registerNotificationIPCHandlers(ipcMain: IpcMain) {
   ipcMain.handle('notification:display', displayNotification);
   ipcMain.handle('notification:close', closeNotification);
-}
-
-export function handleWindowsToastXMLProtocolAction(parts: UrlWithParsedQuery) {
-  const windowsNotifEventArgs = {
-    id: parts.query.id as string,
-    threadId: parts.query.threadId as string,
-    messageId: parts.query.messageId as string,
-  };
-
-  if (parts.host === 'notification-click') {
-    sendToAllWindows('notification:clicked', windowsNotifEventArgs);
-  } else if (parts.host === 'notification-action') {
-    const actionIndex = parseInt(parts.query.actionIndex as string, 10);
-    sendToAllWindows('notification:action', { ...windowsNotifEventArgs, actionIndex });
-  }
 }

--- a/app/src/native-notifications.ts
+++ b/app/src/native-notifications.ts
@@ -58,7 +58,6 @@ interface IIPCNotificationOptions {
   actions?: Array<{ type: 'button'; text: string }>;
   urgency?: 'low' | 'normal' | 'critical';
   timeoutType?: 'default' | 'never';
-  toastXml?: string;
 }
 
 class NativeNotifications {
@@ -181,20 +180,6 @@ class NativeNotifications {
   }
 
   /**
-   * Safely escape a string for use in XML content using browser DOM APIs.
-   * This handles the full UTF-8 range including Chinese characters and other
-   * international text, as well as any special characters in untrusted email input.
-   */
-  private escapeXml(str: string): string {
-    if (!str) return '';
-    // Use the DOM's XMLSerializer to properly escape text for XML.
-    // Creating a text node and serializing it handles all XML special characters.
-    const doc = document.implementation.createDocument(null, 'root', null);
-    const textNode = doc.createTextNode(str);
-    return new XMLSerializer().serializeToString(textNode);
-  }
-
-  /**
    * Format an array of sender names into a human-readable string.
    * Uses proper English formatting: "X", "X and Y", "X, Y, and Z", "X, Y, and N others"
    *
@@ -213,105 +198,6 @@ class NativeNotifications {
     } else {
       return `${senders[0]}, ${senders[1]}, and ${senders.length - 2} others`;
     }
-  }
-
-  /**
-   * Build Windows toast XML following Microsoft's best practices for email notifications.
-   * See: https://learn.microsoft.com/en-us/windows/apps/design/shell/tiles-and-notifications/adaptive-interactive-toasts
-   *
-   * @param options Notification options
-   * @returns Toast XML string
-   */
-  private buildWindowsToastXml(options: {
-    id: string;
-    title: string;
-    subtitle?: string;
-    body?: string;
-    actions?: Array<{ type: 'button'; text: string }>;
-    threadId?: string;
-    messageId?: string;
-    replyPlaceholder?: string;
-    canReply?: boolean;
-  }): string {
-    // Build URL query parameters for protocol activation
-    // These are used to route actions back through the app's URL handler
-    // We use URLSearchParams for proper URL encoding, then XML-escape the full URL
-    const baseParams = new URLSearchParams({
-      id: options.id,
-      threadId: options.threadId || '',
-      messageId: options.messageId || '',
-    }).toString();
-
-    // Build action buttons XML using protocol activation
-    // Note: Windows supports up to 5 buttons total (including reply button)
-    const actionsContent = (options.actions || [])
-      .map((action, i) => {
-        const actionUrl = `mailspring://notification-action?${baseParams}&actionIndex=${i}`;
-        return `    <action content="${this.escapeXml(action.text)}" arguments="${this.escapeXml(
-          actionUrl
-        )}" activationType="protocol"/>`;
-      })
-      .join('\n');
-
-    const actionsXml = actionsContent ? `  <actions>\n${actionsContent}\n  </actions>` : '';
-
-    // Build the complete toast XML
-    // - hint-maxLines="1" prevents sender name from wrapping
-    // - group attribute enables notification stacking per thread
-    // - activationType="protocol" allows handling when app is closed
-    const clickUrl = `mailspring://notification-click?${baseParams}`;
-    return `<toast launch="${this.escapeXml(
-      clickUrl
-    )}" activationType="protocol" group="thread-${options.threadId || 'default'}">
-  <visual>
-    <binding template="ToastGeneric">
-      <text hint-maxLines="1">${this.escapeXml(options.title)}</text>
-      ${options.subtitle ? `<text>${this.escapeXml(options.subtitle)}</text>` : ''}
-      ${
-        options.body
-          ? `<text hint-style="captionSubtle">${this.escapeXml(options.body)}</text>`
-          : ''
-      }
-    </binding>
-  </visual>
-  <audio silent="true"/>
-${actionsXml}
-</toast>`;
-  }
-
-  /**
-   * Build Windows toast XML for a summary notification (multiple unread messages).
-   * Used when there are 5+ unread messages to avoid notification spam.
-   *
-   * @param count Number of unread messages
-   * @param senders Array of sender names to display
-   * @returns Toast XML string
-   */
-  private buildWindowsSummaryToastXml(id: string, count: number, senders: string[]): string {
-    const sendersText = this.formatSenderList(senders);
-
-    const baseParams = new URLSearchParams({
-      id: id,
-      threadId: '',
-      messageId: '',
-    }).toString();
-
-    const clickUrl = `mailspring://notification-click?${baseParams}`;
-
-    return `<toast launch="${this.escapeXml(clickUrl)}" activationType="protocol">
-  <visual>
-    <binding template="ToastGeneric">
-      <text hint-maxLines="1">${count} new messages</text>
-      ${sendersText ? `<text>${this.escapeXml(sendersText)}</text>` : ''}
-      <text hint-style="captionSubtle">Click to view your inbox</text>
-    </binding>
-  </visual>
-  <audio silent="true"/>
-  <actions>
-    <action content="View Inbox" arguments="${this.escapeXml(clickUrl)}" activationType="protocol"/>
-    <action content="Dismiss" arguments="dismiss" activationType="system"/>
-  </actions>
-</toast>`;
   }
 
   async displayNotification({
@@ -347,8 +233,8 @@ ${actionsXml}
       messageId,
     };
 
-    // macOS-specific features
-    if (platform === 'darwin') {
+    // macOS and Windows support inline reply and action buttons natively
+    if (platform === 'darwin' || platform === 'win32') {
       if (canReply) {
         options.hasReply = true;
         options.replyPlaceholder = replyPlaceholder || 'Reply...';
@@ -356,21 +242,6 @@ ${actionsXml}
       if (actions && actions.length > 0) {
         options.actions = actions;
       }
-    }
-
-    // Windows toast XML for rich notifications with actions and/or reply
-    if (platform === 'win32' && (actions?.length > 0 || canReply)) {
-      options.toastXml = this.buildWindowsToastXml({
-        id,
-        title,
-        subtitle,
-        body,
-        actions,
-        threadId,
-        messageId,
-        canReply,
-        replyPlaceholder,
-      });
     }
 
     try {
@@ -392,7 +263,6 @@ ${actionsXml}
 
   /**
    * Display a summary notification for multiple unread messages.
-   * On Windows, this uses a special toast XML format optimized for summaries.
    *
    * @param count Number of unread messages
    * @param senders Array of sender names (will show up to 3)
@@ -424,11 +294,6 @@ ${actionsXml}
       tag: 'unread-summary',
       icon: this.resolvedIcon,
     };
-
-    // Use special summary toast XML on Windows
-    if (platform === 'win32') {
-      options.toastXml = this.buildWindowsSummaryToastXml(id, count, senders);
-    }
 
     try {
       await ipcRenderer.invoke('notification:display', options);


### PR DESCRIPTION
## Summary
This PR removes the custom Windows toast XML implementation and simplifies notification handling by relying on Electron's native notification API for both macOS and Windows platforms, now that they are available for Windows in Electron 41!

## Key Changes
- **Removed Windows toast XML generation**: Deleted `buildWindowsToastXml()` and `buildWindowsSummaryToastXml()` methods that manually constructed Windows toast notifications
- **Removed XML escaping utility**: Deleted the `escapeXml()` helper method used for XML content sanitization
- **Simplified platform detection**: Updated platform checks to treat macOS and Windows equally for native features (inline reply, action buttons)
- **Removed protocol URL handling**: Deleted `handleWindowsToastXMLProtocolAction()` function and associated `mailspring://notification-*` URL routing logic
- **Removed toastXml option**: Eliminated the `toastXml` field from notification options across both renderer and main process
- **Cleaned up comments**: Updated documentation to reflect that both macOS and Windows now use native notification APIs

## Implementation Details
- Windows notifications now use Electron's native `Notification` API with `hasReply` and `actions` properties instead of custom XML
- Removed the complex URL parameter encoding and protocol activation scheme previously used for Windows toast interactions
- The `notification:reply` and `notification:action` events now handle both platforms uniformly through Electron's standard event handlers
- Simplified the `displayNotification()` method by removing Windows-specific XML building logic
- Removed unused import of `UrlWithParsedQuery` from the url module

This change reduces code complexity and maintenance burden while maintaining feature parity through Electron's cross-platform notification support.

https://claude.ai/code/session_01YRPvfct2JPRFSPHU91sBJi