### PR TITLE
Handle ensureCorrectAccount failure gracefully when sending drafts

### DIFF
--- a/app/src/flux/stores/draft-editing-session.ts
+++ b/app/src/flux/stores/draft-editing-session.ts
@@ -385,6 +385,11 @@ export class DraftEditingSession extends MailspringStore {
   //
   async ensureCorrectAccount() {
     const draft = this.draft();
+    if (!draft.from || !draft.from.length) {
+      throw new Error(
+        'DraftEditingSession::ensureCorrectAccount - draft has no from address.'
+      );
+    }
     const account = AccountStore.accountForEmail(draft.from[0].email);
     if (!account) {
       throw new Error(

--- a/app/src/flux/stores/draft-store.ts
+++ b/app/src/flux/stores/draft-store.ts
@@ -538,7 +538,18 @@ class DraftStore extends MailspringStore {
 
     // move the draft to another account if necessary to match the from: field
     const accountIdBeforeEnsure = session.draft()?.accountId;
-    await session.ensureCorrectAccount();
+    try {
+      await session.ensureCorrectAccount();
+    } catch (ensureErr) {
+      this._draftsSending[headerMessageId] = false;
+      this.trigger({ headerMessageId });
+      AppEnv.showErrorDialog(
+        localized(
+          "This message can't be sent because the 'From' address is not a configured account. Please add the account back in Preferences or change the 'From' address before sending."
+        )
+      );
+      return;
+    }
     diagnostics.ensureCorrectAccountChangedAccount =
       session.draft()?.accountId !== accountIdBeforeEnsure;
     diagnostics.draftIdAfterEnsure = session.draft()?.id;


### PR DESCRIPTION
## What and Why

Fixes Sentry issue **MAILSPRING-CLIENT-Z** (22 users impacted, still ongoing as of 2026-06-09).

### Root Cause

When a user sends a draft whose "From" address no longer matches any configured account — for example, because they removed that account after composing the draft — `ensureCorrectAccount()` in `DraftEditingSession` throws:

```
Error: DraftEditingSession::ensureCorrectAccount - you can only send drafts from a configured account.
```

The caller, `DraftStore._onSendDraft()`, does not wrap this call in a try/catch. The thrown error propagates as an **unhandled promise rejection**, which means:

1. **The user sees nothing** — no error dialog, no UI feedback. The "Send" button appears to do nothing (or the composer window just closes silently).
2. **Sentry captures it** as an unhandled error, even though there's a perfectly sensible user-facing message we can show.

This was identified by reviewing Sentry issue MAILSPRING-CLIENT-Z, sorted by user count in the `release:1.21.1-ae68e881` unresolved query.

### Investigation

The stack trace in Sentry:
```
DraftStore._onSendDraft (draft-store.js:266)
DraftEditingSession.ensureCorrectAccount (draft-editing-session.js:372)
```

`ensureCorrectAccount()` is designed to either:
- Accept the from address (account found, accountId already matches → no-op)
- Move the draft to a different account (account found, accountId doesn't match → creates new draft in that account)
- **Throw** if no account matches the from email at all

The throw path was never caught, so the send flow halted silently.

### Fix

1. **`DraftStore._onSendDraft`**: Wrap `await session.ensureCorrectAccount()` in a try/catch. On failure, reset `_draftsSending`, trigger a UI update, and show the user an actionable error dialog — matching the pattern already used for other send-time failures in the same function.

2. **`DraftEditingSession.ensureCorrectAccount`**: Add a defensive guard for the edge case where `draft.from` is empty. Previously, an empty `from` array would cause a secondary `TypeError: Cannot read properties of undefined (reading 'email')` at `draft.from[0].email` before even reaching the account lookup.

## Test Plan

- [ ] Send a draft from an account that is still configured → sends normally
- [ ] Remove an account, then try to send a draft that uses it as the From address → error dialog appears, composer unlocks (send button re-enables / window stays open)
- [ ] Verify no Sentry error is reported for the removed-account case

## Sentry Link

https://foundry-376-llc.sentry.io/issues/MAILSPRING-CLIENT-Z

https://claude.ai/code/session_01FqmDBbhCBYzYGwKLdv5iBU

---
_Generated by [Claude Code](https://claude.ai/code/session_01FqmDBbhCBYzYGwKLdv5iBU)_