### PR TITLE
Fix path traversal vulnerability in protocol handler

### DIFF
--- a/app/src/browser/mailspring-protocol-handler.ts
+++ b/app/src/browser/mailspring-protocol-handler.ts
@@ -35,7 +35,9 @@ export default class MailspringProtocolHandler {
       let filePath = null;
       for (const loadPath of this.loadPaths) {
         const resolvedBase = path.resolve(loadPath);
-        const candidate = path.resolve(resolvedBase, relativePath);
+        // Use path.join (not path.resolve) so absolute-looking inputs like
+        // "/foo" stay anchored to the load path instead of replacing it.
+        const candidate = path.resolve(path.join(resolvedBase, relativePath));
         // Ensure the resolved path is contained within the load path.
         // Append path.sep to prevent prefix-matching attacks (e.g. /packages-evil/).
         if (

--- a/app/src/browser/mailspring-protocol-handler.ts
+++ b/app/src/browser/mailspring-protocol-handler.ts
@@ -34,14 +34,24 @@ export default class MailspringProtocolHandler {
 
       let filePath = null;
       for (const loadPath of this.loadPaths) {
-        filePath = path.join(loadPath, relativePath);
+        const resolvedBase = path.resolve(loadPath);
+        const candidate = path.resolve(resolvedBase, relativePath);
+        // Ensure the resolved path is contained within the load path.
+        // Append path.sep to prevent prefix-matching attacks (e.g. /packages-evil/).
+        if (
+          candidate !== resolvedBase &&
+          !candidate.startsWith(resolvedBase + path.sep)
+        ) {
+          continue;
+        }
         let fileStats: fs.Stats | false = false;
         try {
-          fileStats = fs.statSync(filePath);
+          fileStats = fs.statSync(candidate);
         } catch (e) {
           // path doesn't exist
         }
         if (fileStats && fileStats.isFile && fileStats.isFile()) {
+          filePath = candidate;
           break;
         }
       }


### PR DESCRIPTION
## Summary
This change addresses a path traversal security vulnerability in the Mailspring protocol handler by implementing proper path validation before file access.

## Key Changes
- **Path validation**: Added `path.resolve()` to normalize and validate file paths before attempting to access them
- **Containment check**: Implemented validation to ensure resolved paths are contained within their intended load paths, preventing directory traversal attacks
- **Prefix-matching protection**: Added `path.sep` suffix to prevent prefix-matching attacks (e.g., `/packages-evil/` matching `/packages/`)
- **Deferred assignment**: Moved `filePath` assignment to only occur after successful validation and file existence checks

## Implementation Details
The fix uses `path.resolve()` to normalize both the base load path and the candidate file path, then validates that the candidate path either equals the base path or starts with the base path followed by a path separator. This prevents attackers from using relative path sequences (like `../`) to escape the intended directory. The validation occurs before any filesystem operations, ensuring only safe paths are accessed.

https://claude.ai/code/session_01Xxp6onsCryBaXHhy6kmeMZ