### PR TITLE
Add allowlist validation for IPC window and webcontents methods

### DIFF
--- a/app/src/browser/application.ts
+++ b/app/src/browser/application.ts
@@ -688,15 +688,37 @@ export default class Application extends EventEmitter {
       win.emit(command, ...args);
     });
 
+    const ALLOWED_WINDOW_METHODS = new Set([
+      'setPosition',
+      'center',
+      'focus',
+      'show',
+      'hide',
+      'maximize',
+      'minimize',
+      'setFullScreen',
+    ]);
+    const ALLOWED_WEBCONTENTS_METHODS = new Set(['reload', 'openDevTools', 'toggleDevTools']);
+    const ALLOWED_DEVTOOLS_WEBCONTENTS_METHODS = new Set(['executeJavaScript']);
+
     ipcMain.on('call-window-method', (event, method, ...args) => {
+      if (!ALLOWED_WINDOW_METHODS.has(method)) {
+        console.error(`Method ${method} is not permitted on BrowserWindow!`);
+        return;
+      }
       const win = BrowserWindow.fromWebContents(event.sender);
       if (!win[method]) {
         console.error(`Method ${method} does not exist on BrowserWindow!`);
+        return;
       }
       win[method](...args);
     });
 
     ipcMain.on('call-devtools-webcontents-method', (event, method, ...args) => {
+      if (!ALLOWED_DEVTOOLS_WEBCONTENTS_METHODS.has(method)) {
+        console.error(`Method ${method} is not permitted on devToolsWebContents!`);
+        return;
+      }
       // If devtools aren't open the `webContents::devToolsWebContents` will be null
       if (event.sender.devToolsWebContents) {
         event.sender.devToolsWebContents[method](...args);
@@ -704,8 +726,13 @@ export default class Application extends EventEmitter {
     });
 
     ipcMain.on('call-webcontents-method', (event, method, ...args) => {
+      if (!ALLOWED_WEBCONTENTS_METHODS.has(method)) {
+        console.error(`Method ${method} is not permitted on WebContents!`);
+        return;
+      }
       if (!event.sender[method]) {
         console.error(`Method ${method} does not exist on WebContents!`);
+        return;
       }
       event.sender[method](...args);
     });

--- a/app/src/browser/application.ts
+++ b/app/src/browser/application.ts
@@ -720,9 +720,14 @@ export default class Application extends EventEmitter {
         return;
       }
       // If devtools aren't open the `webContents::devToolsWebContents` will be null
-      if (event.sender.devToolsWebContents) {
-        event.sender.devToolsWebContents[method](...args);
+      if (!event.sender.devToolsWebContents) {
+        return;
       }
+      if (!event.sender.devToolsWebContents[method]) {
+        console.error(`Method ${method} does not exist on devToolsWebContents!`);
+        return;
+      }
+      event.sender.devToolsWebContents[method](...args);
     });
 
     ipcMain.on('call-webcontents-method', (event, method, ...args) => {


### PR DESCRIPTION
## Summary
This change adds security validation to IPC method calls by implementing allowlists for permitted methods on BrowserWindow, WebContents, and DevTools WebContents objects. Previously, any method could be invoked through IPC channels, creating a potential security vulnerability.

## Key Changes
- Added `ALLOWED_WINDOW_METHODS` set containing safe BrowserWindow methods: `setPosition`, `center`, `focus`, `show`, `hide`, `maximize`, `minimize`, and `setFullScreen`
- Added `ALLOWED_WEBCONTENTS_METHODS` set containing safe WebContents methods: `reload`, `openDevTools`, and `toggleDevTools`
- Added `ALLOWED_DEVTOOLS_WEBCONTENTS_METHODS` set containing safe DevTools WebContents methods: `executeJavaScript`
- Added validation checks in all three IPC handlers (`call-window-method`, `call-webcontents-method`, `call-devtools-webcontents-method`) to verify requested methods are in their respective allowlists before execution
- Added early returns on validation failures to prevent method execution
- Added early returns on existence checks to prevent undefined method calls

## Implementation Details
The allowlist approach ensures that only explicitly permitted methods can be invoked through IPC channels, significantly reducing the attack surface for potential privilege escalation or unauthorized system access through renderer process exploitation.

https://claude.ai/code/session_01NEu7HBKyP57J2y3YLJgLJL