### PR TITLE
build.js: add option to skip installer creation

### DIFF
--- a/app/build/build.js
+++ b/app/build/build.js
@@ -463,6 +463,11 @@ async function createRpmInstaller() {
 async function main() {
   await runPackager();
 
+  if (process.argv.includes('--skip-installers')) {
+    console.log('---> Skipping installer creation (--skip-installers flag detected)');
+    return;
+  }
+
   if (platform === 'darwin') {
     await createMacZip();
   } else if (platform === 'linux') {


### PR DESCRIPTION
Adds an option to build.js that allows to skip the creation of installers.
Usage: `npm run build -- --skip-installers`

Makes it easier to reuse the script when packaging for other formats.

This patch is part of a series attempting to upstream the Flatpak patches.