### PR TITLE
Fix lint step in CI that was performing fixes, not performing validation

### DIFF
--- a/.github/workflows/build-linux-arm64.yaml
+++ b/.github/workflows/build-linux-arm64.yaml
@@ -49,7 +49,7 @@ jobs:
           aws-region: us-east-1
 
       - name: Lint
-        run: npm run lint
+        run: npm run lint:check
 
       - name: Build
         run: DEBUG=electron-packager npm run build

--- a/.github/workflows/build-linux.yaml
+++ b/.github/workflows/build-linux.yaml
@@ -50,7 +50,7 @@ jobs:
           aws-region: us-east-1
 
       - name: Lint
-        run: npm run lint
+        run: npm run lint:check
 
       - name: Build
         run: DEBUG=electron-packager npm run build

--- a/.github/workflows/build-macos.yaml
+++ b/.github/workflows/build-macos.yaml
@@ -57,7 +57,7 @@ jobs:
           aws-region: us-east-1
 
       - name: Lint
-        run: npm run lint
+        run: npm run lint:check
 
       - name: Build
         run: SIGN_BUILD=true DEBUG=electron-packager,electron-osx-sign,electron-notarize* npm run build

--- a/.github/workflows/build-windows.yaml
+++ b/.github/workflows/build-windows.yaml
@@ -42,7 +42,7 @@ jobs:
           aws-region: us-east-1
 
       - name: Lint
-        run: npm run lint
+        run: npm run lint:check
 
       - name: Build
         run: npm run build

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,7 +37,7 @@ jobs:
         run: npm ci
 
       - name: Run lint
-        run: npm run lint
+        run: npm run lint:check
 
       - name: Run Typecheck
         run: npm run typecheck

--- a/app/internal_packages/composer-signature/lib/signature-account-default-picker.tsx
+++ b/app/internal_packages/composer-signature/lib/signature-account-default-picker.tsx
@@ -1,11 +1,5 @@
 import React from 'react';
