### PR TITLE
Validate system accent color format with strict hex regex

### DIFF
--- a/app/src/browser/system-accent-watcher.ts
+++ b/app/src/browser/system-accent-watcher.ts
@@ -8,11 +8,18 @@ const APPLE_COLOR_NOTIFICATION = 'AppleColorPreferencesChangedNotification';
 
 // Normalize Electron's #RRGGBBAA (or platform-specific "rrggbbaa" without #)
 // to #RRGGBB. Returns null when the platform/DE didn't provide a color.
+//
+// Strictly validates that the value is hex digits only — some Linux DEs
+// return non-hex tokens (empty string, names like "default") that previously
+// passed a length-only check and were spliced into invalid CSS like #defaul,
+// which broke every var(--system-accent, ...) consumer downstream.
+const HEX_ACCENT_RE = /^#?([0-9a-fA-F]{6})(?:[0-9a-fA-F]{2})?$/;
+
 function normalize(raw: string | null | undefined): string | null {
   if (!raw) return null;
-  const hex = raw.startsWith('#') ? raw.slice(1) : raw;
-  if (hex.length < 6) return null;
-  return `#${hex.slice(0, 6).toLowerCase()}`;
+  const match = HEX_ACCENT_RE.exec(raw);
+  if (!match) return null;
+  return `#${match[1].toLowerCase()}`;
 }
 
 function readAccent(): string | null {


### PR DESCRIPTION
## Summary
Improved validation of system accent color values to prevent invalid CSS from being generated when non-hex tokens are provided by the platform or desktop environment.

## Key Changes
- Replaced lenient length-only validation with strict regex pattern (`HEX_ACCENT_RE`) that ensures the color value contains only valid hexadecimal digits
- The regex accepts optional `#` prefix and validates 6 hex digits (RGB) with optional 2 additional digits (alpha channel)
- Updated `normalize()` function to use regex matching instead of string slicing, preventing malformed values like "default" from being truncated to invalid CSS like `#defaul`

## Implementation Details
- New regex pattern: `/^#?([0-9a-fA-F]{6})(?:[0-9a-fA-F]{2})?$/`
  - Optionally matches leading `#`
  - Captures exactly 6 hex digits (required)
  - Optionally matches 2 additional hex digits for alpha channel
- Returns `null` for any non-matching input, preventing downstream CSS variable consumers from receiving malformed color values
- Maintains backward compatibility with both `#RRGGBBAA` (Electron) and `rrggbbaa` (platform-specific) formats

https://claude.ai/code/session_01MCtvu2v8oYKsqTbBw9R3ZA