### PR TITLE
Add URL validation to autoupdate handler

### DIFF
--- a/app/src/browser/autoupdate-impl-base.ts
+++ b/app/src/browser/autoupdate-impl-base.ts
@@ -3,6 +3,18 @@ import https from 'https';
 import { shell } from 'electron';
 import url from 'url';
 
+const FALLBACK_DOWNLOAD_URL = 'https://getmailspring.com/download';
+
+function isSafeHttpUrl(value: unknown): value is string {
+  if (typeof value !== 'string') return false;
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === 'https:' || parsed.protocol === 'http:';
+  } catch {
+    return false;
+  }
+}
+
 export default class AutoupdateImplBase extends EventEmitter {
   feedURL: string;
   lastRetrievedUpdateURL?: string;
@@ -63,6 +75,12 @@ export default class AutoupdateImplBase extends EventEmitter {
               this.emitError(new Error(`Autoupdater response did not include URL: ${data}`));
               return;
             }
+            if (!isSafeHttpUrl(json.url)) {
+              this.emitError(
+                new Error(`Autoupdater response URL has disallowed scheme: ${json.url}`)
+              );
+              return;
+            }
             successCallback(json);
           } catch (err) {
             this.emitError(err);
@@ -92,6 +110,9 @@ export default class AutoupdateImplBase extends EventEmitter {
 
   /* Public: Install the update. */
   quitAndInstall() {
-    shell.openExternal(this.lastRetrievedUpdateURL || 'https://getmailspring.com/download');
+    const target = isSafeHttpUrl(this.lastRetrievedUpdateURL)
+      ? this.lastRetrievedUpdateURL
+      : FALLBACK_DOWNLOAD_URL;
+    shell.openExternal(target);
   }
 }

--- a/app/src/browser/autoupdate-impl-base.ts
+++ b/app/src/browser/autoupdate-impl-base.ts
@@ -5,13 +5,14 @@ import url from 'url';
 
 const FALLBACK_DOWNLOAD_URL = 'https://getmailspring.com/download';
 
-function isSafeHttpUrl(value: unknown): value is string {
-  if (typeof value !== 'string') return false;
+function safeHttpUrl(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
   try {
     const parsed = new URL(value);
-    return parsed.protocol === 'https:' || parsed.protocol === 'http:';
+    if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') return null;
+    return parsed.href;
   } catch {
-    return false;
+    return null;
   }
 }
 
@@ -75,12 +76,14 @@ export default class AutoupdateImplBase extends EventEmitter {
               this.emitError(new Error(`Autoupdater response did not include URL: ${data}`));
               return;
             }
-            if (!isSafeHttpUrl(json.url)) {
+            const safeUrl = safeHttpUrl(json.url);
+            if (!safeUrl) {
               this.emitError(
                 new Error(`Autoupdater response URL has disallowed scheme: ${json.url}`)
               );
               return;
             }
+            json.url = safeUrl;
             successCallback(json);
           } catch (err) {
             this.emitError(err);
@@ -110,9 +113,6 @@ export default class AutoupdateImplBase extends EventEmitter {
 
   /* Public: Install the update. */
   quitAndInstall() {
-    const target = isSafeHttpUrl(this.lastRetrievedUpdateURL)
-      ? this.lastRetrievedUpdateURL
-      : FALLBACK_DOWNLOAD_URL;
-    shell.openExternal(target);
+    shell.openExternal(safeHttpUrl(this.lastRetrievedUpdateURL) ?? FALLBACK_DOWNLOAD_URL);
   }
 }


### PR DESCRIPTION
## Summary
This PR adds security validation to the autoupdate mechanism to ensure that only safe HTTP(S) URLs are used when opening external links for updates.

## Key Changes
- Added `isSafeHttpUrl()` utility function to validate that URLs use only `http:` or `https:` protocols
- Added URL validation in the autoupdate response handler to reject responses with disallowed URL schemes
- Updated `quitAndInstall()` to validate the stored update URL before opening it, falling back to the official download page if invalid
- Introduced `FALLBACK_DOWNLOAD_URL` constant for the official Mailspring download page

## Implementation Details
- The `isSafeHttpUrl()` function performs type checking and uses the URL constructor to safely parse and validate the protocol
- Invalid URLs in autoupdate responses now trigger an error emission instead of silently proceeding
- The fallback mechanism ensures users can still access updates even if the stored URL becomes invalid

https://claude.ai/code/session_013pjzNYv18UpJHQn8XCdcZT