### PR TITLE
Mailspring.desktop: use a template var as icon value

### DIFF
--- a/app/build/resources/linux/Mailspring.desktop.in
+++ b/app/build/resources/linux/Mailspring.desktop.in
@@ -3,7 +3,7 @@ Name=<%= productName %>
 Comment=<%= description %>
 GenericName=Mail Client
 Exec=mailspring %U
-Icon=mailspring
+Icon=<%= name %>
 Type=Application
 Categories=GNOME;GTK;Network;Email;
 Keywords=email;internet;


### PR DESCRIPTION
`build.js` will replace this with `mailspring`, so for the default distribution nothing changes.

It does make flatpak packing easier however, as the icon is named `com.getmailspring.Mailspring` there. Since the icon name should always equal the application name anyway, this is also unlikely to break something in the future.