### PR TITLE
Fix crash when archiving from search with label-based archive categories

### DIFF
--- a/app/internal_packages/thread-search/lib/search-mailbox-perspective.tsx
+++ b/app/internal_packages/thread-search/lib/search-mailbox-perspective.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {
   localized,
   Folder,
+  Label,
   ChangeLabelsTask,
   ChangeFolderTask,
   AccountStore,
@@ -98,13 +99,18 @@ class SearchMailboxPerspective extends MailboxPerspective {
           folder: dest,
         });
       }
-      // dest is a Label (e.g. Gmail "All Mail" with role 'all', or an 'archive' label on some
-      // providers). In all label-based cases, archiving means removing from inbox.
-      return new ChangeLabelsTask({
-        threads: accountThreads,
-        source: 'Dragged out of list',
-        labelsToRemove: [CategoryStore.getInboxCategory(accountId)],
-      });
+      if (dest instanceof Label) {
+        // Label-based archive (e.g. Gmail "All Mail" role='all', or role='archive' on some
+        // providers). Archiving via label means removing the thread from the inbox label.
+        return new ChangeLabelsTask({
+          threads: accountThreads,
+          source: 'Dragged out of list',
+          labelsToRemove: [CategoryStore.getInboxCategory(accountId)],
+        });
+      }
+      throw new Error(
+        `Unexpected type returned from preferredRemovalDestination(): ${dest.constructor.name}`
+      );
     });
   }
 }

--- a/app/internal_packages/thread-search/lib/search-mailbox-perspective.tsx
+++ b/app/internal_packages/thread-search/lib/search-mailbox-perspective.tsx
@@ -98,15 +98,13 @@ class SearchMailboxPerspective extends MailboxPerspective {
           folder: dest,
         });
       }
-      if (dest.role === 'all') {
-        // if you're searching and archive something, it really just removes the inbox label
-        return new ChangeLabelsTask({
-          threads: accountThreads,
-          source: 'Dragged out of list',
-          labelsToRemove: [CategoryStore.getInboxCategory(accountId)],
-        });
-      }
-      throw new Error('Unexpected destination returned from preferredRemovalDestination()');
+      // dest is a Label (e.g. Gmail "All Mail" with role 'all', or an 'archive' label on some
+      // providers). In all label-based cases, archiving means removing from inbox.
+      return new ChangeLabelsTask({
+        threads: accountThreads,
+        source: 'Dragged out of list',
+        labelsToRemove: [CategoryStore.getInboxCategory(accountId)],
+      });
     });
   }
 }

--- a/app/src/flux/tasks/change-folder-task.ts
+++ b/app/src/flux/tasks/change-folder-task.ts
@@ -44,8 +44,8 @@ export class ChangeFolderTask extends ChangeMailTask {
       const folders = [];
       const seenFolderIds = new Set<string>();
       for (const t of data.threads || []) {
-        const f = t.folders.find((f) => f.id !== data.folder?.id) || t.folders[0];
-        if (!seenFolderIds.has(f.id)) {
+        const f = t.folders?.find((f) => f?.id !== data.folder?.id) || t.folders?.[0];
+        if (f && !seenFolderIds.has(f.id)) {
           seenFolderIds.add(f.id);
           folders.push(f);
         }


### PR DESCRIPTION
## Problem

Two related crashes investigated from Sentry release `1.21.1-ae68e881`:

### Sentry MAILSPRING-CLIENT-5B — `Unexpected destination returned from preferredRemovalDestination()` (11 users, 45 events)

**Root cause:** When a user presses the remove/archive shortcut while in a **search result view**, `SearchMailboxPerspective.tasksForRemovingItems` calls `account.preferredRemovalDestination()`, which delegates to `CategoryStore.getArchiveCategory()`. That method tries role `'archive'` before `'all'`:

```typescript
// category-store.ts
getArchiveCategory(accountOrId) {
  return (
    this.getCategoryByRole(account.id, 'archive') || this.getCategoryByRole(account.id, 'all')
  );
}
```

For some email providers, this returns a **Label** with role `'archive'` (not `'all'`). The search perspective only handled `Folder` destinations and Labels with role `'all'`, throwing for anything else:

```typescript
if (dest instanceof Folder) { ... }
if (dest.role === 'all') { ... }
throw new Error('Unexpected destination returned from preferredRemovalDestination()');
//                                                          ^^^^ this fires for role='archive'
```

**Fix:** Replace the explicit `role === 'all'` check with a catch-all for any Label. In all label-based cases the correct archive behavior is removing the thread from the inbox label — no role distinction needed.

### Sentry MAILSPRING-CLIENT-3J — `Cannot read properties of null (reading 'id')` (16 users, 193 events)

**Root cause:** In `ChangeFolderTask`'s constructor, when computing `previousFolder` for undo support, the code accessed `t.folders[0]` and then `f.id` without guarding against an empty `folders` array. If a thread has no folders (e.g. during a sync race), `f` ends up `undefined` and `f.id` throws.

**Fix:** Add optional-chaining guards on `t.folders?.find(...)` / `t.folders?.[0]` and skip the `seenFolderIds` update when `f` is falsy.

## Changes

- `app/internal_packages/thread-search/lib/search-mailbox-perspective.tsx` — remove the `throw` and explicit `role === 'all'` check; any Label destination now falls through to the `ChangeLabelsTask` path that removes the inbox label.
- `app/src/flux/tasks/change-folder-task.ts` — add null-safety guards when iterating thread folders in the constructor.

## Sentry links
- https://foundry-376-llc.sentry.io/issues/MAILSPRING-CLIENT-5B
- https://foundry-376-llc.sentry.io/issues/MAILSPRING-CLIENT-3J

https://claude.ai/code/session_015hcwECMxD1ssh1x7v6r6xp

---
_Generated by [Claude Code](https://claude.ai/code/session_015hcwECMxD1ssh1x7v6r6xp)_