### PR TITLE
Fix Windows print crash (invalid file URL)

### DIFF
--- a/app/internal_packages/print/lib/print-window.ts
+++ b/app/internal_packages/print/lib/print-window.ts
@@ -1,5 +1,6 @@
 import path from 'path';
 import fs from 'fs';
+import { pathToFileURL } from 'url';
 
 import { localized } from 'mailspring-exports';
 import { escapeHTML } from 'underscore.string';
@@ -35,7 +36,7 @@ export default class PrintWindow {
           <meta http-equiv="Content-Security-Policy" content="default-src * mailspring:; frame-src 'none'; script-src 'self' chrome-extension://react-developer-tools; style-src * 'unsafe-inline' mailspring:; img-src * data: mailspring: file:; object-src none; media-src none; manifest-src none;">
           <meta charset="utf-8">
           ${styleTags}
-          <link rel="stylesheet" type="text/css" href="${stylesPath}">
+          <link rel="stylesheet" type="text/css" href="${pathToFileURL(stylesPath).href}">
         </head>
         <body>
           <div id="print-header">
@@ -68,8 +69,8 @@ export default class PrintWindow {
             </ul>
           </div>
           ${htmlContent}
-          <script type="text/javascript" src="${tmpMessagesPath}"></script>
-          <script type="text/javascript" src="${scriptPath}"></script>
+          <script type="text/javascript" src="${pathToFileURL(tmpMessagesPath).href}"></script>
+          <script type="text/javascript" src="${pathToFileURL(scriptPath).href}"></script>
         </body>
       </html>
     `;
@@ -124,6 +125,6 @@ export default class PrintWindow {
    * that script will pop out the print dialog.
    */
   load() {
-    this.browserWin.loadURL(`file://${this.tmpFile}`);
+    this.browserWin.loadURL(pathToFileURL(this.tmpFile).href);
   }
 }

--- a/app/src/flux/models/query-subscription.ts
+++ b/app/src/flux/models/query-subscription.ts
@@ -253,13 +253,7 @@ export class QuerySubscription<T extends Model> {
         return;
       }
 
-      // Use actual results length for the contiguity check — the DB may return fewer
-      // results than range.limit (e.g. near the end of the list), and a check against
-      // the requested limit could incorrectly allow a non-adjacent addIdsInRange call.
-      const effectiveRange = range.isInfinite()
-        ? range
-        : new QueryRange({ offset: range.offset, limit: results.length });
-      if (this._set && !this._set.range().isContiguousWith(effectiveRange)) {
+      if (this._set && !this._set.range().isContiguousWith(range)) {
         this._set = null;
       }
       this._set = this._set || new MutableQueryResultSet();

--- a/app/src/flux/models/query-subscription.ts
+++ b/app/src/flux/models/query-subscription.ts
@@ -253,7 +253,13 @@ export class QuerySubscription<T extends Model> {
         return;
       }
 
-      if (this._set && !this._set.range().isContiguousWith(range)) {
+      // Use actual results length for the contiguity check — the DB may return fewer
+      // results than range.limit (e.g. near the end of the list), and a check against
+      // the requested limit could incorrectly allow a non-adjacent addIdsInRange call.
+      const effectiveRange = range.isInfinite()
+        ? range
+        : new QueryRange({ offset: range.offset, limit: results.length });
+      if (this._set && !this._set.range().isContiguousWith(effectiveRange)) {
         this._set = null;
       }
       this._set = this._set || new MutableQueryResultSet();


### PR DESCRIPTION
## Summary

Two bugs fixed based on Sentry issue analysis for release 1.21.1-ae68e881.

---

### Fix 1: Windows print window crash — ERR_FAILED loading print.html

**Sentry issue**: [MAILSPRING-CLIENT-N](https://foundry-376-llc.sentry.io/issues/MAILSPRING-CLIENT-N) — 149 users affected

**Root cause**: In `print-window.ts`, file paths were interpolated directly into URLs using template strings like `` `file://${this.tmpFile}` ``. On macOS/Linux, paths start with `/` so this accidentally produces a valid `file:///path` URL. On Windows, `app.getPath('temp')` returns a backslash path like `C:\Users\User\AppData\Local\Temp`, making the resulting URL `file://C:\Users\User\AppData\Local\Temp\print.html` — which Electron correctly rejects with `ERR_FAILED (-2)`. The same problem affected the stylesheet `href` and both `<script src>` paths embedded in the generated HTML.

**Fix**: Import `pathToFileURL` from Node's built-in `url` module and apply it to every file path used as a URL — the `loadURL()` call and the three embedded HTML resource paths. `pathToFileURL` correctly produces `file:///C:/Users/User/AppData/Local/Temp/print.html` on Windows and the equivalent on other platforms.

---

### Fix 2: addIdsInRange crash in thread list virtualization

**Sentry issues**: [MAILSPRING-CLIENT-1A](https://foundry-376-llc.sentry.io/issues/MAILSPRING-CLIENT-1A) (30 users) and [MAILSPRING-CLIENT-17](https://foundry-376-llc.sentry.io/issues/MAILSPRING-CLIENT-17) (24 users)

**Root cause**: `QuerySubscription._fetchRange` checks whether the existing result set is contiguous with the *requested* range before merging new results in. The contiguity check used `range.limit` as the end of the fetched range, but the database can return **fewer rows than requested** when the query is near the end of the list (e.g., requesting offset 50 limit 50 when only 25 threads exist → actual end is 75, not 100). If the existing set started at offset 100, the contiguity check saw `range.end = 100` and passed (50–100 touches 100–150), but then `addIdsInRange` correctly computed `rangeIdsEnd = 75` and threw `"You can only add adjacent values (75 < 100)"` because there was a real gap.

**Fix**: Build an `effectiveRange` from `results.length` (actual returned items) rather than `range.limit`, and use that for the contiguity check. When the effective end of the fetched data falls short of the existing set's start, the set is cleared and rebuilt from scratch, which is the correct behavior.

## Test plan

- [ ] **Print on Windows**: Open a thread, press Print (Cmd/Ctrl+P). The print preview window should open and render the email correctly. Previously this crashed silently on Windows with no print window appearing.
- [ ] **Print on macOS/Linux**: Verify print still works (unchanged behavior, but regression check).
- [ ] **Thread list scrolling**: Scroll quickly through a large mailbox. The thread list should not crash or go blank. Previously users with accounts near the end of their thread list saw the list go blank.
- [ ] **Thread list at end of inbox**: Test with an account that has a small number of threads (< the scroll window size). Verify the list loads and stays stable.

---
_Generated by [Claude Code](https://claude.ai/code/session_013dnsEj4KmoWzK9ayAmD5sk)_