### PR TITLE
Enable Windows toast notifications by setting CLSID activator

### DIFF
--- a/app/src/browser/main.js
+++ b/app/src/browser/main.js
@@ -272,6 +272,13 @@ const handleStartupEventWithSquirrel = () => {
 };
 
 const start = () => {
+  if (process.platform === 'win32') {
+    // Must be set before setAppUserModelId so RegisterActivator writes it
+    // into the Start Menu shortcut. Without this, action/reply notification
+    // events are silently dropped (COM server is never registered).
+    app.setToastActivatorCLSID('{E6AD16B0-2830-48E7-9DB7-439152FA917B}');
+  }
+
   app.setAppUserModelId('com.squirrel.mailspring.mailspring');
 
   // Set the app name explicitly for Linux to ensure the system tray icon


### PR DESCRIPTION
## Summary
This change enables Windows toast notifications in Mailspring by registering the COM server activator CLSID before setting the app user model ID. This ensures that action and reply notification events are properly handled by the system.

## Key Changes
- Added `app.setToastActivatorCLSID()` call on Windows platform with a specific CLSID (`{E6AD16B0-2830-48E7-9DB7-439152FA917B}`)
- This call is placed before `app.setAppUserModelId()` to ensure the CLSID is written into the Start Menu shortcut
- Platform check ensures this Windows-specific code only runs on `win32`

## Implementation Details
Without setting the toast activator CLSID, Windows silently drops action and reply notification events because the COM server is never registered. By calling `setToastActivatorCLSID()` before `setAppUserModelId()`, the CLSID gets properly written into the Start Menu shortcut, allowing the notification system to function correctly.

https://claude.ai/code/session_01Ru9dNaNhYmCeX4Z5xZHLzk