### PR TITLE
Improve HTML sanitization in composer on paste

### DIFF
--- a/app/src/components/composer-editor/composer-editor.tsx
+++ b/app/src/components/composer-editor/composer-editor.tsx
@@ -4,7 +4,7 @@ import * as Immutable from 'immutable';
 import { Editor, Value, Operation, Range, Block, Text } from 'slate';
 import { Editor as SlateEditorComponent, EditorProps, Plugin } from 'slate-react';
 import { clipboard as ElectronClipboard } from 'electron';
-import { InlineStyleTransformer } from 'mailspring-exports';
+import { InlineStyleTransformer, SanitizeTransformer } from 'mailspring-exports';
 import os from 'os';
 import path from 'path';
 import fs from 'fs';
@@ -246,6 +246,11 @@ export class ComposerEditor extends React.Component<ComposerEditorProps, Compose
     let html = event.clipboardData.getData('text/html');
 
     if (html) {
+      // Strip event handlers and disallowed tags before any DOM parsing or rendering — the
+      // composer runs with nodeIntegration so an <img onerror=...> in pasted HTML would
+      // execute with full Node access once it lands inside an uneditable block.
+      html = SanitizeTransformer.runSync(html);
+
       // Unfortuantely, pasting HTML requires an synchronous hop through our main process style
       // transfomer. This ensures that we inline styles and preserve as much as possible.
       // (eg: pasting tables from Excel).

--- a/app/src/components/composer-editor/uneditable-plugins.tsx
+++ b/app/src/components/composer-editor/uneditable-plugins.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Editor } from 'slate';
 import { RetinaImg } from 'mailspring-component-kit';
-import { localized } from 'mailspring-exports';
+import { localized, SanitizeTransformer } from 'mailspring-exports';
 import { ComposerEditorPlugin } from './types';
 
 export const UNEDITABLE_TYPE = 'uneditable';
@@ -51,11 +51,16 @@ const rules = [
       const tagName = el.tagName.toLowerCase();
 
       if (UNEDITABLE_TAGS.includes(tagName)) {
+        // The captured HTML is later re-injected via dangerouslySetInnerHTML in
+        // UneditableNode. Because this composer runs in a renderer with nodeIntegration,
+        // any preserved <img onerror=...>, <iframe>, or <script> would execute with Node
+        // access. Sanitize here so every input path (mailto, paste, drag-drop, programmatic)
+        // is covered at the funnel.
         return {
           object: 'block',
           type: UNEDITABLE_TYPE,
           data: {
-            html: el.outerHTML,
+            html: SanitizeTransformer.runSync(el.outerHTML),
           },
           nodes: [],
         };

--- a/app/src/flux/stores/draft-factory.ts
+++ b/app/src/flux/stores/draft-factory.ts
@@ -157,6 +157,7 @@ class DraftFactory {
 
     if (query.body && this.useHTML()) {
       query.body = query.body.replace(/[\n\r]/g, '<br/>');
+      query.body = await SanitizeTransformer.run(query.body);
     }
 
     return this.createDraft(Object.assign(query, await Promise.props(contacts)));

--- a/app/src/services/sanitize-transformer.ts
+++ b/app/src/services/sanitize-transformer.ts
@@ -238,13 +238,17 @@ const AllowedAttributes = [
 ];
 
 class SanitizeTransformer {
-  async run(bodyHTML: string) {
+  runSync(bodyHTML: string) {
     return DOMPurify.sanitize(bodyHTML, {
       ALLOWED_TAGS: AllowedTags,
       ALLOWED_ATTR: AllowedAttributes,
       ALLOWED_URI_REGEXP: /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|sms|cid|xmpp|xxx):|[^a-z]|[a-z+.-]+(?:[^a-z+.\-:]|$))/i,
       KEEP_CONTENT: true,
     });
+  }
+
+  async run(bodyHTML: string) {
+    return this.runSync(bodyHTML);
   }
 }
 

--- a/app/src/services/sanitize-transformer.ts
+++ b/app/src/services/sanitize-transformer.ts
@@ -82,6 +82,7 @@ const AllowedTags = [
   'samp',
   'section',
   'select',
+  'signature',
   'small',
   'source',
   'span',


### PR DESCRIPTION
## Summary
This PR adds HTML sanitization at multiple input points in the composer to prevent malicious code execution. Since the composer runs with Node integration enabled, unescaped HTML containing event handlers (e.g., `<img onerror=...>`) or disallowed tags could execute with full Node access.

## Key Changes
- **uneditable-plugins.tsx**: Sanitize HTML when capturing uneditable blocks before they're stored and later re-injected via `dangerouslySetInnerHTML`
- **composer-editor.tsx**: Sanitize pasted HTML immediately upon paste event, before any DOM parsing or rendering
- **sanitize-transformer.ts**: Add `runSync()` method for synchronous sanitization, with `async run()` now delegating to it
- **draft-factory.ts**: Sanitize body HTML when creating drafts from queries

## Implementation Details
- All sanitization uses the existing `SanitizeTransformer` with configured allowed tags and attributes
- Sanitization is applied at the funnel entry points (paste, drag-drop, programmatic, mailto) to ensure comprehensive coverage
- The synchronous `runSync()` method enables sanitization in contexts where async operations aren't feasible
- Sanitization occurs before any rendering or DOM manipulation to prevent execution of malicious payloads

https://claude.ai/code/session_01KF86APrwYt6tL1LSVL6Fji