### PR TITLE
Fix null crash when removing threads with unsynced trash/archive folder

### DIFF
--- a/app/src/flux/tasks/change-folder-task.ts
+++ b/app/src/flux/tasks/change-folder-task.ts
@@ -44,7 +44,7 @@ export class ChangeFolderTask extends ChangeMailTask {
       const folders = [];
       const seenFolderIds = new Set<string>();
       for (const t of data.threads || []) {
-        const f = t.folders.find((f) => f.id !== data.folder.id) || t.folders[0];
+        const f = t.folders.find((f) => f.id !== data.folder?.id) || t.folders[0];
         if (!seenFolderIds.has(f.id)) {
           seenFolderIds.add(f.id);
           folders.push(f);

--- a/app/src/mailbox-perspective.ts
+++ b/app/src/mailbox-perspective.ts
@@ -553,6 +553,7 @@ class CategoryMailboxPerspective extends MailboxPerspective {
     return TaskFactory.tasksForThreadsByAccountId(threads, (accountThreads, accountId) => {
       const acct = AccountStore.accountForId(accountId);
       const preferred = acct.preferredRemovalDestination();
+      if (!preferred) return null;
       const cat = this.categories().find((c) => c.accountId === accountId);
       if (cat instanceof Label && preferred.role !== 'trash') {
         const inboxCat = CategoryStore.getInboxCategory(accountId);


### PR DESCRIPTION
## Summary

Fixes a crash reported in Sentry as [MAILSPRING-CLIENT-25](https://foundry-376-llc.sentry.io/issues/MAILSPRING-CLIENT-25) — **27 users, 197 events** in release 1.21.1.

## Root Cause

When a user clicks "Remove from View" (the × button in the thread toolbar), `CategoryMailboxPerspective.tasksForRemovingItems()` calls `acct.preferredRemovalDestination()` to decide whether to archive or trash the selected threads.

`preferredRemovalDestination()` can return `null` when the account's trash or archive folder hasn't synced yet:

```typescript
// account.ts
preferredRemovalDestination() {
  const preferDelete = AppEnv.config.get('core.reading.backspaceDelete');
  if (preferDelete || !CategoryStore.getArchiveCategory(this)) {
    return CategoryStore.getTrashCategory(this);  // can be null
  }
  return CategoryStore.getArchiveCategory(this);  // can be null
}
```

That `null` was passed directly as `folder` to `new ChangeFolderTask({ folder: null, ... })`. The `ChangeFolderTask` constructor then crashed immediately trying to read `data.folder.id` while computing the undo snapshot:

```typescript
// change-folder-task.ts  (before fix)
const f = t.folders.find((f) => f.id !== data.folder.id) || t.folders[0];
//                                          ^^^ TypeError: Cannot read properties of null (reading 'id')
```

The full call chain from Sentry:
```
HiddenGenericRemoveButton._onRemoveFromView
  → CategoryMailboxPerspective.tasksForRemovingItems
    → TaskFactory.tasksForThreadsByAccountId (callback)
      → new ChangeFolderTask   ← crash
```

## What I Noticed That Led to the Solution

`SearchMailboxPerspective.tasksForRemovingItems()` in `search-mailbox-perspective.tsx` already has the identical null-check:

```typescript
const dest = account.preferredRemovalDestination();
if (!dest) {
  return [];   // ← already guarded here
}
```

`CategoryMailboxPerspective` had the same need but was missing the guard.

## Fix

Two changes, one line each:

**1. `mailbox-perspective.ts` — primary fix** — bail out early if no destination is available, returning `null` from the `tasksForThreadsByAccountId` callback (which `tasksForThreadsByAccountId` already handles gracefully by skipping null results):

```typescript
const preferred = acct.preferredRemovalDestination();
+ if (!preferred) return null;
```

**2. `change-folder-task.ts` — defensive fix** — use optional chaining when accessing `data.folder` during undo-snapshot computation, so a null folder never causes a crash inside the constructor:

```typescript
- const f = t.folders.find((f) => f.id !== data.folder.id) || t.folders[0];
+ const f = t.folders.find((f) => f.id !== data.folder?.id) || t.folders[0];
```

## Test plan

- [ ] With a freshly-added account (trash/archive not yet synced), select a thread and click "Remove from View" — should no longer crash
- [ ] With a fully-synced account, "Remove from View" should move the thread to archive or trash as before
- [ ] Undo of a folder-move task should still work correctly

---
_Generated by [Claude Code](https://claude.ai/code/session_01XxkzRripTPQmkEAr8J6qu4)_