### PR TITLE
fix: catch EPERM when forking background query agent on Windows

### DIFF
--- a/app/src/flux/stores/database-store.ts
+++ b/app/src/flux/stores/database-store.ts
@@ -375,7 +375,9 @@ class DatabaseStore extends MailspringStore {
         // On Windows, security software (antivirus / AppLocker) can deny the
         // fork() call with EPERM. Fall back to in-process queries rather than
         // crashing — the promise below already handles a null agent.
-        console.error(`Query Agent: failed to spawn (${err.toString()}), falling back to local execution`);
+        console.error(
+          `Query Agent: failed to spawn (${err.toString()}), falling back to local execution`
+        );
         this._agent = null;
       }
     }

--- a/app/src/flux/stores/database-store.ts
+++ b/app/src/flux/stores/database-store.ts
@@ -349,26 +349,35 @@ class DatabaseStore extends MailspringStore {
   _executeInBackground(query: SQLString, values: SQLValue[]) {
     if (!this._agent) {
       this._agentOpenQueries = {};
-      this._agent = childProcess.fork(AGENT_PATH, [], { silent: true });
-      if (this._agent.stdout) this._agent.stdout.on('data', (data) => console.log(data.toString()));
-      if (this._agent.stderr)
-        this._agent.stderr.on('data', (data) => console.error(data.toString()));
-      this._agent.on('close', (code) => {
-        debug(`Query Agent: exited with code ${code}`);
+      try {
+        this._agent = childProcess.fork(AGENT_PATH, [], { silent: true });
+        if (this._agent.stdout)
+          this._agent.stdout.on('data', (data) => console.log(data.toString()));
+        if (this._agent.stderr)
+          this._agent.stderr.on('data', (data) => console.error(data.toString()));
+        this._agent.on('close', (code) => {
+          debug(`Query Agent: exited with code ${code}`);
+          this._agent = null;
+        });
+        this._agent.on('error', (err) => {
+          console.error(`Query Agent: failed to start or receive message: ${err.toString()}`);
+          if (this._agent) this._agent.kill('SIGTERM');
+          this._agent = null;
+        });
+        this._agent.on('message', (message: Record<string, any>) => {
+          const { type, id, results, agentTime } = message;
+          if (type === 'results' && this._agentOpenQueries[id]) {
+            this._agentOpenQueries[id]({ results, agentTime });
+            delete this._agentOpenQueries[id];
+          }
+        });
+      } catch (err) {
+        // On Windows, security software (antivirus / AppLocker) can deny the
+        // fork() call with EPERM. Fall back to in-process queries rather than
+        // crashing — the promise below already handles a null agent.
+        console.error(`Query Agent: failed to spawn (${err.toString()}), falling back to local execution`);
         this._agent = null;
-      });
-      this._agent.on('error', (err) => {
-        console.error(`Query Agent: failed to start or receive message: ${err.toString()}`);
-        if (this._agent) this._agent.kill('SIGTERM');
-        this._agent = null;
-      });
-      this._agent.on('message', (message: Record<string, any>) => {
-        const { type, id, results, agentTime } = message;
-        if (type === 'results' && this._agentOpenQueries[id]) {
-          this._agentOpenQueries[id]({ results, agentTime });
-          delete this._agentOpenQueries[id];
-        }
-      });
+      }
     }
 
     // eslint-disable-next-line no-async-promise-executor

--- a/app/src/flux/stores/database-store.ts
+++ b/app/src/flux/stores/database-store.ts
@@ -344,10 +344,11 @@ class DatabaseStore extends MailspringStore {
   }
 
   _agent?: ChildProcess;
+  _agentSpawnFailed = false;
   _agentOpenQueries: { [id: string]: (args: AgentResponse) => void };
 
   _executeInBackground(query: SQLString, values: SQLValue[]) {
-    if (!this._agent) {
+    if (!this._agent && !this._agentSpawnFailed) {
       this._agentOpenQueries = {};
       try {
         this._agent = childProcess.fork(AGENT_PATH, [], { silent: true });
@@ -375,10 +376,13 @@ class DatabaseStore extends MailspringStore {
         // On Windows, security software (antivirus / AppLocker) can deny the
         // fork() call with EPERM. Fall back to in-process queries rather than
         // crashing — the promise below already handles a null agent.
+        // Set _agentSpawnFailed so we skip the fork on every subsequent query
+        // rather than re-attempting and spamming the console.
         console.error(
           `Query Agent: failed to spawn (${err.toString()}), falling back to local execution`
         );
         this._agent = null;
+        this._agentSpawnFailed = true;
       }
     }
 


### PR DESCRIPTION
## Sentry Issue

Fixes [MAILSPRING-CLIENT-1M](https://foundry-376-llc.sentry.io/issues/MAILSPRING-CLIENT-1M) — **98 users impacted**, 120 events.

## Root Cause

`DatabaseStore._executeInBackground` spawns a background `database-agent.js` worker via `childProcess.fork()` to run expensive SQLite queries off the main thread. On Windows, security software (antivirus, AppLocker, Windows Defender Application Control, etc.) can block child process creation entirely, causing `fork()` to throw a synchronous `EPERM` error.

The throw happens *before* any event handlers are registered, so the existing `'error'` event handler on the `ChildProcess` never fires. The exception propagated all the way up through `DatabaseStore.run` → `SearchQuerySubscription._fetchRange`, crashing the query pipeline for the entire session.

Ironically, `_executeInBackground` already has the right fallback: if `this._agent` is `null` after the spawn attempt, it silently runs the query in-process via `_executeLocally`. But that path was unreachable because the synchronous throw exited the function before reaching it.

## The Fix

Wrap the `childProcess.fork()` call and all its event-handler wiring in a `try/catch`. On any synchronous spawn failure, log to console and set `this._agent = null` — the existing local-execution fallback in the promise body then takes over transparently. The app stays fully functional; background queries just run in-process instead of a worker, with no user-visible impact.

```
// Before: fork() throws EPERM → unhandled exception → crash
this._agent = childProcess.fork(AGENT_PATH, [], { silent: true });

// After: fork() throws EPERM → caught → this._agent stays null → fallback to _executeLocally
try {
  this._agent = childProcess.fork(AGENT_PATH, [], { silent: true });
  // ...event handler wiring...
} catch (err) {
  console.error(`Query Agent: failed to spawn (${err.toString()}), falling back to local execution`);
  this._agent = null;
}
```

## Test Plan

- [ ] Normal operation: background query agent spawns and handles queries as before
- [ ] Simulated EPERM (e.g. rename/remove the agent binary temporarily): app falls back to in-process queries without error dialog or crash
- [ ] Verify no regression in search / thread list on macOS and Linux

https://claude.ai/code/session_01MkBD9PMeA22JcaTLMhtDAc

---
_Generated by [Claude Code](https://claude.ai/code/session_01MkBD9PMeA22JcaTLMhtDAc)_