### PR TITLE
Fix two Sentry crashes: null account in preferences and null window in app menu IPC

### DIFF
--- a/app/internal_packages/preferences/lib/tabs/preferences-accounts.tsx
+++ b/app/internal_packages/preferences/lib/tabs/preferences-accounts.tsx
@@ -87,10 +87,12 @@ class PreferencesAccounts extends React.Component<
             onSelectAccount={this._onSelectAccount}
             onRemoveAccount={this._onRemoveAccount}
           />
-          <PreferencesAccountDetails
-            account={this.state.selected}
-            onAccountUpdated={this._onAccountUpdated}
-          />
+          {this.state.selected && (
+            <PreferencesAccountDetails
+              account={this.state.selected}
+              onAccountUpdated={this._onAccountUpdated}
+            />
+          )}
         </div>
       </div>
     );

--- a/app/src/browser/application.ts
+++ b/app/src/browser/application.ts
@@ -668,7 +668,9 @@ export default class Application extends EventEmitter {
 
     ipcMain.on('update-application-menu', (event, template, keystrokesByCommand) => {
       const win = BrowserWindow.fromWebContents(event.sender);
-      this.applicationMenu.update(win, template, keystrokesByCommand);
+      if (win) {
+        this.applicationMenu.update(win, template, keystrokesByCommand);
+      }
     });
 
     ipcMain.on('command', (event, command, ...args) => {


### PR DESCRIPTION
## Summary

Fixes two unresolved Sentry issues from release `1.21.1-ae68e881`, both traced to missing null/undefined guards.

---

### Fix 1 — [MAILSPRING-CLIENT-1C](https://foundry-376-llc.sentry.io/issues/MAILSPRING-CLIENT-1C): `Cannot read properties of undefined (reading 'name')` (23 users)

**Root cause:** `PreferencesAccounts.getStateFromStores()` falls back to `accounts[0]` as the selected account. When `AccountStore.accounts()` returns an empty array, `accounts[0]` is `undefined`. This `undefined` value was passed directly as the `account` prop to `PreferencesAccountDetails`.

Inside `PreferencesAccountDetails.render()`, the first thing it does is call `this._makeAlias(...)`, which defaults its `account` parameter to `this.props.account` (i.e. `undefined`). When the email regex doesn't match the placeholder string, it tries `account.name` — crashing with "Cannot read properties of undefined (reading 'name')".

**Fix:** Wrap `<PreferencesAccountDetails>` in a conditional so it is only mounted when `this.state.selected` is truthy.

---

### Fix 2 — [MAILSPRING-CLIENT-4F](https://foundry-376-llc.sentry.io/issues/MAILSPRING-CLIENT-4F): `TypeError: Invalid value used as weak map key` (18 users)

**Root cause:** In the `update-application-menu` IPC handler in `application.ts`, `BrowserWindow.fromWebContents(event.sender)` is called to resolve which window sent the message. The Electron docs note this can return `null` when the `WebContents` is not associated with a `BrowserWindow` (e.g. a DevTools window, or a window that was already closed by the time the IPC message is processed).

`null` was passed directly to `applicationMenu.update()`, which calls `this.windowTemplates.set(window, template)` on a `WeakMap`. `WeakMap` keys must be non-null objects — passing `null` throws "Invalid value used as weak map key".

**Fix:** Add a `if (win)` guard in the IPC handler before calling `applicationMenu.update()`.

---

## Test plan

- [ ] Open Preferences → Accounts with at least one account — details panel renders correctly
- [ ] Verify no crash occurs when there are zero configured accounts (edge case that triggered the Sentry issue)
- [ ] Verify the app menu updates correctly when switching between windows
- [ ] Verify no crash in the main process when an IPC `update-application-menu` message arrives from a non-BrowserWindow WebContents

https://claude.ai/code/session_01JPzqH6HmNT2CzbSNVZw4Fv

---
_Generated by [Claude Code](https://claude.ai/code/session_01JPzqH6HmNT2CzbSNVZw4Fv)_