### PR TITLE
fix: DefaultClientHelperMac passes boolean to error callback, causing false Sentry error reports on macOS

### DIFF
--- a/app/src/default-client-helper.ts
+++ b/app/src/default-client-helper.ts
@@ -147,11 +147,17 @@ export class DefaultClientHelperMac implements DCH {
   }
 
   resetURLScheme(scheme: string, callback = (error?: Error) => {}) {
-    return callback(require('@electron/remote').app.removeAsDefaultProtocolClient(scheme));
+    const success = require('@electron/remote').app.removeAsDefaultProtocolClient(scheme);
+    return callback(
+      success ? null : new Error(`Failed to remove Mailspring as default handler for ${scheme}`)
+    );
   }
 
   registerForURLScheme(scheme: string, callback = (error?: Error) => {}) {
-    return callback(require('@electron/remote').app.setAsDefaultProtocolClient(scheme));
+    const success = require('@electron/remote').app.setAsDefaultProtocolClient(scheme);
+    return callback(
+      success ? null : new Error(`Failed to set Mailspring as default handler for ${scheme}`)
+    );
   }
 }
 


### PR DESCRIPTION
## Problem

Sentry issue [MAILSPRING-CLIENT-6C](https://foundry-376-llc.sentry.io/issues/MAILSPRING-CLIENT-6C) — **"Error: Empty error reported (true)"** — has been affecting **77 users** (84 events in the past 14 days).

### Root Cause

Electron's `app.setAsDefaultProtocolClient(scheme)` and `app.removeAsDefaultProtocolClient(scheme)` return a **boolean** — `true` on success, `false` on failure. However, `DefaultClientHelperMac` was passing this boolean **directly** as the first argument to the callback:

```typescript
// BEFORE — broken
registerForURLScheme(scheme: string, callback = (error?: Error) => {}) {
  return callback(require('@electron/remote').app.setAsDefaultProtocolClient(scheme));
  //              ↑ passes boolean `true` on success, `false` on failure
}
```

The DCH interface declares the callback signature as `(error?: Error) => void`, meaning callers expect `null`/`undefined` on success and an `Error` object on failure. On macOS, when `setAsDefaultProtocolClient` succeeds it returns `true`, so `callback(true)` is called.

In `default-client-notif.tsx`, the `_onAccept` handler does:

```typescript
this.helper.registerForURLScheme('mailto', (err) => {
  if (err) {             // ← truthy when err === true
    // ...
    AppEnv.reportError(err);   // ← called with boolean `true` on success!
  }
});
```

`AppEnv.reportError(true)` hits the `error-logger` path that wraps non-Error values and reports them to Sentry as `"Empty error reported (true)"`. So **every macOS user who clicks "Yes" to make Mailspring the default mail client triggers a Sentry error report** — even when the operation succeeds.

The `DefaultClientHelperLinux` and `DefaultClientHelperWindows` implementations both correctly call `callback(null)` on success and `callback(err)` on failure. Only the Mac implementation was broken.

## Fix

Capture the boolean return value and convert it to `null` (success) or a descriptive `Error` (failure) before passing to the callback:

```typescript
// AFTER — correct
registerForURLScheme(scheme: string, callback = (error?: Error) => {}) {
  const success = require('@electron/remote').app.setAsDefaultProtocolClient(scheme);
  return callback(
    success ? null : new Error(`Failed to set Mailspring as default handler for ${scheme}`)
  );
}
```

Same fix applied to `resetURLScheme`.

## Impact

- Eliminates 77-user false-positive Sentry error on macOS
- If `setAsDefaultProtocolClient` ever genuinely fails (returns `false`), the error is now properly reported with a descriptive message instead of being silently swallowed

Fixes: https://foundry-376-llc.sentry.io/issues/MAILSPRING-CLIENT-6C

https://claude.ai/code/session_01D6y1RSJ3XgDiX4hgWRogHo

---
_Generated by [Claude Code](https://claude.ai/code/session_01D6y1RSJ3XgDiX4hgWRogHo)_