### PR TITLE
Improve error logging for empty or malformed error objects

### DIFF
--- a/app/src/browser/application.ts
+++ b/app/src/browser/application.ts
@@ -835,9 +835,21 @@ export default class Application extends EventEmitter {
         // correctly to error reporting tools like Sentry/Raven.
         const message =
           errorParams && typeof errorParams === 'object' ? errorParams.message : undefined;
+        const stack =
+          errorParams && typeof errorParams === 'object' ? errorParams.stack : undefined;
+
+        // Drop reports with neither a message nor a stack: they would surface
+        // in Sentry as "Unknown error" with only this IPC handler frame,
+        // which is unactionable. The renderer wraps inputs before sending so
+        // this is defense-in-depth for any path that bypasses that wrapping.
+        if (!message && !stack) {
+          event.returnValue = true;
+          return;
+        }
+
         const err = new Error(message || undefined);
-        if (errorParams && typeof errorParams === 'object' && errorParams.stack) {
-          err.stack = errorParams.stack;
+        if (stack) {
+          err.stack = stack;
         }
         Object.assign(err, errorParams);
         global.errorLogger.reportError(err, extra);

--- a/app/src/error-logger.js
+++ b/app/src/error-logger.js
@@ -79,8 +79,16 @@ module.exports = ErrorLogger = (function () {
       }
       var wrapped = new Error('Empty error reported (' + description + ')');
       if (error && typeof error === 'object') {
+        // Copy any other useful fields from the original, but never let an
+        // empty `message`/`stack` on the input clobber the wrap's real values
+        // — that would defeat the whole purpose of wrapping.
         try {
-          Object.assign(wrapped, error);
+          var keys = Object.getOwnPropertyNames(error);
+          for (var i = 0; i < keys.length; i++) {
+            var key = keys[i];
+            if (key === 'message' || key === 'stack') continue;
+            wrapped[key] = error[key];
+          }
         } catch (e) {
           // ignore non-assignable inputs
         }

--- a/app/src/error-logger.js
+++ b/app/src/error-logger.js
@@ -70,10 +70,7 @@ module.exports = ErrorLogger = (function () {
     if (!hasMessage && !hasStack) {
       var description;
       try {
-        if (error === undefined) description = 'undefined';
-        else if (error === null) description = 'null';
-        else if (typeof error === 'object') description = JSON.stringify(error);
-        else description = String(error);
+        description = JSON.stringify(error);
       } catch (e) {
         description = Object.prototype.toString.call(error);
       }

--- a/app/src/error-logger.js
+++ b/app/src/error-logger.js
@@ -60,8 +60,32 @@ module.exports = ErrorLogger = (function () {
     if (this.inSpecMode) {
       return;
     }
-    if (!error) {
-      error = { stack: '' };
+    // Without a message and a stack, an error logged to Sentry shows up as
+    // "Unknown error" with only the IPC handler frame, which is unactionable.
+    // Wrap such inputs in a real Error here so we capture the call site as
+    // the stack and describe the original input in the message.
+    var hasMessage =
+      error && typeof error.message === 'string' && error.message.length > 0;
+    var hasStack = error && typeof error.stack === 'string' && error.stack.length > 0;
+    if (!hasMessage && !hasStack) {
+      var description;
+      try {
+        if (error === undefined) description = 'undefined';
+        else if (error === null) description = 'null';
+        else if (typeof error === 'object') description = JSON.stringify(error);
+        else description = String(error);
+      } catch (e) {
+        description = Object.prototype.toString.call(error);
+      }
+      var wrapped = new Error('Empty error reported (' + description + ')');
+      if (error && typeof error === 'object') {
+        try {
+          Object.assign(wrapped, error);
+        } catch (e) {
+          // ignore non-assignable inputs
+        }
+      }
+      error = wrapped;
     }
     if (process.type === 'renderer') {
       var errorJSON = '{}';


### PR DESCRIPTION
## Summary
This PR improves error reporting to Sentry by ensuring that errors without meaningful messages or stack traces are properly wrapped with context about the original input. This prevents "Unknown error" entries in Sentry that only show the IPC handler frame and are difficult to debug.

## Key Changes

- **error-logger.js**: Enhanced error validation and wrapping logic
  - Instead of silently creating an empty error object, now checks for both `message` and `stack` properties
  - When an error lacks both properties, wraps it in a new Error that captures the call site as the stack trace
  - Includes a description of the original input (undefined, null, stringified object, etc.) in the error message
  - Attempts to preserve original error properties via `Object.assign` with graceful fallback

- **application.ts**: Added defensive filtering and improved error handling
  - Extracts both `message` and `stack` from error parameters for validation
  - Drops error reports that have neither a message nor a stack before sending to Sentry
  - Provides defense-in-depth for any code path that might bypass the renderer's error wrapping
  - Simplified stack assignment logic by extracting the stack check

## Implementation Details
Both changes work together to ensure actionable error reports:
1. The renderer (error-logger.js) wraps problematic errors before sending them via IPC
2. The main process (application.ts) validates incoming errors and drops unactionable ones as a safety net
3. This prevents Sentry from being cluttered with "Unknown error" entries that only show framework internals

https://claude.ai/code/session_01MhtXA7SgVZ33aQWwwHvDNn