### PR TITLE
Fix quickpreview CSP clobbering the app-wide CSP (breaks O365/Gmail OAuth)

### DIFF
--- a/app/src/quickpreview/index.ts
+++ b/app/src/quickpreview/index.ts
@@ -13,6 +13,12 @@ function cleanupPreviewToken(token: string): void {
   ipcRenderer.invoke('quickpreview:cleanupToken', token);
 }
 
+// Quickpreview windows use a dedicated in-memory session partition so the strict
+// CSP below can be applied via onHeadersReceived without replacing the listener
+// on the default session — Electron keeps only one onHeadersReceived listener per
+// session, and the default session's listener (main.js) injects the app-wide CSP.
+const QuickPreviewPartition = 'quickpreview';
+
 // Content Security Policy for quickpreview windows
 // Restricts script execution while allowing external images
 const QuickPreviewCSP = [
@@ -227,10 +233,11 @@ export function displayQuickPreviewWindow(filePath: string) {
         preload: path.join(filesRoot, 'preload.js'),
         nodeIntegration: false,
         contextIsolation: true,
+        partition: QuickPreviewPartition,
       },
     });
 
-    // Apply Content Security Policy
+    // Apply Content Security Policy to the quickpreview partition only
     quickPreviewWindow.webContents.session.webRequest.onHeadersReceived((details, callback) => {
       callback({
         responseHeaders: {
@@ -325,10 +332,11 @@ function _createCaptureWindow() {
       preload: path.join(filesRoot, 'preload.js'),
       nodeIntegration: false,
       contextIsolation: true,
+      partition: QuickPreviewPartition,
     },
   });
 
-  // Apply Content Security Policy
+  // Apply Content Security Policy to the quickpreview partition only
   win.webContents.session.webRequest.onHeadersReceived((details, callback) => {
     callback({
       responseHeaders: {


### PR DESCRIPTION
## Problem

  The strict quickpreview CSP added in #2523 is registered via
  `session.webRequest.onHeadersReceived` on the **default session**, because the
  preview and thumbnail capture windows are created without a `partition`.
  Electron keeps only one `onHeadersReceived` listener per session, so the first
  generated attachment preview/thumbnail silently replaces the app-wide CSP
  handler (`main.js`) with `default-src 'self'`.

  Every window loaded afterward inherits the strict policy, blocking
  cross-origin fetches. Most visibly, the OAuth token exchange in onboarding
  (`login.microsoftonline.com` / `accounts.google.com`) is refused by CSP,
  breaking Office 365 and Gmail account setup:

      Connecting to 'https://login.microsoftonline.com/common/oauth2/v2.0/token'
      violates the following Content Security Policy directive: "default-src 'self'".

  ## Fix

  Give both quickpreview windows a dedicated in-memory session partition
  (`partition: 'quickpreview'`) so the strict CSP applies only to them, as
  intended. Side benefit: preview content no longer shares cookies/cache with
  the app session.

  ## Repro / verification

  1. Open an email attachment so a thumbnail is generated.
  2. Settings → Accounts → Add Office 365 account.
  3. Before: token exchange blocked by CSP. After: account setup succeeds.

  `tsc --noEmit`, eslint, and prettier all pass.
