### PR TITLE
Fix null crash when clicking "Send now" on undo-send toast

### DIFF
--- a/app/internal_packages/undo-redo/lib/undo-redo-toast.tsx
+++ b/app/internal_packages/undo-redo/lib/undo-redo-toast.tsx
@@ -27,6 +27,12 @@ async function sendMessageNow(block) {
       ),
       newExpiry = Math.floor(Date.now() / 1000);
 
+    // Message may be null if the sync engine already processed/sent it before
+    // the user clicked "Send now". In that case there's nothing to do.
+    if (!message) {
+      return true;
+    }
+
     Actions.queueTask(
       SyncbackMetadataTask.forSaving({
         model: message,

--- a/app/src/flux/tasks/syncback-metadata-task.ts
+++ b/app/src/flux/tasks/syncback-metadata-task.ts
@@ -17,6 +17,9 @@ export class SyncbackMetadataTask extends Task {
     if (!pluginId) {
       throw new Error('SyncbackMetadataTask.forSaving: You must specify a pluginId.');
     }
+    if (!model) {
+      throw new Error('SyncbackMetadataTask.forSaving: model is null or undefined.');
+    }
     const task = new SyncbackMetadataTask({
       modelId: model.id,
       pluginId: pluginId,


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Fixes Sentry issue [MAILSPRING-CLIENT-1R](https://foundry-376-llc.sentry.io/issues/MAILSPRING-CLIENT-1R) — **34 users impacted**, still ongoing.

## What I observed

The "Send now instead" button in the undo-send countdown toast calls `sendMessageNow()`, which does:

```typescript
const message = await DatabaseStore.find<Message>(Message, modelId);
Actions.queueTask(SyncbackMetadataTask.forSaving({ model: message, ... }));
```

`DatabaseStore.find` returns `null` when the message isn't in the local DB. This happens when the sync engine has already processed the send before the user clicks the button — the message is gone by the time the toast is still visible. Passing `null` to `SyncbackMetadataTask.forSaving` crashes immediately at `model.id` with:

> **Cannot read properties of null (reading 'id')**

Stack trace from Sentry:
```
undo-redo-toast.js (async onClick)
undo-redo-toast.js (sendMessageNow)
syncback-metadata-task.js (SyncbackMetadataTask.forSaving)
```

## The fix

- In `sendMessageNow()`: guard against a null `message` return. If the message is already gone, the send already happened — silently return `true` so the toast dismisses cleanly.
- In `SyncbackMetadataTask.forSaving`: add an explicit null check for `model` with a clear error message, so any future callers that inadvertently pass null get a useful exception instead of a confusing property-access crash.

https://claude.ai/code/session_01AUjCTKsRiyw3otYVJeqseE
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AUjCTKsRiyw3otYVJeqseE)_