### PR TITLE
fix: check actual result length for contiguity in QuerySubscription._fetchRange

### DIFF
--- a/app/spec/models/query-subscription-spec.ts
+++ b/app/spec/models/query-subscription-spec.ts
@@ -253,6 +253,57 @@ describe('QuerySubscription', function QuerySubscriptionSpecs() {
       }));
   });
 
+  describe('_fetchRange', () => {
+    it('should reset _set instead of throwing when actual results do not reach the existing set', () => {
+      // Regression test for MAILSPRING-CLIENT-1A / MAILSPRING-CLIENT-17:
+      // When _set covers {50,70} and a fetch for range {30,50} returns only 16
+      // results (rangeIdsEnd = 46 < _offset = 50), contiguity must be checked
+      // against the actual results length, not the requested limit. Otherwise
+      // isContiguousWith({50,70}, {30,50}) passes (they share endpoint 50) but
+      // addIdsInRange throws "You can only add adjacent values (46 < 50)".
+      const query = DatabaseStore.findAll<Thread>(Thread)
+        .where(Thread.attributes.accountId.equal('a'))
+        .limit(20)
+        .offset(30);
+
+      const threads50to70 = Array.from({ length: 20 }, (_, i) =>
+        new Thread({ id: `t${50 + i}`, accountId: 'a' })
+      );
+      const threads30to46 = Array.from({ length: 16 }, (_, i) =>
+        new Thread({ id: `t${30 + i}`, accountId: 'a' })
+      );
+
+      // Prevent the constructor's update() from issuing a real DB query
+      spyOn(QuerySubscription.prototype, 'update').andReturn(undefined);
+
+      const subscription = new QuerySubscription(query);
+      subscription._set = new MutableQueryResultSet();
+      subscription._set.addModelsInRange(threads50to70, new QueryRange({ offset: 50, limit: 20 }));
+
+      // DB returns 16 results for the requested range of 20 — actual end is 46, not 50
+      spyOn(DatabaseStore, 'run').andReturn(Promise.resolve(threads30to46));
+
+      let completed = false;
+      spyOn(subscription, '_createResultAndTrigger').andCallFake(() => {
+        completed = true;
+      });
+
+      // _fetchRange requests range {30,50} but only 16 results come back
+      subscription._fetchRange(new QueryRange({ offset: 30, limit: 20 }), {
+        version: subscription._queryVersion,
+        fetchEntireModels: true,
+      });
+
+      waitsFor(() => completed, 'fetch to complete', 1000);
+
+      runs(() => {
+        // _set should be valid (reset and repopulated with the 16 partial results)
+        expect(subscription._set).not.toBe(null);
+        expect(subscription._set.ids()).toEqual(threads30to46.map(t => t.id));
+      });
+    });
+  });
+
   describe('update', () => {
     beforeEach(() =>
       spyOn(QuerySubscription.prototype, '_fetchRange').andCallFake(() => {

--- a/app/spec/models/query-subscription-spec.ts
+++ b/app/spec/models/query-subscription-spec.ts
@@ -266,11 +266,13 @@ describe('QuerySubscription', function QuerySubscriptionSpecs() {
         .limit(20)
         .offset(30);
 
-      const threads50to70 = Array.from({ length: 20 }, (_, i) =>
-        new Thread({ id: `t${50 + i}`, accountId: 'a' })
+      const threads50to70 = Array.from(
+        { length: 20 },
+        (_, i) => new Thread({ id: `t${50 + i}`, accountId: 'a' })
       );
-      const threads30to46 = Array.from({ length: 16 }, (_, i) =>
-        new Thread({ id: `t${30 + i}`, accountId: 'a' })
+      const threads30to46 = Array.from(
+        { length: 16 },
+        (_, i) => new Thread({ id: `t${30 + i}`, accountId: 'a' })
       );
 
       // Prevent the constructor's update() from issuing a real DB query
@@ -299,7 +301,7 @@ describe('QuerySubscription', function QuerySubscriptionSpecs() {
       runs(() => {
         // _set should be valid (reset and repopulated with the 16 partial results)
         expect(subscription._set).not.toBe(null);
-        expect(subscription._set.ids()).toEqual(threads30to46.map(t => t.id));
+        expect(subscription._set.ids()).toEqual(threads30to46.map((t) => t.id));
       });
     });
   });

--- a/app/src/flux/models/query-subscription.ts
+++ b/app/src/flux/models/query-subscription.ts
@@ -258,10 +258,7 @@ export class QuerySubscription<T extends Model> {
       // or items deleted since the scroll position was computed), the actual
       // data may not reach the existing set — treating the requested range as
       // contiguous would pass the check but then throw inside addIdsInRange.
-      const actualResultRange = new QueryRange({
-        offset: range.offset,
-        limit: (results as any[]).length,
-      });
+      const actualResultRange = new QueryRange({ offset: range.offset, limit: results.length });
       if (this._set && !this._set.range().isContiguousWith(actualResultRange)) {
         this._set = null;
       }

--- a/app/src/flux/models/query-subscription.ts
+++ b/app/src/flux/models/query-subscription.ts
@@ -253,7 +253,16 @@ export class QuerySubscription<T extends Model> {
         return;
       }
 
-      if (this._set && !this._set.range().isContiguousWith(range)) {
+      // Use the actual results length (not the requested range limit) to check
+      // contiguity. If fewer items were returned than requested (end of list,
+      // or items deleted since the scroll position was computed), the actual
+      // data may not reach the existing set — treating the requested range as
+      // contiguous would pass the check but then throw inside addIdsInRange.
+      const actualResultRange = new QueryRange({
+        offset: range.offset,
+        limit: (results as any[]).length,
+      });
+      if (this._set && !this._set.range().isContiguousWith(actualResultRange)) {
         this._set = null;
       }
       this._set = this._set || new MutableQueryResultSet();

--- a/app/src/flux/models/query-subscription.ts
+++ b/app/src/flux/models/query-subscription.ts
@@ -258,8 +258,12 @@ export class QuerySubscription<T extends Model> {
       // or items deleted since the scroll position was computed), the actual
       // data may not reach the existing set — treating the requested range as
       // contiguous would pass the check but then throw inside addIdsInRange.
-      const actualResultRange = new QueryRange({ offset: range.offset, limit: results.length });
-      if (this._set && !this._set.range().isContiguousWith(actualResultRange)) {
+      // For infinite ranges keep the original `range` so isContiguousWith can
+      // short-circuit with `return true` as it always did for infinite ranges.
+      const contiguityRange = range.isInfinite()
+        ? range
+        : new QueryRange({ offset: range.offset, limit: results.length });
+      if (this._set && !this._set.range().isContiguousWith(contiguityRange)) {
         this._set = null;
       }
       this._set = this._set || new MutableQueryResultSet();


### PR DESCRIPTION
## Sentry Issue

Fixes [MAILSPRING-CLIENT-1A](https://foundry-376-llc.sentry.io/issues/MAILSPRING-CLIENT-1A) (and the identical [MAILSPRING-CLIENT-17](https://foundry-376-llc.sentry.io/issues/MAILSPRING-CLIENT-17))

**58 users affected, 204 events, last seen today.**

---

## Root Cause

`QuerySubscription._fetchRange` (in `query-subscription.ts`) fetches a page of results from the database, then checks whether those results are *contiguous* with the existing `_set` before merging. If not contiguous, `_set` is reset so `addIdsInRange` can start fresh.

The bug: the contiguity check used the **requested** `range` object (which has `range.limit = 20`), not the **actual** results returned by the DB. When fewer items come back than requested (end of list, or items deleted while the fetch was in flight), the actual data ends before the existing set begins — but the check passes because the *requested* range still touches the set.

### Concrete failure sequence

1. User scrolls so `_set` covers items `{50–70}` (`_offset = 50`)
2. User scrolls up — `update()` calls `_fetchRange` for the **missing** range `{30–50}` (limit=20, offset=30)
3. DB returns only **16** results (items were deleted/moved, or the list truly ends at 46)
4. `isContiguousWith({50,70}, {30,50})` → **true** (they share endpoint 50) → `_set` is **not** reset
5. `addIdsInRange(16 results, range)` computes `rangeIdsEnd = 30 + 16 = 46`
6. `46 < 50 = this._offset` → **throws**: `"addIdsInRange: You can only add adjacent values (46 < 50)"`

This becomes an unhandled error caught by Electron's global handler and reported to Sentry.

---

## Fix

Compute `actualResultRange` using `results.length` (the real count) instead of `range.limit` (what was requested), and use that for the contiguity check:

```typescript
// Before
if (this._set && !this._set.range().isContiguousWith(range)) {
  this._set = null;
}

// After
const actualResultRange = new QueryRange({
  offset: range.offset,
  limit: (results as any[]).length,
});
if (this._set && !this._set.range().isContiguousWith(actualResultRange)) {
  this._set = null;
}
```

When actual results don't reach the existing set, `_set` is reset to `null`. `addIdsInRange` then uses its `this._offset === null` fast path (simple assignment) instead of throwing.

The `range` passed to `addModelsInRange`/`addIdsInRange` is unchanged — those methods already use `rangeIds.length` for their arithmetic (not `range.limit`), so they handle partial results correctly once they get past the early throw.

---

## Test

Added a regression test to `query-subscription-spec.ts` that reproduces the exact condition: `_set` at offset 50, fetch for range `{30,50}`, only 16 results returned. Verifies no exception and `_set` correctly contains the 16 results.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VZyMRS8ZfUvEM8ke3gnkPP)_