### PR TITLE
Allow uppercase letters in package names

### DIFF
--- a/app/src/package-manager.ts
+++ b/app/src/package-manager.ts
@@ -251,7 +251,7 @@ export default class PackageManager {
       return callback(
         new Error(
           localized(
-            `The plugin or theme you selected has an invalid or missing "name" field in its package.json. Names must match /^[a-z0-9._-]+$/.`
+            `The plugin or theme you selected has an invalid or missing "name" field in its package.json. Names must match /^[a-zA-Z0-9._-]+$/.`
           )
         )
       );

--- a/app/src/package.ts
+++ b/app/src/package.ts
@@ -4,7 +4,7 @@ import fs from 'fs';
 class NoPackageJSONError extends Error {}
 class InvalidPackageNameError extends Error {}
 
-const VALID_PACKAGE_NAME = /^[a-z0-9._-]+$/;
+const VALID_PACKAGE_NAME = /^[a-zA-Z0-9._-]+$/;
 
 export function isValidPackageName(name: unknown): name is string {
   return (
@@ -44,7 +44,7 @@ export default class Package {
     this.json = JSON.parse(jsonString);
     if (!isValidPackageName(this.json.name)) {
       throw new InvalidPackageNameError(
-        `Plugin in ${dir} has an invalid or missing "name" field. Names must match /^[a-z0-9._-]+$/.`
+        `Plugin in ${dir} has an invalid or missing "name" field. Names must match /^[a-zA-Z0-9._-]+$/.`
       );
     }
     this.name = this.json.name;


### PR DESCRIPTION
## Summary
Updated the package name validation regex to accept uppercase letters (A-Z) in addition to lowercase letters, allowing for more flexible package naming conventions.

## Changes
- Modified `VALID_PACKAGE_NAME` regex pattern from `/^[a-z0-9._-]+$/` to `/^[a-zA-Z0-9._-]+$/` in `app/src/package.ts`
- Updated error messages in `app/src/package.ts` and `app/src/package-manager.ts` to reflect the new validation pattern

## Details
This change relaxes the package naming constraints to permit camelCase and PascalCase naming conventions, which are common in JavaScript/TypeScript ecosystems. The validation now accepts:
- Lowercase letters (a-z)
- Uppercase letters (A-Z)
- Numbers (0-9)
- Dots, underscores, and hyphens (._-)

Error messages have been updated to accurately reflect the new validation requirements.

https://claude.ai/code/session_01CeqkQ4HBGw1rYVtx83hcfB