### PR TITLE
Replace deprecated componentWillMount with componentDidMount

### DIFF
--- a/app/internal_packages/message-list/lib/message-item-body.tsx
+++ b/app/internal_packages/message-list/lib/message-item-body.tsx
@@ -71,17 +71,14 @@ export default class MessageItemBody extends React.Component<
     };
   }
 
-  componentWillMount() {
+  componentDidMount() {
+    this._mounted = true;
     const needInitialCallback = this.state.processedBody === null;
     this._unsub = MessageBodyProcessor.subscribe(
       this.props.message,
       needInitialCallback,
       this._onBodyProcessed
     );
-  }
-
-  componentDidMount() {
-    this._mounted = true;
   }
 
   componentDidUpdate(prevProps: MessageItemBodyProps) {

--- a/app/src/components/billing-modal.tsx
+++ b/app/src/components/billing-modal.tsx
@@ -25,15 +25,6 @@ export default class BillingModal extends React.Component<BillingModalProps, Bil
     };
   }
 
-  componentWillMount() {
-    if (!this.state.src) {
-      IdentityStore.fetchSingleSignOnURL('/payment?embedded=true').then((url) => {
-        if (!this._mounted) return;
-        this.setState({ src: url });
-      });
-    }
-  }
-
   componentDidMount() {
     // Due to a bug in Electron, opening a webview with a non 100% size when
     // the app has a custom zoomLevel scales it's contents incorrectly and no
@@ -44,6 +35,13 @@ export default class BillingModal extends React.Component<BillingModalProps, Bil
       webFrame.setZoomFactor(1);
     }
     this._mounted = true;
+
+    if (!this.state.src) {
+      IdentityStore.fetchSingleSignOnURL('/payment?embedded=true').then((url) => {
+        if (!this._mounted) return;
+        this.setState({ src: url });
+      });
+    }
   }
 
   /**

--- a/app/src/components/metadata-composer-toggle-button.tsx
+++ b/app/src/components/metadata-composer-toggle-button.tsx
@@ -35,19 +35,20 @@ export default class MetadataComposerToggleButton extends React.Component<
   constructor(props) {
     super(props);
 
+    const wantsDefault = this._isEnabledByDefault() && !this._isEnabled();
     this.state = {
       pending: false,
-      onByDefaultButUsedUp: false,
+      onByDefaultButUsedUp: wantsDefault && !FeatureUsageStore.isUsable(props.pluginId),
     };
   }
 
-  componentWillMount() {
-    if (this._isEnabledByDefault() && !this._isEnabled()) {
-      if (FeatureUsageStore.isUsable(this.props.pluginId)) {
-        this._setEnabled(true);
-      } else {
-        this.setState({ onByDefaultButUsedUp: true });
-      }
+  componentDidMount() {
+    if (
+      this._isEnabledByDefault() &&
+      !this._isEnabled() &&
+      FeatureUsageStore.isUsable(this.props.pluginId)
+    ) {
+      this._setEnabled(true);
     }
   }
 

--- a/app/src/flux/stores/message-store.ts
+++ b/app/src/flux/stores/message-store.ts
@@ -39,9 +39,7 @@ class _MessageStore extends MailspringStore {
     const viewingHiddenCategory = FolderNamesHiddenByDefault.includes(viewing);
 
     return this._items.filter((item) => {
-      const inHidden = item.folder
-        ? FolderNamesHiddenByDefault.includes(item.folder.role)
-        : false;
+      const inHidden = item.folder ? FolderNamesHiddenByDefault.includes(item.folder.role) : false;
       return viewingHiddenCategory ? inHidden || item.draft : !inHidden;
     });
   }


### PR DESCRIPTION
## Summary
This PR migrates away from the deprecated `componentWillMount` lifecycle method to `componentDidMount` across three components. This change aligns with React best practices and prepares the codebase for future React versions where `componentWillMount` will be removed.

## Key Changes
- **MetadataComposerToggleButton**: Moved initialization logic from `componentWillMount` to `componentDidMount`. Refactored state initialization to compute `onByDefaultButUsedUp` in the constructor based on feature usage, simplifying the lifecycle method.

- **BillingModal**: Moved SSO URL fetching logic from `componentWillMount` to `componentDidMount`. The fetch now occurs after `_mounted` flag is set, ensuring proper cleanup handling.

- **MessageItemBody**: Moved message body processor subscription setup from `componentWillMount` to `componentDidMount`. Consolidated `_mounted` flag initialization into the same lifecycle method where it's needed.

## Implementation Details
- State initialization that depends on props is now computed in the constructor where appropriate
- All async operations and subscriptions are properly deferred to `componentDidMount`, ensuring the component is fully mounted before side effects occur
- The `_mounted` flag pattern is preserved to prevent state updates on unmounted components

https://claude.ai/code/session_01WKtv972YyMBxrFMvV2yg3P