-import {
-  localized,
-  Actions,
-  IAliasSet,
-  ISignature,
-  IDefaultSignatures,
-} from 'mailspring-exports';
+import { localized, Actions, IAliasSet, ISignature, IDefaultSignatures } from 'mailspring-exports';
 import { MultiselectDropdown } from 'mailspring-component-kit';
 
 interface SignatureAccountDefaultPickerProps {

--- a/app/internal_packages/composer-signature/lib/signature-utils.ts
+++ b/app/internal_packages/composer-signature/lib/signature-utils.ts
@@ -42,7 +42,10 @@ export function currentSignatureId(body: string) {
   return signatureMatch && signatureMatch[1];
 }
 
-export function applySignature(body: string, signature: { id: string; body: string } | null | undefined) {
+export function applySignature(
+  body: string,
+  signature: { id: string; body: string } | null | undefined
+) {
   // Remove any existing signature in the body
   let additionalWhitespace = '<br/>';
 

--- a/app/internal_packages/composer/lib/composer-view.tsx
+++ b/app/internal_packages/composer/lib/composer-view.tsx
@@ -172,7 +172,9 @@ export default class ComposerView extends React.Component<ComposerViewProps, Com
                   propsForPlugins={{ draft, session }}
                   onFileReceived={this._onFileReceived}
                   onUpdatedSlateEditor={(editor) => session.setMountedEditor(editor)}
-                  onDrop={(e) => this.dropzone.current._onDrop(e as React.DragEvent<HTMLDivElement>)}
+                  onDrop={(e) =>
+                    this.dropzone.current._onDrop(e as React.DragEvent<HTMLDivElement>)
+                  }
                   onChange={(change) => {
                     // We minimize thrashing and support editors in multiple windows by ensuring
                     // non-value changes (eg focus) to the editorState don't trigger database saves
@@ -241,7 +243,10 @@ export default class ComposerView extends React.Component<ComposerViewProps, Com
   }
 
   _onMouseUpComposerBody = (event: React.MouseEvent<HTMLDivElement>) => {
-    if (event.target === this._mouseDownTarget && !this._inFooterRegion(event.target as HTMLElement)) {
+    if (
+      event.target === this._mouseDownTarget &&
+      !this._inFooterRegion(event.target as HTMLElement)
+    ) {
       // We don't set state directly here because we want the native
       // contenteditable focus behavior. When the contenteditable gets focused
       const bodyRect = (

--- a/app/internal_packages/contacts/specs/vcf-helpers-spec.ts
+++ b/app/internal_packages/contacts/specs/vcf-helpers-spec.ts
@@ -410,9 +410,7 @@ describe('parseName', function () {
 
 describe('formatDisplayName', function () {
   it('concatenates givenName and familyName with a space', () => {
-    expect(formatDisplayName({ givenName: 'John', familyName: 'Smith' } as any)).toBe(
-      'John Smith'
-    );
+    expect(formatDisplayName({ givenName: 'John', familyName: 'Smith' } as any)).toBe('John Smith');
   });
 
   it('returns only familyName when givenName is empty', () => {

--- a/app/internal_packages/link-tracking/lib/link-tracking-composer-extension.ts
+++ b/app/internal_packages/link-tracking/lib/link-tracking-composer-extension.ts
@@ -1,7 +1,16 @@
-import { ComposerExtension, RegExpUtils, FeatureUsageStore, Message, Contact } from 'mailspring-exports';
+import {
+  ComposerExtension,
+  RegExpUtils,
+  FeatureUsageStore,
+  Message,
+  Contact,
+} from 'mailspring-exports';
 import { PLUGIN_ID, PLUGIN_URL } from './link-tracking-constants';
 
-function forEachATagInBody(draftBodyRootNode: HTMLElement, callback: (el: HTMLAnchorElement) => void) {
+function forEachATagInBody(
+  draftBodyRootNode: HTMLElement,
+  callback: (el: HTMLAnchorElement) => void
+) {
   const treeWalker = document.createTreeWalker(draftBodyRootNode, NodeFilter.SHOW_ELEMENT, {
     acceptNode: (node: HTMLElement) => {
       if (node.classList.contains('gmail_quote')) {
@@ -38,7 +47,15 @@ export default class LinkTrackingComposerExtension extends ComposerExtension {
     return !draft.plaintext && !!draft.metadataForPluginId(PLUGIN_ID);
   }
 
-  static applyTransformsForSending({ draftBodyRootNode, draft, recipient }: { draftBodyRootNode: HTMLElement; draft: Message; recipient?: Contact }) {
+  static applyTransformsForSending({
+    draftBodyRootNode,
+    draft,
+    recipient,
+  }: {
+    draftBodyRootNode: HTMLElement;
+    draft: Message;
+    recipient?: Contact;
+  }) {
     if (draft.plaintext) {
       return;
     }

--- a/app/internal_packages/list-unsubscribe/specs/unsubscribe-service-spec.ts
+++ b/app/internal_packages/list-unsubscribe/specs/unsubscribe-service-spec.ts
@@ -12,8 +12,7 @@ import {
 describe('parseListUnsubscribeHeader', function () {
   describe('standard valid headers', () => {
     it('parses a header with both mailto and https URIs', () => {
-      const header =
-        '<mailto:unsubscribe@example.com>, <https://example.com/unsub>';
+      const header = '<mailto:unsubscribe@example.com>, <https://example.com/unsub>';
       const result = parseListUnsubscribeHeader(header);
       expect(result.length).toBe(2);
       expect(result[0]).toEqual({ type: 'mailto', uri: 'mailto:unsubscribe@example.com' });
@@ -35,9 +34,7 @@ describe('parseListUnsubscribeHeader', function () {
       const result = parseListUnsubscribeHeader(header);
       expect(result.length).toBe(1);
       expect(result[0].type).toBe('mailto');
-      expect(result[0].uri).toBe(
-        'mailto:list-unsub@newsletter.example.com?subject=unsubscribe'
-      );
+      expect(result[0].uri).toBe('mailto:list-unsub@newsletter.example.com?subject=unsubscribe');
     });
 
     it('parses a header with an http URI', () => {

--- a/app/internal_packages/preferences/lib/tabs/sending-section.tsx
+++ b/app/internal_packages/preferences/lib/tabs/sending-section.tsx
@@ -28,11 +28,7 @@ function getExtendedSendingSchema(configSchema) {
   return configSchema.properties.sending;
 }
 
-function SendingSection(props: {
-  config?: any;
-  configSchema?: any;
-  sendingConfigSchema?: any;
-}) {
+function SendingSection(props: { config?: any; configSchema?: any; sendingConfigSchema?: any }) {
   const { config, sendingConfigSchema } = props;
 
   return (

--- a/app/internal_packages/send-reminders/lib/send-reminders-utils.ts
+++ b/app/internal_packages/send-reminders/lib/send-reminders-utils.ts
@@ -54,7 +54,10 @@ function assertMetadataShape(value: Record<string, unknown>) {
   }
 }
 
-export async function updateReminderMetadata(thread: Thread, metadataValue: Record<string, unknown>) {
+export async function updateReminderMetadata(
+  thread: Thread,
+  metadataValue: Record<string, unknown>
+) {
   assertMetadataShape(metadataValue);
 
   if (!(await incrementMetadataUse(thread, metadataValue.expiration as Date | null))) {
@@ -69,10 +72,15 @@ export async function updateReminderMetadata(thread: Thread, metadataValue: Reco
   );
 }
 
-export async function updateDraftReminderMetadata(draftSession: DraftEditingSession, metadataValue: Record<string, unknown>) {
+export async function updateDraftReminderMetadata(
+  draftSession: DraftEditingSession,
+  metadataValue: Record<string, unknown>
+) {
   assertMetadataShape(metadataValue);
 
-  if (!(await incrementMetadataUse(draftSession.draft(), metadataValue.expiration as Date | null))) {
+  if (
+    !(await incrementMetadataUse(draftSession.draft(), metadataValue.expiration as Date | null))
+  ) {
     return;
   }
   draftSession.changes.add({ pristine: false });

--- a/app/internal_packages/thread-list/lib/thread-list-scroll-tooltip.tsx
+++ b/app/internal_packages/thread-list/lib/thread-list-scroll-tooltip.tsx
@@ -7,7 +7,7 @@ function indexFor({ viewportCenter, totalHeight }: ScrollRegionTooltipComponentP
   return Math.floor((ThreadListStore.dataSource().count() / totalHeight) * viewportCenter);
 }
 
-const ThreadListScrollTooltip: React.FC<ScrollRegionTooltipComponentProps> = props => {
+const ThreadListScrollTooltip: React.FC<ScrollRegionTooltipComponentProps> = (props) => {
   const idx = indexFor(props);
   const item = ThreadListStore.dataSource().get(idx) as Thread | undefined;
   const content = item
@@ -18,4 +18,7 @@ const ThreadListScrollTooltip: React.FC<ScrollRegionTooltipComponentProps> = pro
 
 ThreadListScrollTooltip.displayName = 'ThreadListScrollTooltip';
 
-export default React.memo(ThreadListScrollTooltip, (prev, next) => indexFor(prev) === indexFor(next));
+export default React.memo(
+  ThreadListScrollTooltip,
+  (prev, next) => indexFor(prev) === indexFor(next)
+);

--- a/app/internal_packages/thread-sharing/lib/thread-sharing-popover.tsx
+++ b/app/internal_packages/thread-sharing/lib/thread-sharing-popover.tsx
@@ -1,12 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import {
-  Rx,
-  Thread,
-  DatabaseStore,
-  localized,
-  FeatureUsageStore,
-} from 'mailspring-exports';
+import { Rx, Thread, DatabaseStore, localized, FeatureUsageStore } from 'mailspring-exports';
 import { RetinaImg } from 'mailspring-component-kit';
 
 import CopyButton from './copy-button';

--- a/app/src/components/code-snippet.tsx
+++ b/app/src/components/code-snippet.tsx
@@ -1,10 +1,6 @@
 import React from 'react';
 
-export default function CodeSnippet(props: {
-  intro?: string;
-  code?: string;
-  className?: string;
-}) {
+export default function CodeSnippet(props: { intro?: string; code?: string; className?: string }) {
   return (
     <div className={props.className}>
       {props.intro}

--- a/app/src/components/composer-editor/patch-chrome-ime.ts
+++ b/app/src/components/composer-editor/patch-chrome-ime.ts
@@ -28,7 +28,11 @@ dispatch a TextEvent into the editor manually.
 
 let lastTextInputEvent = null;
 document.addEventListener('textInput', (e: Event) => (lastTextInputEvent = e), true);
-document.addEventListener('compositionstart', (_e: CompositionEvent) => (lastTextInputEvent = null), true);
+document.addEventListener(
+  'compositionstart',
+  (_e: CompositionEvent) => (lastTextInputEvent = null),
+  true
+);
 document.addEventListener(
   'compositionend',
   (e: CompositionEvent) => {

--- a/app/src/components/evented-iframe.tsx
+++ b/app/src/components/evented-iframe.tsx
@@ -363,21 +363,24 @@ export class EventedIFrame extends React.Component<
         new MenuItem({
           label: localized('Save Image') + '...',
           click() {
-            AppEnv.showSaveDialog({ defaultPath: srcFilename }, function (path: string | undefined) {
-              if (!path) {
-                return;
+            AppEnv.showSaveDialog(
+              { defaultPath: srcFilename },
+              function (path: string | undefined) {
+                if (!path) {
+                  return;
+                }
+                const oReq = new XMLHttpRequest();
+                oReq.open('GET', src, true);
+                oReq.responseType = 'arraybuffer';
+                oReq.onload = function () {
+                  const buffer = Buffer.from(new Uint8Array(oReq.response));
+                  fs.writeFile(path, buffer, (err) => {
+                    require('@electron/remote').shell.showItemInFolder(path);
+                  });
+                };
+                oReq.send();
               }
-              const oReq = new XMLHttpRequest();
-              oReq.open('GET', src, true);
-              oReq.responseType = 'arraybuffer';
-              oReq.onload = function () {
-                const buffer = Buffer.from(new Uint8Array(oReq.response));
-                fs.writeFile(path, buffer, (err) => {
-                  require('@electron/remote').shell.showItemInFolder(path);
-                });
-              };
-              oReq.send();
-            });
+            );
           },
         })
       );

--- a/app/src/components/key-commands-region.tsx
+++ b/app/src/components/key-commands-region.tsx
@@ -103,13 +103,7 @@ export class KeyCommandsRegion extends React.Component<
 > {
   static displayName = 'KeyCommandsRegion';
 
-  static ownPropKeys = [
-    'className',
-    'localHandlers',
-    'globalHandlers',
-    'onFocusIn',
-    'onFocusOut',
-  ];
+  static ownPropKeys = ['className', 'localHandlers', 'globalHandlers', 'onFocusIn', 'onFocusOut'];
 
   static defaultProps = {
     className: '',

--- a/app/src/components/scroll-region.tsx
+++ b/app/src/components/scroll-region.tsx
@@ -525,7 +525,10 @@ export class ScrollRegion extends React.Component<
       return;
     }
 
-    this._setSharedState({ scrolling: true, viewportScrollTop: (event.target as HTMLElement).scrollTop });
+    this._setSharedState({
+      scrolling: true,
+      viewportScrollTop: (event.target as HTMLElement).scrollTop,
+    });
 
     if (typeof this.props.onScroll === 'function') {
       this.props.onScroll(event);

--- a/app/src/components/time-picker.tsx
+++ b/app/src/components/time-picker.tsx
@@ -93,7 +93,10 @@ export default class TimePicker extends React.Component<TimePickerProps, TimePic
 
   _onBlur = (event: React.FocusEvent<HTMLInputElement>) => {
     this.setState({ focused: false });
-    if (event.relatedTarget && Array.from((event.relatedTarget as Element).classList).includes('time-options')) {
+    if (
+      event.relatedTarget &&
+      Array.from((event.relatedTarget as Element).classList).includes('time-options')
+    ) {
       return;
     }
     this._saveIfValid(this.state.rawText);

--- a/app/src/components/tokenizing-text-field.tsx
+++ b/app/src/components/tokenizing-text-field.tsx
@@ -424,7 +424,11 @@ export class TokenizingTextField<T> extends React.Component<
   _onClick = (event: React.MouseEvent<HTMLDivElement>) => {
     // Don't focus if the focus is already on an input within our field,
     // like an editable token's input
-    if (event.target instanceof HTMLElement && event.target.tagName === 'INPUT' && ReactDOM.findDOMNode(this).contains(event.target)) {
+    if (
+      event.target instanceof HTMLElement &&
+      event.target.tagName === 'INPUT' &&
+      ReactDOM.findDOMNode(this).contains(event.target)
+    ) {
       return;
     }
 

--- a/app/src/config.ts
+++ b/app/src/config.ts
@@ -623,7 +623,10 @@ export default class Config {
     return value;
   }
 
-  onDidChangeKeyPath(keyPath: string, callback: (event: { oldValue: unknown; newValue: unknown }) => void) {
+  onDidChangeKeyPath(
+    keyPath: string,
+    callback: (event: { oldValue: unknown; newValue: unknown }) => void
+  ) {
     let oldValue = this.get(keyPath);
     return this.emitter.on('did-change', () => {
       const newValue = this.get(keyPath);

--- a/app/src/date-utils.ts
+++ b/app/src/date-utils.ts
@@ -40,7 +40,10 @@ function midnight(momentDate: Moment, midnightHour = Hours.Midnight) {
   return oclock(momentDate.hour(midnightHour));
 }
 
-function isPastDate(inputDateObj: { month: number; [key: string]: unknown }, currentDate: Date | Moment | string) {
+function isPastDate(
+  inputDateObj: { month: number; [key: string]: unknown },
+  currentDate: Date | Moment | string
+) {
   const inputMoment = moment({ ...inputDateObj, month: inputDateObj.month - 1 });
   const currentMoment = moment(currentDate);
 

--- a/app/src/flux/stores/contact-store.ts
+++ b/app/src/flux/stores/contact-store.ts
@@ -92,7 +92,10 @@ class ContactStore extends MailspringStore {
     return contact instanceof Contact ? contact.isValid() : false;
   }
 
-  parseContactsInString(contactString: string, { skipNameLookup }: { skipNameLookup?: boolean } = {}) {
+  parseContactsInString(
+    contactString: string,
+    { skipNameLookup }: { skipNameLookup?: boolean } = {}
+  ) {
     const detected: Contact[] = [];
     const emailRegex = RegExpUtils.emailRegex();
     let lastMatchEnd = 0;

--- a/app/src/flux/stores/database-change-record.ts
+++ b/app/src/flux/stores/database-change-record.ts
@@ -12,7 +12,17 @@ export class DatabaseChangeRecord<T extends Model> {
   type: string;
   objectClass: any;
 
-  constructor({ type, objectClass, objects, objectsRawJSON }: { type: string; objectClass: string; objects: T[]; objectsRawJSON: Record<string, any>[] }) {
+  constructor({
+    type,
+    objectClass,
+    objects,
+    objectsRawJSON,
+  }: {
+    type: string;
+    objectClass: string;
+    objects: T[];
+    objectsRawJSON: Record<string, any>[];
+  }) {
     this.objects = objects;
     this.objectsRawJSON = objectsRawJSON;
     this.type = type;

--- a/app/src/flux/stores/database-store.ts
+++ b/app/src/flux/stores/database-store.ts
@@ -307,7 +307,9 @@ class DatabaseStore extends MailspringStore {
         if (msec > 100) {
           const msgPrefix = msec > 100 ? 'DatabaseStore: query took more than 100ms - ' : '';
           if (query.startsWith(`SELECT `) && DEBUG_QUERY_PLANS) {
-            const plan = this._db.prepare<any,{detail: string}>(`EXPLAIN QUERY PLAN ${query}`).all(values);
+            const plan = this._db
+              .prepare<any, { detail: string }>(`EXPLAIN QUERY PLAN ${query}`)
+              .all(values);
             const planString = `${plan.map((row) => row.detail).join('\n')} for ${query}`;
             const quiet = ['ThreadCounts', 'ThreadSearch', 'ContactSearch', 'COVERING INDEX'];
 

--- a/app/src/flux/stores/draft-factory.ts
+++ b/app/src/flux/stores/draft-factory.ts
@@ -185,7 +185,15 @@ class DraftFactory {
     return this.createDraftForReply({ message, thread, type });
   }
 
-  async createDraftForReply({ message, thread, type }: { message: Message; thread: Thread; type: ReplyType }) {
+  async createDraftForReply({
+    message,
+    thread,
+    type,
+  }: {
+    message: Message;
+    thread: Thread;
+    type: ReplyType;
+  }) {
     const prevBody = await this.prepareBodyForQuoting(message);
     let participants = { to: [], cc: [] };
     if (type === 'reply') {

--- a/app/src/flux/stores/draft-store.ts
+++ b/app/src/flux/stores/draft-store.ts
@@ -464,7 +464,10 @@ class DraftStore extends MailspringStore {
     }
   };
 
-  _onSendDraft = async (headerMessageId: string, options: { delay?: number; actionKey?: string } = {}) => {
+  _onSendDraft = async (
+    headerMessageId: string,
+    options: { delay?: number; actionKey?: string } = {}
+  ) => {
     const { delay = AppEnv.config.get('core.sending.undoSend'), actionKey = DefaultSendActionKey } =
       options;
 

--- a/app/src/flux/stores/workspace-store.ts
+++ b/app/src/flux/stores/workspace-store.ts
@@ -283,7 +283,7 @@ class WorkspaceStore extends MailspringStore {
 
   // Public: Returns a {Boolean} indicating whether the location provided is hidden.
   // You should provide one of the WorkspaceStore.Location constant values.
-  isLocationHidden(loc: {id: string} | null) {
+  isLocationHidden(loc: { id: string } | null) {
     if (!loc) {
       return false;
     }

--- a/app/src/mailsync-process.ts
+++ b/app/src/mailsync-process.ts
@@ -206,12 +206,7 @@ export class MailsyncProcess extends EventEmitter {
     if (!text) return text;
     let out = text;
 
-    const SENSITIVE_JSON_KEYS = [
-      'refresh_token',
-      'access_token',
-      'imap_password',
-      'smtp_password',
-    ];
+    const SENSITIVE_JSON_KEYS = ['refresh_token', 'access_token', 'imap_password', 'smtp_password'];
     for (const key of SENSITIVE_JSON_KEYS) {
       // Match "key":"<anything-but-unescaped-quote>" allowing escaped quotes inside.
       const re = new RegExp(`("${key}"\\s*:\\s*")(?:\\\\.|[^"\\\\])+(")`, 'g');

--- a/app/src/style-manager.ts
+++ b/app/src/style-manager.ts
@@ -13,7 +13,10 @@ export default class StyleManager {
     return Array.from(this.el.children);
   }
 
-  addStyleSheet(source: string, { sourcePath, priority }: { sourcePath: string; priority: number }) {
+  addStyleSheet(
+    source: string,
+    { sourcePath, priority }: { sourcePath: string; priority: number }
+  ) {
     let styleElement = sourcePath ? this.styleElementsBySourcePath[sourcePath] : null;
 
     if (styleElement) {

--- a/app/src/system-start-service.ts
+++ b/app/src/system-start-service.ts
@@ -119,13 +119,17 @@ class SystemStartServiceLinux extends SystemStartServiceBase {
 
   doesLaunchOnSystemStart() {
     return new Promise<boolean>((resolve) => {
-      fs.access(this._shortcutPath(), fs.constants.R_OK | fs.constants.W_OK, (err: NodeJS.ErrnoException | null) => {
-        if (err) {
-          resolve(false);
-        } else {
-          resolve(true);
+      fs.access(
+        this._shortcutPath(),
+        fs.constants.R_OK | fs.constants.W_OK,
+        (err: NodeJS.ErrnoException | null) => {
+          if (err) {
+            resolve(false);
+          } else {
+            resolve(true);
+          }
         }
-      });
+      );
     });
   }
 

--- a/app/src/theme-manager.ts
+++ b/app/src/theme-manager.ts
@@ -48,7 +48,7 @@ export default class ThemeManager {
 
   private _systemAccentColor: string | null = null;
   private _systemAccentDisposable: Disposable | null = null;
-  private _systemDarkMode: boolean = false;
+  private _systemDarkMode = false;
 
   constructor({ packageManager, resourcePath, configDirPath, safeMode }) {
     this.packageManager = packageManager;

--- a/package.json
+++ b/package.json
@@ -74,8 +74,8 @@
   "scripts": {
     "postinstall": "node scripts/postinstall.js",
     "start": "electron ./app --enable-logging --dev",
-    "lint": "eslint --fix -c .eslintrc app/src/**/*.ts app/internal_packages/**/*.tsx",
-    "lint:check": "eslint -c .eslintrc app/src/**/*.ts app/internal_packages/**/*.tsx",
+    "lint": "eslint --fix -c .eslintrc \"app/src/**/*.{ts,tsx}\" \"app/internal_packages/**/*.{ts,tsx}\"",
+    "lint:check": "eslint -c .eslintrc \"app/src/**/*.{ts,tsx}\" \"app/internal_packages/**/*.{ts,tsx}\"",
     "typecheck": "./node_modules/.bin/tsc -p app/tsconfig.json --noEmit",
     "test": "electron ./app --enable-logging --test",
     "test-window": "electron ./app --enable-logging --test=window",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "postinstall": "node scripts/postinstall.js",
     "start": "electron ./app --enable-logging --dev",
     "lint": "eslint --fix -c .eslintrc app/src/**/*.ts app/internal_packages/**/*.tsx",
+    "lint:check": "eslint -c .eslintrc app/src/**/*.ts app/internal_packages/**/*.tsx",
     "typecheck": "./node_modules/.bin/tsc -p app/tsconfig.json --noEmit",
     "test": "electron ./app --enable-logging --test",
     "test-window": "electron ./app --enable-logging --test=window",


### PR DESCRIPTION
## Summary
This PR applies code formatting improvements and introduces a non-modifying lint script for CI pipelines.

## Key Changes
- **Code Formatting**: Applied consistent formatting across multiple TypeScript/TSX files:
  - Reformatted multi-line function calls and conditionals in composer components
  - Simplified import statements by removing unnecessary line breaks
  - Added parentheses around arrow function parameters for consistency
  - Adjusted line breaks in React.memo and function type definitions

- **Lint Script Addition**: 
  - Added new `lint:check` npm script that runs ESLint in check-only mode (without `--fix`)
  - Updated all CI workflow files to use `npm run lint:check` instead of `npm run lint`
  - This prevents CI from automatically modifying code and ensures developers run linting locally

## Implementation Details
- The `lint` script continues to support local development with auto-fixing enabled
- The `lint:check` script is used in CI to verify code style without modifications
- All formatting changes follow the project's existing ESLint configuration

https://claude.ai/code/session_01MNes4z8BivJNCBd2vxVKEK