### PR TITLE
Fix two null-access crashes in onboarding autoconfig and thread-list context menu

### DIFF
--- a/app/internal_packages/onboarding/lib/onboarding-helpers.ts
+++ b/app/internal_packages/onboarding/lib/onboarding-helpers.ts
@@ -424,7 +424,8 @@ async function TryThunderbirdAutoconfig(populated: Account, account: Account) {
     autoConfig = await getThunderbirdAutoconfig(url);
   }
   // emailProvider could potentially be an array
-  if (autoConfig !== false && autoConfig.emailProvider) {
+  // autoConfig can be null if the server returns 200 with an empty/unparseable XML body
+  if (autoConfig && autoConfig.emailProvider) {
     let provider = autoConfig.emailProvider;
     if (Array.isArray(provider)) {
       provider = provider.find((p) => p.$.id === domain);

--- a/app/internal_packages/thread-list/lib/thread-list-context-menu.ts
+++ b/app/internal_packages/thread-list/lib/thread-list-context-menu.ts
@@ -35,7 +35,8 @@ export default class ThreadListContextMenu {
   menuItemTemplate() {
     return DatabaseStore.modelify<Thread>(Thread, this.threadIds)
       .then((threads) => {
-        this.threads = threads;
+        // modelify returns undefined for IDs not found in the DB (e.g. deleted threads)
+        this.threads = threads.filter(Boolean);
 
         return Promise.all<TemplateItem>([
           this.findWithFrom(),


### PR DESCRIPTION
## Summary

Fixes two distinct null/undefined crashes surfaced in Sentry for release `1.21.1-ae68e881`, together affecting **68 users**.

---

### Bug 1 — `TryThunderbirdAutoconfig`: null autoConfig crashes on `.emailProvider` access
**Sentry issues:** MAILSPRING-CLIENT-1G (28 users, Windows) · MAILSPRING-CLIENT-18 (18 users, macOS)

**Root cause:** `getThunderbirdAutoconfig` fetches an XML autoconfig URL and returns the result of `xml2js.parseStringPromise(body)`. When the remote server responds with HTTP 200 but an empty or structurally degenerate XML body, `parseStringPromise` returns `null` rather than throwing. The function therefore returns `null` (not `false`), and the call-site guard:

```typescript
if (autoConfig !== false && autoConfig.emailProvider) {
```

passes for `null` — `null !== false` is `true` — and then `autoConfig.emailProvider` throws:

> `Cannot read properties of null (reading 'emailProvider')`

This would only happen for users whose email domain has an autoconfig endpoint that returns a 200 with a malformed/empty XML body (e.g. an nginx default page or blank response served at the well-known URL).

**Fix:** Replace `autoConfig !== false` with a plain truthy check so both `false` and `null` (and any other falsy value) are handled:

```typescript
if (autoConfig && autoConfig.emailProvider) {
```

---

### Bug 2 — `ThreadListContextMenu.markAsReadItem`: undefined thread crashes on `.unread` access
**Sentry issue:** MAILSPRING-CLIENT-2V (22 users)

**Root cause:** `menuItemTemplate` calls `DatabaseStore.modelify(Thread, this.threadIds)`. `modelify` builds the result array with `arr.map(id => modelsByString[id])` — if an ID is not found in the database (thread was deleted between the user right-clicking and the DB lookup resolving), the map returns `undefined` for that slot. `markAsReadItem` (and other methods) then iterates `this.threads` without null-checking:

```typescript
const unread = this.threads.every((t) => t.unread === false);
```

When `t` is `undefined`, accessing `t.unread` throws:

> `Cannot read properties of undefined (reading 'unread')`

**Fix:** Filter out undefined entries immediately after `modelify` resolves:

```typescript
this.threads = threads.filter(Boolean);
```

This protects all downstream methods (`markAsReadItem`, `markAsSpamItem`, `archiveItem`, etc.) in one place.

---

## Test plan

- [ ] Add an email account whose domain serves a 200 OK but empty body at `https://autoconfig.<domain>/mail/config-v1.1.xml` — account setup should proceed past autoconfig without crashing
- [ ] Right-click on threads in the thread list; verify no crash when a thread is simultaneously deleted/archived

https://claude.ai/code/session_01JRpspgNR3pz8R2fM8XTZGJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01JRpspgNR3pz8R2fM8XTZGJ)_