### PR TITLE
Fix activeMarks access errors in composer editor

### DIFF
--- a/app/src/components/composer-editor/base-mark-plugins.tsx
+++ b/app/src/components/composer-editor/base-mark-plugins.tsx
@@ -6,6 +6,7 @@ import {
   BuildToggleButton,
   BuildColorPicker,
   BuildFontPicker,
+  safeActiveMarks,
 } from './toolbar-component-factories';
 
 import BaseBlockPlugins from './base-block-plugins';
@@ -64,7 +65,7 @@ export const MARK_CONFIG: {
     tagNames: ['b', 'strong'],
     render: (props) => <strong>{props.children}</strong>,
     button: {
-      isActive: (value) => value.activeMarks.some((m) => m.type === MARK_CONFIG.bold.type),
+      isActive: (value) => safeActiveMarks(value).some((m) => m.type === MARK_CONFIG.bold.type),
       onToggle: (editor) => editor.toggleMark(MARK_CONFIG.bold.type),
       iconClass: 'fa fa-bold',
     },
@@ -74,7 +75,7 @@ export const MARK_CONFIG: {
     tagNames: ['em', 'i'],
     render: (props) => <em>{props.children}</em>,
     button: {
-      isActive: (value) => value.activeMarks.some((m) => m.type === MARK_CONFIG.italic.type),
+      isActive: (value) => safeActiveMarks(value).some((m) => m.type === MARK_CONFIG.italic.type),
       onToggle: (editor) => editor.toggleMark(MARK_CONFIG.italic.type),
       iconClass: 'fa fa-italic',
     },
@@ -84,7 +85,8 @@ export const MARK_CONFIG: {
     tagNames: ['u'],
     render: (props) => <u>{props.children}</u>,
     button: {
-      isActive: (value) => value.activeMarks.some((m) => m.type === MARK_CONFIG.underline.type),
+      isActive: (value) =>
+        safeActiveMarks(value).some((m) => m.type === MARK_CONFIG.underline.type),
       onToggle: (editor) => editor.toggleMark(MARK_CONFIG.underline.type),
       iconClass: 'fa fa-underline',
     },
@@ -95,7 +97,7 @@ export const MARK_CONFIG: {
     tagNames: ['strike', 's', 'del'],
     render: (props) => <strike>{props.children}</strike>,
     button: {
-      isActive: (value) => value.activeMarks.some((m) => m.type === MARK_CONFIG.strike.type),
+      isActive: (value) => safeActiveMarks(value).some((m) => m.type === MARK_CONFIG.strike.type),
       onToggle: (editor) => editor.toggleMark(MARK_CONFIG.strike.type),
       iconClass: 'fa fa-strikethrough',
     },

--- a/app/src/components/composer-editor/emoji-plugins.tsx
+++ b/app/src/components/composer-editor/emoji-plugins.tsx
@@ -9,6 +9,7 @@ import {
   ComposerEditorPluginToolbarComponentProps,
 } from './types';
 import EmojiToolbarPopover from './emoji-toolbar-popover';
+import { safeActiveMarks } from './toolbar-component-factories';
 
 let EmojiNameToImageTable = null;
 
@@ -90,7 +91,7 @@ function FloatingEmojiPicker({ editor, value }: ComposerEditorPluginTopLevelComp
   if (!sel.rangeCount) return null;
   const range = sel.getRangeAt(0);
 
-  const emoji = value.activeMarks.find((i) => i.type === EMOJI_TYPING_TYPE);
+  const emoji = safeActiveMarks(value).find((i) => i.type === EMOJI_TYPING_TYPE);
   if (!emoji) return null;
 
   const picked = emoji.data.get('picked');

--- a/app/src/components/composer-editor/link-plugins.tsx
+++ b/app/src/components/composer-editor/link-plugins.tsx
@@ -4,7 +4,7 @@ import { Mark, Editor } from 'slate';
 import AutoReplace from 'slate-auto-replace';
 import { RegExpUtils } from 'mailspring-exports';
 
-import { BuildMarkButtonWithValuePicker } from './toolbar-component-factories';
+import { BuildMarkButtonWithValuePicker, safeActiveMarks } from './toolbar-component-factories';
 import { ComposerEditorPlugin } from './types';
 
 export const LINK_TYPE = 'link';
@@ -23,7 +23,7 @@ function onPaste(event: React.ClipboardEvent, editor: Editor, next: () => void) 
 
 function buildAutoReplaceHandler({ hrefPrefix = '' } = {}) {
   return function (editor: Editor, e, matches) {
-    if (editor.value.activeMarks.find((m) => m.type === LINK_TYPE))
+    if (safeActiveMarks(editor.value).find((m) => m.type === LINK_TYPE))
       return editor.insertText(TriggerKeyValues[e.key]);
 
     const link = matches.before[0];
@@ -109,7 +109,7 @@ const BaseLinkPlugin: ComposerEditorPlugin = {
     if (!['Space', 'Enter', ' ', 'Return'].includes(event.key)) {
       return next();
     }
-    const mark = editor.value.activeMarks.find((m) => m.type === LINK_TYPE);
+    const mark = safeActiveMarks(editor.value).find((m) => m.type === LINK_TYPE);
     if (mark) {
       editor.removeMark(mark);
     }

--- a/app/src/components/composer-editor/toolbar-component-factories.tsx
+++ b/app/src/components/composer-editor/toolbar-component-factories.tsx
@@ -5,6 +5,22 @@ import { ComposerEditorPluginToolbarComponentProps } from './types';
 
 // Helper Functions
 
+// Slate's `value.activeMarks` getter calls `Document.getActiveMarksAtRange`,
+// which can throw "Invalid attempt to destructure non-iterable instance" when
+// the value's selection references a node the document no longer contains
+// (e.g. mid-edit, after a paste, or when a stale value is rendered). We can't
+// fix Slate, so funnel every access through this helper: on throw, fall back
+// to an empty list. `.find` / `.some` work the same on arrays as on the
+// Immutable.Set Slate normally returns, and the next render picks up the
+// correct state once Slate re-normalizes.
+export function safeActiveMarks(value: Value): { find: any; some: any; [key: string]: any } {
+  try {
+    return value.activeMarks as any;
+  } catch (err) {
+    return [] as any;
+  }
+}
+
 export interface IEditorToolbarConfigItem {
   type: string;
   tagNames?: string[];
@@ -24,7 +40,7 @@ export interface IEditorToolbarConfigItem {
 
 function removeMarksOfTypeInRange(editor: Editor, range: Range | Selection, type: string) {
   if (range.isCollapsed) {
-    const active = editor.value.activeMarks.find((m) => m.type === type);
+    const active = safeActiveMarks(editor.value).find((m) => m.type === type);
     if (active) {
       editor.removeMark(active);
     }
@@ -79,14 +95,8 @@ export function expandSelectionToRangeOfMark(editor: Editor, type: string) {
 }
 
 export function getActiveValueForMark(value: Value, type: string) {
-  try {
-    // https://sentry.io/organizations/foundry-376-llc/issues/1076378703
-    // This rarely throws "Invalid attempt to destructure non-iterable instance"
-    const active = value.activeMarks.find((m) => m.type === type);
-    return (active && active.data.get('value')) || '';
-  } catch (err) {
-    return '';
-  }
+  const active = safeActiveMarks(value).find((m) => m.type === type);
+  return (active && active.data.get('value')) || '';
 }
 
 export function applyValueForMark(editor: Editor, type: string, markValue: any) {
@@ -138,7 +148,7 @@ export function BuildMarkButtonWithValuePicker(config) {
 
     onPrompt = (e: React.MouseEvent) => {
       e.preventDefault();
-      const active = this.props.value.activeMarks.find((m) => m.type === config.type);
+      const active = safeActiveMarks(this.props.value).find((m) => m.type === config.type);
       const fieldValue = (active && active.data.get(config.field)) || '';
       this.setState({ expanded: true, fieldValue: fieldValue }, () => {
         setTimeout(() => {
@@ -167,7 +177,7 @@ export function BuildMarkButtonWithValuePicker(config) {
           [config.field]: fieldValue,
         },
       });
-      const active = value.activeMarks.find((m) => m.type === config.type);
+      const active = safeActiveMarks(value).find((m) => m.type === config.type);
       if (active) {
         // update the active mark
         expandSelectionToRangeOfMark(editor, config.type);
@@ -190,7 +200,7 @@ export function BuildMarkButtonWithValuePicker(config) {
     onRemove = (e: React.MouseEvent) => {
       e.preventDefault();
       const { value, editor } = this.props;
-      const active = value.activeMarks.find((m) => m.type === config.type);
+      const active = safeActiveMarks(value).find((m) => m.type === config.type);
       if (value.selection.isCollapsed) {
         const anchorNode = value.document.getNode(value.selection.anchor.key);
         const expanded = value.selection.moveToRangeOfNode(anchorNode);
@@ -210,7 +220,7 @@ export function BuildMarkButtonWithValuePicker(config) {
       const { value, className } = this.props;
       const { expanded } = this.state;
 
-      const active = value.activeMarks.find((m) => m.type === config.type);
+      const active = safeActiveMarks(value).find((m) => m.type === config.type);
       return (
         <div
           className={`${className} link-picker`}

--- a/app/src/components/composer-editor/toolbar-component-factories.tsx
+++ b/app/src/components/composer-editor/toolbar-component-factories.tsx
@@ -13,11 +13,11 @@ import { ComposerEditorPluginToolbarComponentProps } from './types';
 // to an empty list. `.find` / `.some` work the same on arrays as on the
 // Immutable.Set Slate normally returns, and the next render picks up the
 // correct state once Slate re-normalizes.
-export function safeActiveMarks(value: Value): { find: any; some: any; [key: string]: any } {
+export function safeActiveMarks(value: Value): Mark[] {
   try {
-    return value.activeMarks as any;
+    return [...value.activeMarks];
   } catch (err) {
-    return [] as any;
+    return [];
   }
 }
 

--- a/app/src/components/composer-editor/toolbar-component-factories.tsx
+++ b/app/src/components/composer-editor/toolbar-component-factories.tsx
@@ -15,7 +15,7 @@ import { ComposerEditorPluginToolbarComponentProps } from './types';
 // correct state once Slate re-normalizes.
 export function safeActiveMarks(value: Value): Mark[] {
   try {
-    return [...value.activeMarks];
+    return value.activeMarks.toArray();
   } catch (err) {
     return [];
   }


### PR DESCRIPTION
## Summary
Refactored all direct accesses to Slate's `value.activeMarks` property to use a new `safeActiveMarks()` helper function that gracefully handles errors when the selection references stale nodes.

## Problem
Slate's `value.activeMarks` getter can throw "Invalid attempt to destructure non-iterable instance" errors when the value's selection references a node that no longer exists in the document. This occurs during editing operations like pastes or when stale values are rendered mid-normalization.

## Solution
- Created `safeActiveMarks()` helper function that wraps `value.activeMarks` access in a try-catch block, returning an empty array on error
- The empty array is compatible with existing `.find()` and `.some()` calls used throughout the codebase
- Allows the next render to pick up the correct state once Slate re-normalizes

## Changes Made
- **toolbar-component-factories.tsx**: Added `safeActiveMarks()` helper and updated 5 call sites
- **base-mark-plugins.tsx**: Updated 4 `isActive` callbacks for bold, italic, underline, and strike marks
- **link-plugins.tsx**: Updated 2 call sites in auto-replace and key handling logic
- **emoji-plugins.tsx**: Updated 1 call site in floating emoji picker logic

All changes maintain backward compatibility while preventing runtime errors during editor state transitions.

https://claude.ai/code/session_01BLHMy5PCf4JBFtULDTEgpg