### PR TITLE
Improve redaction in mailsync-process to prevent secrets from appearing in connection error detail modal

### DIFF
--- a/app/src/mailsync-process.ts
+++ b/app/src/mailsync-process.ts
@@ -193,6 +193,46 @@ export class MailsyncProcess extends EventEmitter {
     }
   }
 
+  // Redacts known secrets from a log/error string before it's surfaced to
+  // the UI, error reporting, or thrown errors. Two strategies are combined:
+  //
+  // 1. Key-based: replace the value of any known sensitive JSON key (e.g.
+  //    "refresh_token":"abc"). This catches secrets the engine has rotated
+  //    and not yet pushed back to us (e.g. ProcessAccountSecretsUpdated),
+  //    where the new value is not present in this.account.
+  // 2. Value-based: replace literal occurrences of the secrets currently
+  //    cached on this.account, in case they appear outside JSON form.
+  _stripSecrets(text: string) {
+    if (!text) return text;
+    let out = text;
+
+    const SENSITIVE_JSON_KEYS = [
+      'refresh_token',
+      'access_token',
+      'imap_password',
+      'smtp_password',
+    ];
+    for (const key of SENSITIVE_JSON_KEYS) {
+      // Match "key":"<anything-but-unescaped-quote>" allowing escaped quotes inside.
+      const re = new RegExp(`("${key}"\\s*:\\s*")(?:\\\\.|[^"\\\\])*(")`, 'g');
+      out = out.replace(re, '$1*********$2');
+    }
+
+    const cachedSettings = (this.account && this.account.settings) || ({} as any);
+    const cachedValues = [
+      cachedSettings.refresh_token,
+      cachedSettings.imap_password,
+      cachedSettings.smtp_password,
+    ].filter((v): v is string => typeof v === 'string' && v.length > 0);
+
+    const escape = (s: string) => s.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
+    for (const v of cachedValues) {
+      out = out.replace(new RegExp(escape(v), 'g'), '*********');
+    }
+
+    return out;
+  }
+
   _spawnAndWait(mode, { onData }: { onData?: (data: any) => void } = {}) {
     return new Promise<{ response: any; buffer: Buffer }>((resolve, reject) => {
       this._spawnProcess(mode);
@@ -216,21 +256,6 @@ export class MailsyncProcess extends EventEmitter {
       });
 
       this._proc.on('close', (code) => {
-        const stripSecrets = (text: string) => {
-          const settings = (this.account && this.account.settings) || {
-            refresh_token: undefined,
-            imap_password: undefined,
-            smtp_password: undefined,
-          };
-          const { refresh_token, imap_password, smtp_password } = settings;
-
-          const escape = (string: string) => string.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
-          return (text || '')
-            .replace(new RegExp(escape(refresh_token || 'not-present'), 'g'), '*********')
-            .replace(new RegExp(escape(imap_password || 'not-present'), 'g'), '*********')
-            .replace(new RegExp(escape(smtp_password || 'not-present'), 'g'), '*********');
-        };
-
         try {
           const lastLine = buffer.toString('utf-8').split('\n').pop();
 
@@ -241,7 +266,7 @@ export class MailsyncProcess extends EventEmitter {
             // If the Mailsync executable itself failed to run, the logs are not JSON
             // and may contain system errors (shared library issues, etc). Include this
             // in the logs so users can fix on their own or report detailed bugs.
-            const rawLog = stripSecrets(buffer.toString());
+            const rawLog = this._stripSecrets(buffer.toString());
             const error = new Error(
               `${localized(`An unknown error has occurred`)} mailsync: ${code}. ${rawLog}`
             );
@@ -258,11 +283,11 @@ export class MailsyncProcess extends EventEmitter {
               msg = `${msg} (${response.error_service.toUpperCase()})`;
             }
             const error = new Error(msg);
-            (error as any).rawLog = stripSecrets(response.log);
+            (error as any).rawLog = this._stripSecrets(response.log);
             return reject(error);
           }
         } catch (err) {
-          const rawLog = stripSecrets(buffer.toString());
+          const rawLog = this._stripSecrets(buffer.toString());
           const error = new Error(
             `${localized(`An unknown error has occurred`)} (mailsync: ${code})`
           );
@@ -355,7 +380,7 @@ export class MailsyncProcess extends EventEmitter {
       } finally {
         if (lastJSON) {
           if (lastJSON.error) {
-            error = new Error(lastJSON.error);
+            error = new Error(this._stripSecrets(lastJSON.error));
           } else {
             this.emit('deltas', [outBuffer]);
           }
@@ -363,7 +388,7 @@ export class MailsyncProcess extends EventEmitter {
       }
 
       if (errBuffer) {
-        error = new Error(errBuffer);
+        error = new Error(this._stripSecrets(errBuffer));
       }
 
       cleanedUp = true;

--- a/app/src/mailsync-process.ts
+++ b/app/src/mailsync-process.ts
@@ -369,13 +369,13 @@ export class MailsyncProcess extends EventEmitter {
         if (outBuffer.length) {
           // Skip debug output that starts with 'dbg::' prefix
           if (outBuffer.startsWith('dbg::')) {
-            console.log('Skipping debug output from mailsync:', outBuffer);
+            console.log('Skipping debug output from mailsync:', this._stripSecrets(outBuffer));
           } else {
             lastJSON = JSON.parse(outBuffer);
           }
         }
       } catch (parseError) {
-        console.warn('Failed to parse mailsync output as JSON:', outBuffer);
+        console.warn('Failed to parse mailsync output as JSON:', this._stripSecrets(outBuffer));
       } finally {
         if (lastJSON) {
           if (lastJSON.error) {
@@ -434,7 +434,7 @@ export class MailsyncProcess extends EventEmitter {
           if (str.includes('running vacuum')) this._showStatusWindow('vacuum');
         },
       });
-      console.log(buffer.toString());
+      console.log(this._stripSecrets(buffer.toString()));
       this._closeStatusWindow();
     } catch (err) {
       this._closeStatusWindow();

--- a/app/src/mailsync-process.ts
+++ b/app/src/mailsync-process.ts
@@ -225,9 +225,8 @@ export class MailsyncProcess extends EventEmitter {
       cachedSettings.smtp_password,
     ].filter((v): v is string => typeof v === 'string' && v.length > 0);
 
-    const escape = (s: string) => s.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
     for (const v of cachedValues) {
-      out = out.replace(new RegExp(escape(v), 'g'), '*********');
+      out = out.replaceAll(v, '*********');
     }
 
     return out;

--- a/app/src/mailsync-process.ts
+++ b/app/src/mailsync-process.ts
@@ -214,7 +214,7 @@ export class MailsyncProcess extends EventEmitter {
     ];
     for (const key of SENSITIVE_JSON_KEYS) {
       // Match "key":"<anything-but-unescaped-quote>" allowing escaped quotes inside.
-      const re = new RegExp(`("${key}"\\s*:\\s*")(?:\\\\.|[^"\\\\])*(")`, 'g');
+      const re = new RegExp(`("${key}"\\s*:\\s*")(?:\\\\.|[^"\\\\])+(")`, 'g');
       out = out.replace(re, '$1*********$2');
     }
 


### PR DESCRIPTION
## Summary
Refactored and enhanced the secret redaction logic in the mailsync process to better protect sensitive credentials from appearing in UI messages.

## Key Changes
- **Extracted redaction logic**: Moved the inline `stripSecrets` function from the `_spawnAndWait` method into a new `_stripSecrets` instance method for reusability across the class
- **Enhanced redaction strategy**: Implemented a two-pronged approach:
  1. **Key-based redaction**: Uses regex patterns to redact values of known sensitive JSON keys (`refresh_token`, `access_token`, `imap_password`, `smtp_password`) regardless of their current cached values, catching secrets that may have been rotated by the engine
  2. **Value-based redaction**: Continues to redact literal occurrences of cached secret values to handle cases where secrets appear outside JSON form
- **Expanded coverage**: Applied the improved `_stripSecrets` method to additional error paths in the `_spawnAndWait` method and the `_spawnProcess` method, ensuring secrets are redacted in more error scenarios

## Implementation Details
- The regex pattern for key-based redaction (`("key"\s*:\s*")(?:\\.|[^"\\])*(")`  ) properly handles escaped quotes within JSON string values
- Cached values are filtered to only include non-empty strings before attempting redaction
- The escape function properly escapes regex special characters to safely redact literal secret values
- All error messages and logs now consistently use the centralized `_stripSecrets` method

https://claude.ai/code/session_01RUsz543z61nZAxsAEqHruD