### PR TITLE
Fix TOCTOU null-reference crash in draft body setter

### DIFF
--- a/app/src/flux/stores/draft-editing-session.ts
+++ b/app/src/flux/stores/draft-editing-session.ts
@@ -66,11 +66,17 @@ function hotwireDraftBodyState(draft: any, session: DraftEditingSession): Messag
 
       _bodyHTMLValue = inHTML;
 
-      if (session._mountedEditor) {
+      // Capture the editor reference immediately. Between this check and the first use of
+      // the editor below (moveToStartOfDocument), convertFromHTML is called. In rare cases
+      // the composer can unmount during that call — or during the Slate change operations
+      // themselves — setting session._mountedEditor to null. Using a local snapshot prevents
+      // the null-reference crash at the point of use.
+      const mountedEditor = session._mountedEditor;
+      if (mountedEditor) {
         const inHTMLEditorValue = convertFromHTML(inHTML);
         try {
           // try to apply the new value to the existing document to preserve undo history.
-          let edits = session._mountedEditor.moveToStartOfDocument();
+          let edits = mountedEditor.moveToStartOfDocument();
 
           // remove all but the very first node in the document
           const [first, ...rest] = edits.value.document.nodes.toArray();
@@ -88,7 +94,7 @@ function hotwireDraftBodyState(draft: any, session: DraftEditingSession): Messag
           // occasionally inserting the fragment adds a new line at the beginning of the value.
           // It's unclear why this happens and it appears to be specific to replies.
           const firstBlock = edits.value.document.getBlocks().first();
-          if (firstBlock.text === '') {
+          if (firstBlock && firstBlock.text === '') {
             edits = edits.removeNodeByKey(firstBlock.key);
           }
 
@@ -107,8 +113,8 @@ function hotwireDraftBodyState(draft: any, session: DraftEditingSession): Messag
           // equivalent document of the same shape.
           AppEnv.reportError(new Error(`Unable to insert fragment into existing document.`), {
             underlyingError: err,
-            existingSlateShape: session._mountedEditor
-              ? convertToShapeWithoutContent(session._mountedEditor.value)
+            existingSlateShape: mountedEditor
+              ? convertToShapeWithoutContent(mountedEditor.value)
               : null,
             incomingSlateShape: convertToShapeWithoutContent(inHTMLEditorValue),
           });


### PR DESCRIPTION
## Problem

Sentry issue [MAILSPRING-CLIENT-S](https://foundry-376-llc.sentry.io/issues/MAILSPRING-CLIENT-S) — **131 users affected, 196 occurrences** in release `1.21.1-ae68e881`.

The error reported was:
```
Error: Unable to insert fragment into existing document.
  underlying: TypeError: Cannot read properties of null (reading 'moveToStartOfDocument')
    at Message.set (draft-editing-session.js:94)
    at DraftEditingSession._onDraftChanged (draft-editing-session.js:205)
    at DraftStore._onDataChanged
    at DatabaseStore.trigger
    at MailsyncBridge._onIncomingChangeRecord
```

The Sentry event's extra data included:
- `existingSlateShape: null` — confirming `session._mountedEditor` was `null` in the catch block
- `incomingSlateShape: <valid Slate value JSON>` — the incoming HTML from the sync engine was fine

## Root Cause

In `hotwireDraftBodyState`, the body `set` accessor has this structure:

```typescript
if (session._mountedEditor) {              // ← guard: mountedEditor is non-null here
  const inHTMLEditorValue = convertFromHTML(inHTML);  // ← this runs first
  try {
    let edits = session._mountedEditor.moveToStartOfDocument();  // ← CRASH: can be null here
```

This is a classic **time-of-check / time-of-use (TOCTOU)** bug. Between the guard check and the first actual use of `session._mountedEditor`, `convertFromHTML(inHTML)` is called. In rare conditions — e.g. when the lazy `Conversion` module is first loaded (which initialises several Slate plugins and patches `HTMLElement.prototype`), or when Slate's own `onChange` triggers a React re-render that unmounts the composer — `session.setMountedEditor(null)` (or `session.teardown()`) can be called, zeroing out `_mountedEditor` before execution returns to the try-block.

The try/catch *did* recover gracefully (`_bodyEditorValue = inHTMLEditorValue`) but `AppEnv.reportError` was still called, which is why Sentry collected 131 affected users.

## Fix

1. **Capture `session._mountedEditor` into a local `const mountedEditor`** immediately at the guard, before any other code runs. All subsequent references use the captured snapshot, so nulling `session._mountedEditor` on the session later has no effect on this invocation.

2. **Add a null guard for `firstBlock`** — `getBlocks().first()` can return `undefined` when the document has no blocks after the `insertFragment` step, which would cause a secondary null crash (`firstBlock.text`).

```typescript
const mountedEditor = session._mountedEditor;  // snapshot
if (mountedEditor) {
  const inHTMLEditorValue = convertFromHTML(inHTML);
  try {
    let edits = mountedEditor.moveToStartOfDocument();  // safe: local ref
    ...
    const firstBlock = edits.value.document.getBlocks().first();
    if (firstBlock && firstBlock.text === '') {   // null-safe
      edits = edits.removeNodeByKey(firstBlock.key);
    }
  } catch (err) {
    AppEnv.reportError(..., { existingSlateShape: mountedEditor ? ... : null, ... });
    _bodyEditorValue = inHTMLEditorValue;
  }
}
```

The fallback path (`_bodyEditorValue = inHTMLEditorValue`) remains intact for genuine Slate schema errors; this change only prevents the null-reference error from reaching Sentry in the first place.

https://claude.ai/code/session_01LCqa4UfPp1tUkuqhrtvpUZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01LCqa4UfPp1tUkuqhrtvpUZ)_