### PR TITLE
Fix null check in AttributeDateTime.fromJSON()

### DIFF
--- a/app/src/flux/attributes/attribute-datetime.ts
+++ b/app/src/flux/attributes/attribute-datetime.ts
@@ -20,7 +20,7 @@ export class AttributeDateTime extends Attribute {
   }
 
   fromJSON(val) {
-    if (!val || val instanceof Date) {
+    if (val == null || val instanceof Date) {
       return val;
     }
     return new Date(val * 1000);


### PR DESCRIPTION
## Summary
Fixed a type safety issue in the `AttributeDateTime.fromJSON()` method by replacing the loose falsy check (`!val`) with an explicit null check (`val == null`).

## Changes
- Changed the condition from `if (!val || val instanceof Date)` to `if (val == null || val instanceof Date)` in `AttributeDateTime.fromJSON()`

## Details
The original condition using `!val` would incorrectly treat the value `0` as falsy and return it early, even though `0` is a valid numeric timestamp. The updated condition using `val == null` (which checks for both `null` and `undefined`) preserves the original intent while correctly handling all numeric values, including `0`.

This ensures that numeric timestamps are properly converted to Date objects via `new Date(val * 1000)` regardless of their numeric value.

https://claude.ai/code/session_01BsPtjqWUQdaBfdVSPZDPbk