### PR TITLE
fix: use ChangeLabelsTask for trash/spam on Gmail (label-based) accounts

### DIFF
--- a/app/src/flux/tasks/task-factory.ts
+++ b/app/src/flux/tasks/task-factory.ts
@@ -38,6 +38,18 @@ export const TaskFactory = {
 
   tasksForMarkingAsSpam({ threads, source }: { threads: Thread[]; source: string }) {
     return this.tasksForThreadsByAccountId(threads, (accountThreads, accountId) => {
+      const inbox = CategoryStore.getInboxCategory(accountId);
+      if (inbox instanceof Label) {
+        // Gmail: categories are labels, so use ChangeLabelsTask
+        const spam = CategoryStore.getSpamCategory(accountId);
+        if (!spam) return null;
+        return new ChangeLabelsTask({
+          labelsToAdd: [spam as Label],
+          labelsToRemove: [inbox],
+          threads: accountThreads,
+          source,
+        });
+      }
       const folder = CategoryStore.getSpamCategory(accountId);
       if (!folder) return null;
       return new ChangeFolderTask({ folder, source, threads: accountThreads });
@@ -49,9 +61,14 @@ export const TaskFactory = {
       const inbox = CategoryStore.getInboxCategory(accountId);
 
       if (inbox instanceof Label) {
-        const all = CategoryStore.getAllMailCategory(accountId) as any;
-        if (!all) return null;
-        return new ChangeFolderTask({ folder: all, threads: accountThreads, source });
+        // Gmail: remove spam label (moves thread to All Mail)
+        const spam = CategoryStore.getSpamCategory(accountId);
+        return new ChangeLabelsTask({
+          labelsToAdd: [],
+          labelsToRemove: spam ? [spam as Label] : [],
+          threads: accountThreads,
+          source,
+        });
       }
 
       if (!inbox) return null;
@@ -79,7 +96,19 @@ export const TaskFactory = {
 
   tasksForMovingToTrash({ threads, source }: { threads: Thread[]; source: string }) {
     return this.tasksForThreadsByAccountId(threads, (accountThreads, accountId) => {
-      const trash = CategoryStore.getTrashCategory(accountId) as any;
+      const inbox = CategoryStore.getInboxCategory(accountId);
+      if (inbox instanceof Label) {
+        // Gmail: categories are labels, so use ChangeLabelsTask
+        const trash = CategoryStore.getTrashCategory(accountId);
+        if (!trash) return null;
+        return new ChangeLabelsTask({
+          labelsToAdd: [trash as Label],
+          labelsToRemove: [inbox],
+          threads: accountThreads,
+          source,
+        });
+      }
+      const trash = CategoryStore.getTrashCategory(accountId);
       if (!trash) return null;
       return new ChangeFolderTask({ folder: trash, threads: accountThreads, source });
     });

--- a/app/src/flux/tasks/task-factory.ts
+++ b/app/src/flux/tasks/task-factory.ts
@@ -63,9 +63,10 @@ export const TaskFactory = {
       if (inbox instanceof Label) {
         // Gmail: remove spam label (moves thread to All Mail)
         const spam = CategoryStore.getSpamCategory(accountId);
+        if (!spam) return null;
         return new ChangeLabelsTask({
           labelsToAdd: [],
-          labelsToRemove: spam ? [spam as Label] : [],
+          labelsToRemove: [spam as Label],
           threads: accountThreads,
           source,
         });
@@ -97,10 +98,10 @@ export const TaskFactory = {
   tasksForMovingToTrash({ threads, source }: { threads: Thread[]; source: string }) {
     return this.tasksForThreadsByAccountId(threads, (accountThreads, accountId) => {
       const inbox = CategoryStore.getInboxCategory(accountId);
+      const trash = CategoryStore.getTrashCategory(accountId);
+      if (!trash) return null;
       if (inbox instanceof Label) {
         // Gmail: categories are labels, so use ChangeLabelsTask
-        const trash = CategoryStore.getTrashCategory(accountId);
-        if (!trash) return null;
         return new ChangeLabelsTask({
           labelsToAdd: [trash as Label],
           labelsToRemove: [inbox],
@@ -108,8 +109,6 @@ export const TaskFactory = {
           source,
         });
       }
-      const trash = CategoryStore.getTrashCategory(accountId);
-      if (!trash) return null;
       return new ChangeFolderTask({ folder: trash, threads: accountThreads, source });
     });
   },


### PR DESCRIPTION
## What I observed

While reviewing Sentry issues for release `1.21.1-ae68e881`, two issues stood out:

- **[MAILSPRING-CLIENT-3F](https://foundry-376-llc.sentry.io/issues/MAILSPRING-CLIENT-3F)** — 409 events, 14 users (macOS)
- **[MAILSPRING-CLIENT-61](https://foundry-376-llc.sentry.io/issues/MAILSPRING-CLIENT-61)** — 28 events, 11 users (Windows)

Both throw: `ChangeFolderTask: You must provide a single folder.`

The stack trace points to `tasksForMovingToTrash` → `new ChangeFolderTask({ folder: trash, ... })`.

## Root cause

Mailspring represents Gmail categories as `Label` objects, not `Folder` objects. `CategoryStore.getTrashCategory()` returns whichever type the sync engine provides — for Gmail this is a `Label`.

`ChangeFolderTask`'s constructor validates its input:
```typescript
if (this.folder && !(this.folder instanceof Folder)) {
  throw new Error('ChangeFolderTask: You must provide a single folder.');
}
```

So when a Gmail user hits the trash button (or presses Delete), `tasksForMovingToTrash` gets a `Label` from `getTrashCategory`, passes it to `ChangeFolderTask`, and it immediately throws — the thread is never actually moved.

The same structural bug affects `tasksForMarkingAsSpam` (passes the spam `Label` to `ChangeFolderTask`) and `tasksForMarkingNotSpam` (the Gmail branch explicitly calls `ChangeFolderTask` with the All Mail `Label`).

## Fix

Mirror the existing `tasksForArchiving` pattern, which already handles this correctly: check `inbox instanceof Label` to detect label-based accounts and dispatch `ChangeLabelsTask` instead.

- **`tasksForMovingToTrash`**: add trash label + remove inbox label
- **`tasksForMarkingAsSpam`**: add spam label + remove inbox label  
- **`tasksForMarkingNotSpam`**: remove spam label (lands in All Mail, consistent with original intent)

`ChangeLabelsTask.description()` already has display strings for all three of these cases (`Trashed %@`, `Marked %@ as Spam`, `Unmarked %@ as Spam`), so the undo/activity descriptions work correctly out of the box.

## Test plan

- [ ] Gmail account: press Delete on a thread → thread moves to Trash, no exception thrown
- [ ] Gmail account: Mark as Spam → thread moves to Spam folder
- [ ] Gmail account: Not Spam (from Spam view) → thread moves back to All Mail
- [ ] IMAP/Exchange account: same three actions still use `ChangeFolderTask` (unchanged path)

Fixes https://foundry-376-llc.sentry.io/issues/MAILSPRING-CLIENT-3F  
Fixes https://foundry-376-llc.sentry.io/issues/MAILSPRING-CLIENT-61

https://claude.ai/code/session_015iRaqXxQWMMFLE9Qgtn43h

---
_Generated by [Claude Code](https://claude.ai/code/session_015iRaqXxQWMMFLE9Qgtn43h)_