### PR TITLE
Add null check for classList before accessing in SearchableComponentStore

### DIFF
--- a/app/src/flux/stores/searchable-component-store.ts
+++ b/app/src/flux/stores/searchable-component-store.ts
@@ -144,7 +144,7 @@ class SearchableComponentStore extends MailspringStore {
       }
 
       const parentFilter = (node: Element) => {
-        return node.classList.contains('scroll-region-content');
+        return !!node.classList && node.classList.contains('scroll-region-content');
       };
       this.scrollAncestor = DOMUtils.commonAncestor(searchNodes, parentFilter);
       this.scrollAncestor =


### PR DESCRIPTION
## Summary
Added a defensive null check for the `classList` property before attempting to call `contains()` on it in the SearchableComponentStore's parent filter function.

## Key Changes
- Modified the `parentFilter` function to verify that `node.classList` exists before calling `node.classList.contains('scroll-region-content')`
- Changed from `node.classList.contains('scroll-region-content')` to `!!node.classList && node.classList.contains('scroll-region-content')`

## Implementation Details
This change prevents potential runtime errors that could occur if the `parentFilter` function receives a node without a `classList` property. The double negation operator (`!!`) converts the truthy/falsy result to a boolean, maintaining consistent return type behavior while safely guarding against null/undefined classList values.

https://claude.ai/code/session_01TfMisZbhFCcWUP17QUYoGD