### PR TITLE
Fix keyboard shortcuts in tree widgets with text inputs

### DIFF
--- a/app/src/keymap-manager.ts
+++ b/app/src/keymap-manager.ts
@@ -34,42 +34,30 @@ mousetrap.prototype.stopCallback = (e, element, combo) => {
   if (e.isPropagationStopped()) {
     return true;
   }
-  // Stop mousetrap from firing global commands when focus is within a tree widget
-  // (e.g. the mailbox outline view), so the tree's own arrow-key navigation works.
-  const withinTree =
-    !!element.closest('[role="tree"]') ||
-    !!element.closest('[data-usesarrowkeys]:has(:focus-visible)');
-
   const withinTextInput =
     element.tagName === 'INPUT' ||
     element.tagName === 'SELECT' ||
     element.tagName === 'TEXTAREA' ||
     element.isContentEditable;
-
-  if (withinTree) {
-    const isPlainKey = !/(mod|command|ctrl)/.test(combo);
-    const isArrowKey = /(left|right|up|down)/.test(combo);
-
-    if (isPlainKey && isArrowKey) {
-      return true; // block so the tree widget handles its own arrow-key navigation
-    }
-    if (withinTextInput && isPlainKey) {
-      // Typing in a text input (e.g. the inline reply composer) inside the tree:
-      // block all plain keys so they type normally, except Escape which must
-      // still fire core:pop-sheet to close the composer.
-      return combo !== 'escape';
-    }
-    // Focus is on a non-text tree row: allow all non-arrow shortcuts to fire
-    // (Gmail-style single-letter shortcuts, Escape, modifier combos, etc.)
-    return false;
-  }
-
   if (withinTextInput) {
     const isPlainKey = !/(mod|command|ctrl)/.test(combo);
     const isReservedTextEditingShortcut = /(mod|command|ctrl)\+(a|x|c|v|left|right)/.test(combo);
     if (isPlainKey || isReservedTextEditingShortcut) {
       return true;
     }
+  }
+
+  // Stop mousetrap from firing global commands when focus is within a tree widget
+  // (e.g. the mailbox outline view), so the tree's own arrow-key navigation works.
+  // withinTextInput runs first so that typing in an inline composer inside the tree
+  // is handled correctly before we apply tree-specific logic.
+  const withinTree =
+    !!element.closest('[role="tree"]') ||
+    !!element.closest('[data-usesarrowkeys]:has(:focus-visible)');
+  if (withinTree) {
+    const isPlainKey = !/(mod|command|ctrl)/.test(combo);
+    const isArrowKey = /(left|right|up|down)/.test(combo);
+    return isPlainKey && isArrowKey;
   }
   return false;
 };

--- a/app/src/keymap-manager.ts
+++ b/app/src/keymap-manager.ts
@@ -39,24 +39,31 @@ mousetrap.prototype.stopCallback = (e, element, combo) => {
   const withinTree =
     !!element.closest('[role="tree"]') ||
     !!element.closest('[data-usesarrowkeys]:has(:focus-visible)');
-  if (withinTree) {
-    const isPlainKey = !/(mod|command|ctrl)/.test(combo);
-    const isArrowKey = /(left|right|up|down)/.test(combo);
-    // Only block plain arrow keys within tree / arrow-key widgets so the
-    // widget's own navigation works. All other keys (Escape, letter keys
-    // for Gmail-style shortcuts, etc.) must pass through – returning false
-    // explicitly so the withinTextInput check below is skipped. Without
-    // the explicit return, non-arrow keys fall through to withinTextInput
-    // and get blocked when focus is on a contentEditable element inside
-    // the widget (e.g. the reply composer within the message list).
-    return isPlainKey && isArrowKey;
-  }
 
   const withinTextInput =
     element.tagName === 'INPUT' ||
     element.tagName === 'SELECT' ||
     element.tagName === 'TEXTAREA' ||
     element.isContentEditable;
+
+  if (withinTree) {
+    const isPlainKey = !/(mod|command|ctrl)/.test(combo);
+    const isArrowKey = /(left|right|up|down)/.test(combo);
+
+    if (isPlainKey && isArrowKey) {
+      return true; // block so the tree widget handles its own arrow-key navigation
+    }
+    if (withinTextInput && isPlainKey) {
+      // Typing in a text input (e.g. the inline reply composer) inside the tree:
+      // block all plain keys so they type normally, except Escape which must
+      // still fire core:pop-sheet to close the composer.
+      return combo !== 'escape';
+    }
+    // Focus is on a non-text tree row: allow all non-arrow shortcuts to fire
+    // (Gmail-style single-letter shortcuts, Escape, modifier combos, etc.)
+    return false;
+  }
+
   if (withinTextInput) {
     const isPlainKey = !/(mod|command|ctrl)/.test(combo);
     const isReservedTextEditingShortcut = /(mod|command|ctrl)\+(a|x|c|v|left|right)/.test(combo);


### PR DESCRIPTION
## Summary
Refactored the keyboard event handling logic in the keymap manager to properly support text input within tree widgets while maintaining correct keyboard shortcut behavior.

## Key Changes
- Reorganized the `stopCallback` logic to evaluate `withinTextInput` before the tree-specific handling, making it available for conditional checks
- Added special handling for text inputs (like inline reply composers) within tree widgets:
  - Plain keys are blocked to allow normal typing behavior
  - Escape key is allowed to pass through so `core:pop-sheet` can close the composer
- Improved code clarity with explicit return statements and detailed comments explaining the three distinct scenarios:
  1. Plain arrow keys in trees (blocked for widget navigation)
  2. Plain keys in text inputs within trees (blocked for typing, except Escape)
  3. Non-arrow shortcuts on tree rows (allowed to fire)

## Implementation Details
The fix addresses a bug where keyboard shortcuts were being incorrectly blocked when focus was on contentEditable elements (like the reply composer) inside tree widgets. By checking `withinTextInput` status before returning from the tree widget branch, we can now distinguish between typing scenarios and shortcut scenarios and handle each appropriately.

https://claude.ai/code/session_01789a5aui3hq6DU7BbnMMgP