### PR TITLE
Replace legacy context API with React Context for sheet depth

### DIFF
--- a/app/internal_packages/category-picker/lib/toolbar-category-picker.tsx
+++ b/app/internal_packages/category-picker/lib/toolbar-category-picker.tsx
@@ -13,9 +13,7 @@ import MovePickerPopover from './move-picker-popover';
 import LabelPickerPopover from './label-picker-popover';
 
 // This sets the folder / label on one or more threads.
-const MovePicker: React.FC<{ items: Thread[] }> & { containerRequired?: boolean } = ({
-  items,
-}) => {
+const MovePicker: React.FC<{ items: Thread[] }> & { containerRequired?: boolean } = ({ items }) => {
   const sheetDepth = useContext(SheetDepthContext);
   const moveEl = useRef<HTMLButtonElement>(null);
   const labelEl = useRef<HTMLButtonElement>(null);

--- a/app/internal_packages/category-picker/lib/toolbar-category-picker.tsx
+++ b/app/internal_packages/category-picker/lib/toolbar-category-picker.tsx
@@ -1,11 +1,10 @@
-import React from 'react';
+import React, { useContext, useMemo, useRef, useCallback } from 'react';
 import {
   localized,
   Actions,
-  Account,
-  PropTypes,
   AccountStore,
   WorkspaceStore,
+  SheetDepthContext,
   Thread,
 } from 'mailspring-exports';
 import { RetinaImg, KeyCommandsRegion, RovingTabIndexToolbar } from 'mailspring-component-kit';
@@ -14,112 +13,89 @@ import MovePickerPopover from './move-picker-popover';
 import LabelPickerPopover from './label-picker-popover';
 
 // This sets the folder / label on one or more threads.
-class MovePicker extends React.Component<{ items: Thread[] }> {
-  static displayName = 'MovePicker';
-  static containerRequired = false;
-
-  static contextTypes = { sheetDepth: PropTypes.number };
-
-  _account: Account;
-  _labelEl: HTMLElement;
-  _moveEl: HTMLButtonElement;
-
-  constructor(props) {
-    super(props);
-
-    this._account = AccountStore.accountForItems(this.props.items);
-  }
+const MovePicker: React.FC<{ items: Thread[] }> & { containerRequired?: boolean } = ({
+  items,
+}) => {
+  const sheetDepth = useContext(SheetDepthContext);
+  const moveEl = useRef<HTMLButtonElement>(null);
+  const labelEl = useRef<HTMLButtonElement>(null);
 
   // If the threads we're picking categories for change, (like when they
   // get their categories updated), we expect our parents to pass us new
   // props. We don't listen to the DatabaseStore ourselves.
-  componentDidUpdate(prevProps: { items: Thread[] }) {
-    if (prevProps.items !== this.props.items) {
-      this._account = AccountStore.accountForItems(this.props.items);
-    }
+  const account = useMemo(() => AccountStore.accountForItems(items), [items]);
+
+  const onOpenMovePopover = useCallback(() => {
+    if (items.length === 0) return;
+    if (sheetDepth !== WorkspaceStore.sheetStack().length - 1) return;
+    Actions.openPopover(<MovePickerPopover threads={items} account={account} />, {
+      originRect: moveEl.current.getBoundingClientRect(),
+      direction: 'down',
+    });
+  }, [items, account, sheetDepth]);
+
+  const onOpenLabelsPopover = useCallback(() => {
+    if (items.length === 0) return;
+    if (sheetDepth !== WorkspaceStore.sheetStack().length - 1) return;
+    Actions.openPopover(<LabelPickerPopover threads={items} account={account} />, {
+      originRect: labelEl.current.getBoundingClientRect(),
+      direction: 'down',
+    });
+  }, [items, account, sheetDepth]);
+
+  if (!account) {
+    return <span />;
   }
 
-  _onOpenLabelsPopover = () => {
-    if (!(this.props.items.length > 0)) {
-      return;
-    }
-    if (this.context.sheetDepth !== WorkspaceStore.sheetStack().length - 1) {
-      return;
-    }
-    Actions.openPopover(<LabelPickerPopover threads={this.props.items} account={this._account} />, {
-      originRect: this._labelEl.getBoundingClientRect(),
-      direction: 'down',
-    });
+  const handlers: Record<string, () => void> = {
+    'core:change-folders': onOpenMovePopover,
   };
+  if (account.usesLabels()) {
+    handlers['core:change-labels'] = onOpenLabelsPopover;
+  }
 
-  _onOpenMovePopover = () => {
-    if (!(this.props.items.length > 0)) {
-      return;
-    }
-    if (this.context.sheetDepth !== WorkspaceStore.sheetStack().length - 1) {
-      return;
-    }
-    Actions.openPopover(<MovePickerPopover threads={this.props.items} account={this._account} />, {
-      originRect: this._moveEl.getBoundingClientRect(),
-      direction: 'down',
-    });
-  };
-
-  render() {
-    if (!this._account) {
-      return <span />;
-    }
-
-    const handlers = {
-      'core:change-folders': this._onOpenMovePopover,
-    };
-    if (this._account.usesLabels()) {
-      Object.assign(handlers, {
-        'core:change-labels': this._onOpenLabelsPopover,
-      });
-    }
-
-    return (
-      <RovingTabIndexToolbar
-        label={localized('Category Actions')}
-        className="button-group"
-        style={{ order: -103 }}
-      >
-        <KeyCommandsRegion globalHandlers={handlers}>
+  return (
+    <RovingTabIndexToolbar
+      label={localized('Category Actions')}
+      className="button-group"
+      style={{ order: -103 }}
+    >
+      <KeyCommandsRegion globalHandlers={handlers}>
+        <button
+          tabIndex={-1}
+          ref={moveEl}
+          title={localized('Move to Folder')}
+          aria-label={localized('Move to Folder')}
+          onClick={onOpenMovePopover}
+          className={'btn btn-toolbar btn-category-picker'}
+        >
+          <RetinaImg
+            name={'toolbar-movetofolder.png'}
+            mode={RetinaImg.Mode.ContentIsMask}
+            aria-hidden="true"
+          />
+        </button>
+        {account.usesLabels() && (
           <button
             tabIndex={-1}
-            ref={(el) => (this._moveEl = el)}
-            title={localized('Move to Folder')}
-            aria-label={localized('Move to Folder')}
-            onClick={this._onOpenMovePopover}
+            ref={labelEl}
+            title={localized('Apply Label')}
+            aria-label={localized('Apply Label')}
+            onClick={onOpenLabelsPopover}
             className={'btn btn-toolbar btn-category-picker'}
           >
             <RetinaImg
-              name={'toolbar-movetofolder.png'}
+              name={'toolbar-tag.png'}
               mode={RetinaImg.Mode.ContentIsMask}
               aria-hidden="true"
             />
           </button>
-          {this._account.usesLabels() && (
-            <button
-              tabIndex={-1}
-              ref={(el) => (this._labelEl = el)}
-              title={localized('Apply Label')}
-              aria-label={localized('Apply Label')}
-              onClick={this._onOpenLabelsPopover}
-              className={'btn btn-toolbar btn-category-picker'}
-            >
-              <RetinaImg
-                name={'toolbar-tag.png'}
-                mode={RetinaImg.Mode.ContentIsMask}
-                aria-hidden="true"
-              />
-            </button>
-          )}
-        </KeyCommandsRegion>
-      </RovingTabIndexToolbar>
-    );
-  }
-}
+        )}
+      </KeyCommandsRegion>
+    </RovingTabIndexToolbar>
+  );
+};
+MovePicker.displayName = 'MovePicker';
+MovePicker.containerRequired = false;
 
 export default MovePicker;

--- a/app/src/global/mailspring-exports.d.ts
+++ b/app/src/global/mailspring-exports.d.ts
@@ -174,6 +174,7 @@ export const PropTypes: PropTypes;
 // React Components
 export type ComponentRegistry = typeof import('../registries/component-registry').default;
 export const ComponentRegistry: ComponentRegistry;
+export const SheetDepthContext: typeof import('../sheet-context').SheetDepthContext;
 
 // Utils
 export type Utils = typeof import('../flux/models/utils');

--- a/app/src/global/mailspring-exports.js
+++ b/app/src/global/mailspring-exports.js
@@ -176,6 +176,7 @@ lazyLoadWithGetter(`PropTypes`, () => require('prop-types'));
 
 // React Components
 lazyLoad(`ComponentRegistry`, 'registries/component-registry');
+lazyLoadWithGetter(`SheetDepthContext`, () => require('../sheet-context').SheetDepthContext);
 
 // Utils
 lazyLoad(`Utils`, 'flux/models/utils');

--- a/app/src/sheet-context.ts
+++ b/app/src/sheet-context.ts
@@ -1,0 +1,6 @@
+import React from 'react';
+
+// Provides the depth of the current sheet to descendants (e.g. the toolbar
+// category picker, which only opens its popover when it lives in the top sheet).
+// The default value matches the depth of the root sheet.
+export const SheetDepthContext = React.createContext<number>(0);

--- a/app/src/sheet-toolbar.tsx
+++ b/app/src/sheet-toolbar.tsx
@@ -1,7 +1,6 @@
 /* eslint react/prefer-stateless-function: 0 */
 /* eslint global-require: 0 */
 import React from 'react';
-import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 
 import { localized, isRTL, Actions, ComponentRegistry, WorkspaceStore } from 'mailspring-exports';
@@ -12,6 +11,7 @@ import { RovingTabIndexToolbar } from './components/roving-tab-index-toolbar';
 import * as Utils from './flux/models/utils';
 import { Disposable } from 'rx-core';
 import { isWaylandSession } from './browser/is-wayland';
+import { SheetDepthContext } from './sheet-context';
 
 let Category = null;
 let FocusedPerspectiveStore = null;
@@ -253,22 +253,12 @@ let lastReportedToolbarHeight = 0;
 export default class Toolbar extends React.Component<ToolbarProps, ToolbarState> {
   static displayName = 'Toolbar';
 
-  static childContextTypes = {
-    sheetDepth: PropTypes.number,
-  };
-
   mounted = false;
   unlisteners: Array<() => void> = [];
 
   constructor(props) {
     super(props);
     this.state = this._getStateFromStores();
-  }
-
-  getChildContext() {
-    return {
-      sheetDepth: this.props.depth,
-    };
   }
 
   componentDidMount() {
@@ -427,18 +417,20 @@ export default class Toolbar extends React.Component<ToolbarProps, ToolbarState>
     ));
 
     return (
-      <div
-        style={{
-          position: 'absolute',
-          width: '100%',
-          height: '100%',
-          zIndex: 1,
-        }}
-        className={`sheet-toolbar-container mode-${this.state.mode}`}
-        data-id={this.props.data.id}
-      >
-        {toolbars}
-      </div>
+      <SheetDepthContext.Provider value={this.props.depth}>
+        <div
+          style={{
+            position: 'absolute',
+            width: '100%',
+            height: '100%',
+            zIndex: 1,
+          }}
+          className={`sheet-toolbar-container mode-${this.state.mode}`}
+          data-id={this.props.data.id}
+        >
+          {toolbars}
+        </div>
+      </SheetDepthContext.Provider>
     );
   }
 }

--- a/app/src/sheet.tsx
+++ b/app/src/sheet.tsx
@@ -1,11 +1,11 @@
 import React, { CSSProperties } from 'react';
-import PropTypes from 'prop-types';
 
 import { localized, Utils, ComponentRegistry, WorkspaceStore } from 'mailspring-exports';
 import { InjectedComponentSet } from './components/injected-component-set';
 import { ResizableRegion } from './components/resizable-region';
 import { Flexbox } from './components/flexbox';
 import { SheetDeclaration } from './flux/stores/workspace-store';
+import { SheetDepthContext } from './sheet-context';
 
 const FLEX = 10000;
 
@@ -46,21 +46,11 @@ export default class Sheet extends React.Component<SheetProps, SheetState> {
     onColumnSizeChanged: () => {},
   };
 
-  static childContextTypes = {
-    sheetDepth: PropTypes.number,
-  };
-
   private unlisteners = [];
 
   constructor(props) {
     super(props);
     this.state = this._buildState();
-  }
-
-  getChildContext() {
-    return {
-      sheetDepth: this.props.depth,
-    };
   }
 
   componentDidMount() {
@@ -238,16 +228,18 @@ export default class Sheet extends React.Component<SheetProps, SheetState> {
     // http://philipwalton.com/articles/what-no-one-told-you-about-z-index/
 
     return (
-      <div
-        data-role="Sheet"
-        style={style}
-        className={`sheet mode-${this.state.mode}`}
-        data-id={this.props.data.id}
-      >
-        <Flexbox direction="row" style={{ overflow: 'hidden' }}>
-          {this._columnFlexboxElements()}
-        </Flexbox>
-      </div>
+      <SheetDepthContext.Provider value={this.props.depth}>
+        <div
+          data-role="Sheet"
+          style={style}
+          className={`sheet mode-${this.state.mode}`}
+          data-id={this.props.data.id}
+        >
+          <Flexbox direction="row" style={{ overflow: 'hidden' }}>
+            {this._columnFlexboxElements()}
+          </Flexbox>
+        </div>
+      </SheetDepthContext.Provider>
     );
   }
 }


### PR DESCRIPTION
## Summary
Migrated from the deprecated legacy context API (contextTypes/getChildContext) to modern React Context API for passing sheet depth information to child components.

## Key Changes
- Created new `SheetDepthContext` using `React.createContext()` to replace the legacy context pattern
- Converted `MovePicker` class component to a functional component using hooks:
  - Replaced `contextTypes` with `useContext(SheetDepthContext)`
  - Replaced instance variables with `useRef` for DOM element references
  - Replaced lifecycle methods with `useMemo` and `useCallback` hooks
  - Simplified conditional logic and removed unnecessary intermediate variables
- Updated `Toolbar` and `Sheet` components to provide `SheetDepthContext.Provider` instead of using `getChildContext()`
- Removed `PropTypes` imports where they were only used for legacy context type definitions
- Exported `SheetDepthContext` from mailspring-exports for use across the application

## Implementation Details
- The context default value is set to `0`, matching the root sheet depth
- All three components (`Sheet`, `Toolbar`, and `MovePicker`) now use the same context mechanism for consistent depth tracking
- The functional component conversion maintains the same behavior while improving code clarity and reducing boilerplate

https://claude.ai/code/session_01Fz1hia1VcqXW37riBEXiRg