### PR TITLE
Replace legacy context API with React Context for TabGroupRegion

### DIFF
--- a/app/internal_packages/composer/lib/composer-header.tsx
+++ b/app/internal_packages/composer/lib/composer-header.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import {
   localized,
-  PropTypes,
   Actions,
   AccountStore,
   Message,
@@ -12,6 +11,7 @@ import {
   KeyCommandsRegion,
   ParticipantsTextField,
   ListensToFluxStore,
+  TabGroupContext,
 } from 'mailspring-component-kit';
 import AccountContactField from './account-contact-field';
 import ComposerHeaderActions from './composer-header-actions';
@@ -39,9 +39,8 @@ interface ComposerHeaderState {
 export class ComposerHeader extends React.Component<ComposerHeaderProps, ComposerHeaderState> {
   static displayName = 'ComposerHeader';
 
-  static contextTypes = {
-    parentTabGroup: PropTypes.object,
-  };
+  static contextType = TabGroupContext;
+  context!: React.ContextType<typeof TabGroupContext>;
 
   private _els: {
     participantsContainer?: KeyCommandsRegion;
@@ -80,7 +79,7 @@ export class ComposerHeader extends React.Component<ComposerHeaderProps, Compose
 
   hideField = (fieldName: string) => {
     if (ReactDOM.findDOMNode(this._els[fieldName]).contains(document.activeElement)) {
-      this.context.parentTabGroup.shiftFocus(-1);
+      this.context?.shiftFocus(-1);
     }
 
     const enabledFields = this.state.enabledFields.filter((n) => n !== fieldName);

--- a/app/internal_packages/composer/lib/composer-header.tsx
+++ b/app/internal_packages/composer/lib/composer-header.tsx
@@ -73,7 +73,7 @@ export class ComposerHeader extends React.Component<ComposerHeaderProps, Compose
 
   hideField = (fieldName: string) => {
     if (ReactDOM.findDOMNode(this._els[fieldName]).contains(document.activeElement)) {
-      this.context!.shiftFocus(-1);
+      this.context?.shiftFocus(-1);
     }
 
     const enabledFields = this.state.enabledFields.filter((n) => n !== fieldName);

--- a/app/internal_packages/composer/lib/composer-header.tsx
+++ b/app/internal_packages/composer/lib/composer-header.tsx
@@ -1,12 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import {
-  localized,
-  Actions,
-  AccountStore,
-  Message,
-  DraftEditingSession,
-} from 'mailspring-exports';
+import { localized, Actions, AccountStore, Message, DraftEditingSession } from 'mailspring-exports';
 import {
   KeyCommandsRegion,
   ParticipantsTextField,
@@ -79,7 +73,7 @@ export class ComposerHeader extends React.Component<ComposerHeaderProps, Compose
 
   hideField = (fieldName: string) => {
     if (ReactDOM.findDOMNode(this._els[fieldName]).contains(document.activeElement)) {
-      this.context?.shiftFocus(-1);
+      this.context!.shiftFocus(-1);
     }
 
     const enabledFields = this.state.enabledFields.filter((n) => n !== fieldName);

--- a/app/src/components/date-picker.tsx
+++ b/app/src/components/date-picker.tsx
@@ -1,8 +1,9 @@
 import moment from 'moment';
 import classnames from 'classnames';
 import React from 'react';
-import { PropTypes, DateUtils } from 'mailspring-exports';
+import { DateUtils } from 'mailspring-exports';
 import { MiniMonthView } from 'mailspring-component-kit';
+import { TabGroupContext } from './tab-group-region';
 
 type DatePickerProps = {
   value?: number;
@@ -16,9 +17,8 @@ type DatePickerState = {
 export class DatePicker extends React.Component<DatePickerProps, DatePickerState> {
   static displayName = 'DatePicker';
 
-  static contextTypes = {
-    parentTabGroup: PropTypes.object,
-  };
+  static contextType = TabGroupContext;
+  context!: React.ContextType<typeof TabGroupContext>;
 
   static defaultProps = {
     dateFormat: null, // Default to valueOf
@@ -57,7 +57,7 @@ export class DatePicker extends React.Component<DatePickerProps, DatePickerState
     } else if (event.key === 'ArrowDown') {
       this._moveDay(7);
     } else if (event.key === 'Enter') {
-      this.context.parentTabGroup.shiftFocus(1);
+      this.context?.shiftFocus(1);
     }
   };
 
@@ -71,7 +71,7 @@ export class DatePicker extends React.Component<DatePickerProps, DatePickerState
 
   _onSelectDay = (newTimestamp) => {
     this._onChange(moment(newTimestamp));
-    this.context.parentTabGroup.shiftFocus(1);
+    this.context?.shiftFocus(1);
   };
 
   _renderMiniMonthView() {

--- a/app/src/components/date-picker.tsx
+++ b/app/src/components/date-picker.tsx
@@ -56,7 +56,7 @@ export class DatePicker extends React.Component<DatePickerProps, DatePickerState
     } else if (event.key === 'ArrowDown') {
       this._moveDay(7);
     } else if (event.key === 'Enter') {
-      this.context!.shiftFocus(1);
+      this.context?.shiftFocus(1);
     }
   };
 
@@ -70,7 +70,7 @@ export class DatePicker extends React.Component<DatePickerProps, DatePickerState
 
   _onSelectDay = (newTimestamp) => {
     this._onChange(moment(newTimestamp));
-    this.context!.shiftFocus(1);
+    this.context?.shiftFocus(1);
   };
 
   _renderMiniMonthView() {

--- a/app/src/components/date-picker.tsx
+++ b/app/src/components/date-picker.tsx
@@ -2,8 +2,7 @@ import moment from 'moment';
 import classnames from 'classnames';
 import React from 'react';
 import { DateUtils } from 'mailspring-exports';
-import { MiniMonthView } from 'mailspring-component-kit';
-import { TabGroupContext } from './tab-group-region';
+import { MiniMonthView, TabGroupContext } from 'mailspring-component-kit';
 
 type DatePickerProps = {
   value?: number;
@@ -57,7 +56,7 @@ export class DatePicker extends React.Component<DatePickerProps, DatePickerState
     } else if (event.key === 'ArrowDown') {
       this._moveDay(7);
     } else if (event.key === 'Enter') {
-      this.context?.shiftFocus(1);
+      this.context!.shiftFocus(1);
     }
   };
 
@@ -71,7 +70,7 @@ export class DatePicker extends React.Component<DatePickerProps, DatePickerState
 
   _onSelectDay = (newTimestamp) => {
     this._onChange(moment(newTimestamp));
-    this.context?.shiftFocus(1);
+    this.context!.shiftFocus(1);
   };
 
   _renderMiniMonthView() {

--- a/app/src/components/tab-group-region.tsx
+++ b/app/src/components/tab-group-region.tsx
@@ -1,13 +1,5 @@
-/*
- * decaffeinate suggestions:
- * DS102: Remove unnecessary code created because of implicit returns
- * DS202: Simplify dynamic range loops
- * DS206: Consider reworking classes to avoid initClass
- * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
- */
 import React from 'react';
 import ReactDOM from 'react-dom';
-import PropTypes from 'prop-types';
 
 let compositionActive = false;
 document.addEventListener('compositionstart', () => {
@@ -17,9 +9,9 @@ document.addEventListener('compositionend', () => {
   compositionActive = false;
 });
 
-export class TabGroupRegion extends React.Component<React.HTMLProps<HTMLDivElement>> {
-  static childContextTypes = { parentTabGroup: PropTypes.object };
+export const TabGroupContext = React.createContext<TabGroupRegion | null>(null);
 
+export class TabGroupRegion extends React.Component<React.HTMLProps<HTMLDivElement>> {
   _onKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
     if (event.key !== 'Tab' || event.defaultPrevented) return;
     if (compositionActive) return;
@@ -67,14 +59,10 @@ export class TabGroupRegion extends React.Component<React.HTMLProps<HTMLDivEleme
     );
   };
 
-  getChildContext() {
-    return { parentTabGroup: this };
-  }
-
   render() {
     return (
       <div {...this.props} onKeyDown={this._onKeyDown}>
-        {this.props.children}
+        <TabGroupContext.Provider value={this}>{this.props.children}</TabGroupContext.Provider>
       </div>
     );
   }

--- a/app/src/components/time-picker.tsx
+++ b/app/src/components/time-picker.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import PropTypes from 'prop-types';
 import moment from 'moment';
 import classnames from 'classnames';
+import { TabGroupContext } from './tab-group-region';
 
 require('moment-round'); // overrides moment
 
@@ -21,9 +21,8 @@ type TimePickerState = {
 export default class TimePicker extends React.Component<TimePickerProps, TimePickerState> {
   static displayName = 'TimePicker';
 
-  static contextTypes = {
-    parentTabGroup: PropTypes.object,
-  };
+  static contextType = TabGroupContext;
+  context!: React.ContextType<typeof TabGroupContext>;
 
   static defaultProps = {
     value: moment().valueOf(),
@@ -65,7 +64,7 @@ export default class TimePicker extends React.Component<TimePickerProps, TimePic
       event.preventDefault();
       this._onArrow(event.key);
     } else if (event.key === 'Enter') {
-      this.context.parentTabGroup.shiftFocus(1);
+      this.context?.shiftFocus(1);
     }
   };
 

--- a/app/src/components/time-picker.tsx
+++ b/app/src/components/time-picker.tsx
@@ -64,7 +64,7 @@ export default class TimePicker extends React.Component<TimePickerProps, TimePic
       event.preventDefault();
       this._onArrow(event.key);
     } else if (event.key === 'Enter') {
-      this.context!.shiftFocus(1);
+      this.context?.shiftFocus(1);
     }
   };
 

--- a/app/src/components/time-picker.tsx
+++ b/app/src/components/time-picker.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import moment from 'moment';
 import classnames from 'classnames';
-import { TabGroupContext } from './tab-group-region';
+import { TabGroupContext } from 'mailspring-component-kit';
 
 require('moment-round'); // overrides moment
 
@@ -64,7 +64,7 @@ export default class TimePicker extends React.Component<TimePickerProps, TimePic
       event.preventDefault();
       this._onArrow(event.key);
     } else if (event.key === 'Enter') {
-      this.context?.shiftFocus(1);
+      this.context!.shiftFocus(1);
     }
   };
 

--- a/app/src/global/mailspring-component-kit.js
+++ b/app/src/global/mailspring-component-kit.js
@@ -88,6 +88,7 @@ lazyLoad('MultiselectDropdown', 'multiselect-dropdown');
 lazyLoad('KeyCommandsRegion', 'key-commands-region');
 lazyLoad('BindGlobalCommands', 'bind-global-commands');
 lazyLoad('TabGroupRegion', 'tab-group-region');
+lazyLoadFrom('TabGroupContext', 'tab-group-region');
 lazyLoad('InjectedComponent', 'injected-component');
 lazyLoad('TokenizingTextField', 'tokenizing-text-field');
 lazyLoad('ParticipantsTextField', 'participants-text-field');


### PR DESCRIPTION
## Summary

Migrates `TabGroupRegion` from the React 16 `childContextTypes` / `getChildContext()` pattern to `React.createContext`, which becomes required in React 17. This follows the same approach as #2722 (sheet depth context).

- `TabGroupRegion` now exposes itself via a new exported `TabGroupContext` provider rather than legacy child context.
- The three consumers — `DatePicker`, `TimePicker`, and `ComposerHeader` — were converted from `static contextTypes` to `static contextType = TabGroupContext`. `this.context` now holds the `TabGroupRegion` instance directly (or `null`), so the call sites became `this.context?.shiftFocus(...)`.
- All three consumers are stateful classes with refs and lifecycle methods, so they were left as classes; only the context wiring changed.
- `TabGroupContext` is also lazy-exported from `mailspring-component-kit` for use by `composer-header.tsx`.

## Test plan

- [ ] Open the composer; tabbing forward/backward through To/Cc/Bcc/Subject/body still cycles focus.
- [ ] Hide a participant field (Cc/Bcc/Reply-To) while it is focused — focus should shift to the previous field.
- [ ] In the calendar event popover, focus a `DatePicker`, press Enter — focus should move to the next field; arrow keys still change the date.
- [ ] In the calendar event popover, focus a `TimePicker`, type a time, press Enter — focus should move to the next field.

https://claude.ai/code/session_014ng7UKsu6Bfi5zXwtJXAmL

---
_Generated by [Claude Code](https://claude.ai/code/session_014ng7UKsu6Bfi5zXwtJXAmL)_