### PR TITLE
Prevent global shortcuts from firing when focus lands on composer

### DIFF
--- a/app/internal_packages/composer/lib/composer-view.tsx
+++ b/app/internal_packages/composer/lib/composer-view.tsx
@@ -108,8 +108,11 @@ export default class ComposerView extends React.Component<ComposerViewProps, Com
     // so this will autoselect the draft if it has been edited or created in the last 3s.
     const isBrandNew = Date.now() - (date instanceof Date ? date.getTime() : Number(date)) < 3000;
     if (isBrandNew) {
-      (ReactDOM.findDOMNode(this) as HTMLElement).scrollIntoView(false);
-      window.requestAnimationFrame(() => this.focus());
+      const el = ReactDOM.findDOMNode(this) as HTMLElement;
+      window.requestAnimationFrame(() => {
+        el.scrollIntoView(false);
+        this.focus();
+      });
     }
   }
 

--- a/app/internal_packages/message-list/lib/message-list.tsx
+++ b/app/internal_packages/message-list/lib/message-list.tsx
@@ -665,6 +665,14 @@ class MessageListReplyArea extends React.Component<{ onClick: () => void; replyT
     }
   };
 
+  // Prevent the click from moving focus to this placeholder. Otherwise focus
+  // briefly lands here, the placeholder unmounts when the composer mounts in
+  // its place, and the first keystrokes hit `<body>` before the composer's
+  // requestAnimationFrame focus restore can run — firing global shortcuts.
+  _onMouseDown = (e: React.MouseEvent) => {
+    e.preventDefault();
+  };
+
   render() {
     return (
       <div
@@ -672,6 +680,7 @@ class MessageListReplyArea extends React.Component<{ onClick: () => void; replyT
         role="button"
         tabIndex={0}
         onClick={this.props.onClick}
+        onMouseDown={this._onMouseDown}
         onKeyDown={this._onKeyDown}
       >
         <div className="footer-reply-area">

--- a/app/src/keymap-manager.ts
+++ b/app/src/keymap-manager.ts
@@ -34,11 +34,15 @@ mousetrap.prototype.stopCallback = (e, element, combo) => {
   if (e.isPropagationStopped()) {
     return true;
   }
+  // Also treat anything inside an open composer as text input so that focus
+  // landing on composer chrome (footer, attachment area, between recipient
+  // chips, etc.) doesn't let plain keys fall through to global shortcuts.
   const withinTextInput =
     element.tagName === 'INPUT' ||
     element.tagName === 'SELECT' ||
     element.tagName === 'TEXTAREA' ||
-    element.isContentEditable;
+    element.isContentEditable ||
+    !!element.closest('.composer-outer-wrap');
   if (withinTextInput) {
     const isPlainKey = !/(mod|command|ctrl)/.test(combo);
     const isReservedTextEditingShortcut = /(mod|command|ctrl)\+(a|x|c|v|left|right)/.test(combo);


### PR DESCRIPTION
## Summary
This PR fixes an issue where global keyboard shortcuts were being triggered when focus briefly landed on the message reply placeholder before the composer mounted. The fix prevents unwanted focus and keystrokes from reaching global shortcut handlers.

## Key Changes
- **Message List Reply Area**: Added `onMouseDown` handler to prevent focus from moving to the reply placeholder when clicked. This prevents the focus-shift-unmount-keystroke sequence that was triggering global shortcuts.
- **Keymap Manager**: Extended the `stopCallback` logic to treat anything inside an open composer (`.composer-outer-wrap`) as a text input area, preventing plain key presses from triggering global shortcuts when focus lands on composer chrome elements (footer, attachment area, recipient chips, etc.).

## Implementation Details
The fix addresses a timing issue where:
1. User clicks the reply area placeholder
2. Focus moves to the placeholder element
3. The placeholder unmounts as the composer mounts in its place
4. Keystrokes hit `<body>` before the composer's `requestAnimationFrame` focus restoration can run
5. Global shortcuts fire unintentionally

By preventing the initial focus move and treating the entire composer as a text input zone, we ensure that keyboard input is properly scoped to the composer component.

https://claude.ai/code/session_01VDaFRjxCDzxgPXb7WaSXpD