### PR TITLE
Added Reply-To field to composer header

### DIFF
--- a/app/internal_packages/composer/lib/composer-header-actions.tsx
+++ b/app/internal_packages/composer/lib/composer-header-actions.tsx
@@ -62,6 +62,21 @@ export default class ComposerHeaderActions extends React.Component<ComposerHeade
       );
     }
 
+    if (!this.props.enabledFields.includes(Fields.ReplyTo)) {
+      items.push(
+        <span
+          className="action show-reply-to"
+          key="replyTo"
+          role="button"
+          tabIndex={-1}
+          onClick={() => this.props.onShowAndFocusField(Fields.ReplyTo)}
+          onKeyDown={this._onKeyDown(() => this.props.onShowAndFocusField(Fields.ReplyTo))}
+        >
+          {localized('Reply-To')}
+        </span>
+      );
+    }
+
     if (!this.props.enabledFields.includes(Fields.Subject)) {
       items.push(
         <span

--- a/app/internal_packages/composer/lib/composer-header.tsx
+++ b/app/internal_packages/composer/lib/composer-header.tsx
@@ -100,6 +100,9 @@ export class ComposerHeader extends React.Component<ComposerHeaderProps, Compose
     if (draft.bcc.length && !enabledFields.find(f => f === Fields.Bcc)) {
       enabledFields = [Fields.Bcc].concat(enabledFields);
     }
+    if (draft.replyTo.length && !enabledFields.find(f => f === Fields.ReplyTo)) {
+      enabledFields = [Fields.ReplyTo].concat(enabledFields);
+    }
     if (enabledFields !== this.state.enabledFields) {
       this.setState({ enabledFields });
     }
@@ -108,7 +111,8 @@ export class ComposerHeader extends React.Component<ComposerHeaderProps, Compose
   _initialStateForDraft(draft, props) {
     const enabledFields = [Fields.To];
     if (draft.cc.length > 0) enabledFields.push(Fields.Cc);
-    if (draft.cc.length > 0) enabledFields.push(Fields.Bcc);
+    if (draft.bcc.length > 0) enabledFields.push(Fields.Bcc);
+    if (draft.replyTo.length > 0) enabledFields.push(Fields.ReplyTo);
     enabledFields.push(Fields.From);
     if (this._shouldEnableSubject()) {
       enabledFields.push(Fields.Subject);
@@ -167,7 +171,7 @@ export class ComposerHeader extends React.Component<ComposerHeaderProps, Compose
   };
 
   _renderFields = () => {
-    const { to, cc, bcc, from } = this.props.draft;
+    const { to, cc, bcc, from, replyTo } = this.props.draft;
 
     // Note: We need to physically add and remove these elements, not just hide them.
     // If they're hidden, shift-tab between fields breaks.
@@ -185,7 +189,7 @@ export class ComposerHeader extends React.Component<ComposerHeaderProps, Compose
         label={localized('To')}
         change={this._onChangeParticipants}
         className="composer-participant-field to-field"
-        participants={{ to, cc, bcc }}
+        participants={{ to, cc, bcc, replyTo }}
         draft={this.props.draft}
         session={this.props.session}
       />
@@ -205,7 +209,7 @@ export class ComposerHeader extends React.Component<ComposerHeaderProps, Compose
           change={this._onChangeParticipants}
           onEmptied={() => this.hideField(Fields.Cc)}
           className="composer-participant-field cc-field"
-          participants={{ to, cc, bcc }}
+          participants={{ to, cc, bcc, replyTo }}
           draft={this.props.draft}
           session={this.props.session}
         />
@@ -226,7 +230,28 @@ export class ComposerHeader extends React.Component<ComposerHeaderProps, Compose
           change={this._onChangeParticipants}
           onEmptied={() => this.hideField(Fields.Bcc)}
           className="composer-participant-field bcc-field"
-          participants={{ to, cc, bcc }}
+          participants={{ to, cc, bcc, replyTo }}
+          draft={this.props.draft}
+          session={this.props.session}
+        />
+      );
+    }
+
+    if (this.state.enabledFields.includes(Fields.ReplyTo)) {
+      fields.push(
+        <ParticipantsTextField
+          ref={el => {
+            if (el) {
+              this._els[Fields.ReplyTo] = el;
+            }
+          }}
+          key="replyTo"
+          field="replyTo"
+          label={localized('Reply-To')}
+          change={this._onChangeParticipants}
+          onEmptied={() => this.hideField(Fields.ReplyTo)}
+          className="composer-participant-field replyto-field"
+          participants={{ to, cc, bcc, replyTo }}
           draft={this.props.draft}
           session={this.props.session}
         />

--- a/app/internal_packages/composer/lib/fields.ts
+++ b/app/internal_packages/composer/lib/fields.ts
@@ -5,6 +5,7 @@ const Fields = {
   From: 'fromField',
   Subject: 'textFieldSubject',
   Body: 'contentBody',
+  ReplyTo: 'textFieldReplyTo',
   ParticipantFields: [],
   Order: {},
 };
@@ -15,6 +16,7 @@ Fields.Order = {
   textFieldTo: 1,
   textFieldCc: 2,
   textFieldBcc: 3,
+  textFieldReplyTo: 4,
   fromField: -1, // Not selectable
   textFieldSubject: 5,
   contentBody: 6,

--- a/app/internal_packages/composer/styles/composer.less
+++ b/app/internal_packages/composer/styles/composer.less
@@ -20,6 +20,7 @@
     color: @text-color;
     outline: none;
     font-family: @font-family-monospace;
+
     &:focus {
       border: none;
       box-shadow: none;
@@ -58,9 +59,11 @@
   color: @text-color-link;
   text-decoration: underline;
 }
+
 .RichEditor-root .custom-block,
 .RichEditor-root .uneditable.custom-block {
   border: 1px dashed transparent;
+
   &.focused {
     border: 1px dashed @text-color;
   }
@@ -73,21 +76,26 @@
   position: relative;
   white-space: normal;
   min-width: 30px;
+
   .uneditable-remove {
     position: absolute;
     display: none;
     right: -5px;
     top: -5px;
     z-index: 2;
+
     &:active {
       filter: brightness(85%);
     }
   }
+
   blockquote {
     color: mix(@text-color, purple, 50%);
   }
+
   &:hover {
     border: 1px dashed @border-color-divider;
+
     .uneditable-remove {
       display: initial;
     }
@@ -139,15 +147,18 @@
       color: rgb(from color-mix(in srgb, @btn-default-text-color 88%, @component-active-color) r g b / 95%);
       background: none;
     }
+
     &.with-select {
       max-width: 100px;
       white-space: nowrap;
+
       select {
         border: none;
         background: none;
         margin: 0;
         min-width: 72px;
         max-width: 92px;
+
         &:active,
         &:focus {
           background-color: @background-primary;
@@ -173,7 +184,8 @@
   .color-picker {
     display: inline-block;
     position: relative;
-    & > button {
+
+    &>button {
       cursor: pointer;
       width: 20px;
       height: 14px;
@@ -196,6 +208,7 @@
       padding: 5px;
       display: flex;
       flex-direction: row;
+
       button {
         max-width: 50px;
       }
@@ -210,9 +223,11 @@ body.platform-win32 {
     .composer-drop-cover {
       border-radius: 0;
     }
+
     .composer-action-bar-wrap {
       border-radius: 0;
     }
+
     input,
     input:focus {
       box-shadow: none;
@@ -265,6 +280,7 @@ body.platform-win32 {
       color: lighten(@gray, 20%);
       font-weight: 500;
       font-size: 1.1em;
+
       img {
         margin: auto;
         display: block;
@@ -301,13 +317,16 @@ body.platform-win32 {
       img.content-mask {
         background-color: rgb(from color-mix(in srgb, @btn-default-text-color 88%, @component-active-color) r g b / 70%);
       }
+
       &:hover {
         img.content-mask {
           background-color: rgb(from color-mix(in srgb, @btn-default-text-color 88%, @component-active-color) r g b / 95%);
         }
       }
+
       &.btn-enabled {
         color: @component-active-color;
+
         img.content-mask {
           background-color: @component-active-color;
         }
@@ -357,6 +376,7 @@ body.platform-win32 {
         .composer-action-bar-plugins {
           opacity: 1;
         }
+
         .action-bar-cover {
           left: 100%;
         }
@@ -389,11 +409,13 @@ body.platform-win32 {
   .composer-body-wrap {
     padding: 0 0 5px 0;
   }
+
   .composer-header {
     .key-commands-region {
       height: initial;
     }
   }
+
   .composer-header-actions {
     position: relative;
     float: right;
@@ -404,22 +426,29 @@ body.platform-win32 {
 
     .action {
       color: @text-color-very-subtle;
+
       img.content-mask {
         background-color: @text-color-very-subtle;
       }
+
       font-size: @font-size-small;
       padding: 10px 6px;
+
       &:first-child {
         padding-left: @spacing-standard;
       }
+
       &:last-child {
         padding-right: 0;
       }
+
       &:hover {
         color: @text-color-link;
+
         img.content-mask {
           background-color: @text-color-link;
         }
+
         cursor: default;
       }
     }
@@ -448,6 +477,7 @@ body.platform-win32 {
     float: left;
     padding-top: 13px;
     display: block;
+
     &:hover {
       cursor: default;
     }
@@ -475,9 +505,11 @@ body.platform-win32 {
       background-color: transparent;
       border: none;
       margin: 0;
+
       &::-webkit-input-placeholder {
         color: @text-color-very-subtle;
       }
+
       &:focus {
         box-shadow: none;
       }
@@ -486,6 +518,7 @@ body.platform-win32 {
 
   .compose-body-scroll {
     position: initial;
+
     .scroll-region-content .scroll-region-content-inner {
       min-height: 100%;
       display: flex;
@@ -510,6 +543,7 @@ body.platform-win32 {
         overflow: hidden;
         padding: 0;
       }
+
       .gmail_quote_attribution {
         height: 0;
         overflow: hidden;
@@ -533,10 +567,12 @@ body.platform-win32 {
         right: -6px;
         top: -6px;
         border-radius: 0 0 0 3px;
+
         &:active {
           background: none;
           filter: brightness(95%);
         }
+
         img {
           height: 24px;
         }
@@ -551,6 +587,7 @@ body.platform-win32 {
   .composer-footer-region {
     padding: 0 22px;
     cursor: default;
+
     &:hover {
       cursor: default;
     }
@@ -606,38 +643,41 @@ body.platform-win32 {
       .btn.btn-toolbar.btn-trash {
         padding-right: 0;
       }
+
       .show-more-fade {
-        background: linear-gradient(
-          to right,
-          fade(@blurred-primary-color, 0%) 0%,
-          fade(@blurred-primary-color, 100%) 40%
-        );
+        background: linear-gradient(to right,
+            fade(@blurred-primary-color, 0%) 0%,
+            fade(@blurred-primary-color, 100%) 40%);
       }
+
       .composer-action-bar-wrap {
         @action-bar-bg: @blurred-off-primary-color;
         background: @action-bar-bg;
         .action-bar-cover-gen;
       }
+
       .RichEditor-toolbar .inner {
         background: @blurred-primary-color;
       }
     }
+
     .message-item-white-wrap.composer-outer-wrap.focused {
       box-shadow: 0 0 0.5px rgba(0, 0, 0, 0.28), 0 1px 1.5px rgba(0, 0, 0, 0.08),
         0 0 3px @accent-primary;
       background-color: @background-primary;
+
       .show-more-fade {
-        background: linear-gradient(
-          to right,
-          fade(@background-primary, 0%) 0%,
-          fade(@background-primary, 100%) 40%
-        );
+        background: linear-gradient(to right,
+            fade(@background-primary, 0%) 0%,
+            fade(@background-primary, 100%) 40%);
       }
+
       .composer-action-bar-wrap {
         @action-bar-bg: @background-off-primary;
         background: @action-bar-bg;
         .action-bar-cover-gen;
       }
+
       .RichEditor-toolbar .inner {
         background: @background-primary;
       }
@@ -658,22 +698,31 @@ body.platform-win32 {
   .tokenizing-field-wrap {
     padding: 0 22px;
   }
+
   .content-container {
     margin-left: 22px;
     width: calc(~'100% - 44px');
   }
+
   .button-dropdown {
     .content-container {
       margin-left: 0;
       width: 100%;
     }
   }
+
   &:after {
     .composer-field-bottom-border;
   }
 
   &.from-field {
     padding: 0 22px;
+  }
+
+  &.replyto-field {
+    .tokenizing-field-input {
+      margin-left: 5.5em;
+    }
   }
 
   .from-single-name {
@@ -691,15 +740,19 @@ body.platform-win32 {
     .only-item {
       line-height: 2em;
     }
+
     &:hover {
+
       .primary-item,
       .only-item {
         border-radius: @border-radius-base;
       }
     }
+
     .secondary-items {
       border-radius: @border-radius-base;
     }
+
     .item {
       .contact.is-alias {
         font-style: italic;
@@ -720,6 +773,7 @@ body.platform-win32 {
     .participant-primary {
       font-weight: @font-weight-semi-bold;
     }
+
     .participant-secondary {
       color: @text-color-very-subtle;
     }
@@ -750,6 +804,7 @@ body.platform-win32 {
     &:first-child {
       padding-left: 0.5em !important;
     }
+
     &.emoji-option,
     &:hover {
       background-color: @btn-emphasis-bg-color;
@@ -763,33 +818,41 @@ body.platform-win32 {
   width: 210px;
   height: 290px;
   overflow: hidden;
+
   .emoji-tabs {
     display: flex;
     flex-direction: row;
     padding: 5px 5px 5px 10px;
     border-bottom: 1px solid @border-color-primary;
     transition: box-shadow 0.5s;
+
     &.shadow {
       box-shadow: @standard-shadow;
     }
+
     .emoji-tab {
       background-color: @gray-light;
+
       &.active {
         background-color: @component-active-color;
       }
     }
   }
+
   .emoji-finder-container {
     height: 232px;
+
     .scrollbar-track {
       background: transparent;
       border-left: none;
       width: 10px;
     }
+
     .emoji-search-container {
       padding: @padding-base-vertical * 1.5 @padding-base-horizontal 0;
     }
   }
+
   .emoji-name {
     height: 25px;
     width: 192px;


### PR DESCRIPTION
**Summary**
Mailspring has no built-in UI for setting a Reply-To header when composing emails. This PR adds a native Reply-To field to the composer header, consistent with how Cc and Bcc are implemented.

**Changes**
fields.ts — Added ReplyTo constant and order position
composer-header.tsx — Added Reply-To field rendering, initial state handling, and _ensureFilledFieldsEnabled support. Also fixed a pre-existing bug where draft.cc was used instead of draft.bcc when checking initial Bcc state
composer-header-actions.tsx — Added Reply-To toggle button to the composer header actions toolbar
composer.less — Added .replyto-field indent adjustment to align with other participant fields

**How it works**
The Message model already has a replyTo field — it just wasn't exposed in the composer UI. This PR wires it up the same way Cc and Bcc are handled. The field is hidden by default and shown when the user clicks Reply-To in the header actions. When emptied it hides itself again.

**Testing**
Open a new compose window
Click Reply-To in the top-right header actions (next to Cc, Bcc)
Type an email address
Send the email and verify the Reply-To: header is present in the received message

**Related**
Originally prototyped as a standalone plugin: https://github.com/Argjend12345/mailspring-reply-to-from