### PR TITLE
Get desktop name dynamically from package.json

### DIFF
--- a/app/src/default-client-helper.ts
+++ b/app/src/default-client-helper.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import { exec } from 'child_process';
 import { shell } from 'electron';
 import { localized } from './intl';
+import pkg from './utils/package';
 
 const bundleIdentifier = 'com.mailspring.mailspring';
 
@@ -116,7 +117,7 @@ export class DefaultClientHelperLinux implements DCH {
       throw new Error('isRegisteredForURLScheme is async, provide a callback');
     }
     exec(`xdg-mime query default x-scheme-handler/${scheme}`, (err, stdout) =>
-      err ? callback(err) : callback(stdout.trim() === 'Mailspring.desktop')
+      err ? callback(err) : callback(stdout.trim() === pkg.desktopName)
     );
   }
 
@@ -126,7 +127,7 @@ export class DefaultClientHelperLinux implements DCH {
     );
   }
   registerForURLScheme(scheme: string, callback = (error?: Error) => {}) {
-    exec(`xdg-mime default Mailspring.desktop x-scheme-handler/${scheme}`, (err: Error | null) =>
+    exec(`xdg-mime default ${pkg.desktopName} x-scheme-handler/${scheme}`, (err: Error | null) =>
       err ? callback(err) : callback(null)
     );
   }

--- a/app/src/native-notifications.ts
+++ b/app/src/native-notifications.ts
@@ -4,6 +4,7 @@ import { convertToPNG, getIcon, Context } from './linux-theme-utils';
 import { getDoNotDisturb as getMacDoNotDisturb } from './dnd-utils-macos';
 import { getDoNotDisturb as getLinuxDoNotDisturb } from './dnd-utils-linux';
 import { getDoNotDisturb as getWindowsDoNotDisturb } from './dnd-utils-windows';
+import pkg from './utils/package';
 import path from 'path';
 import fs from 'fs';
 import os from 'os';
@@ -146,30 +147,28 @@ class NativeNotifications {
       os.homedir() + '/.local/share/applications/',
       '/usr/share/applications/',
     ];
-    const desktopFileNames = ['mailspring.desktop', 'Mailspring.desktop'];
     // check the applications directories, the user directory has a higher priority
     for (const baseDir of desktopBaseDirs) {
-      // check multiple spellings
-      for (const fileName of desktopFileNames) {
-        const filePath = path.join(baseDir, fileName);
-        const desktopIcon = this.readIconFromDesktopFile(filePath);
-        if (desktopIcon != null) {
-          if (fs.existsSync(desktopIcon)) {
-            // icon is a file and can be returned
-            return desktopIcon;
-          }
-          // icon is a name and we need to get it from the icon theme
-          const iconPath = getIcon(desktopIcon, 64, Context.APPLICATIONS, 2);
-          if (iconPath != null) {
-            // only .png icons work with notifications
-            if (path.extname(iconPath) === '.png') {
-              return iconPath;
-            }
-            const converted = convertToPNG(desktopIcon, iconPath);
-            if (converted != null) {
-              return converted;
-            }
-          }
+      const filePath = path.join(baseDir, pkg.desktopName);
+      const desktopIcon = this.readIconFromDesktopFile(filePath);
+      if (!desktopIcon) {
+        continue;
+      }
+
+      if (fs.existsSync(desktopIcon)) {
+        // icon is a file and can be returned
+        return desktopIcon;
+      }
+      // icon is a name and we need to get it from the icon theme
+      const iconPath = getIcon(desktopIcon, 64, Context.APPLICATIONS, 2);
+      if (iconPath != null) {
+        // only .png icons work with notifications
+        if (path.extname(iconPath) === '.png') {
+          return iconPath;
+        }
+        const converted = convertToPNG(desktopIcon, iconPath);
+        if (converted != null) {
+          return converted;
         }
       }
     }

--- a/app/src/system-start-service.ts
+++ b/app/src/system-start-service.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import fs from 'fs';
 import os from 'os';
+import pkg from './utils/package';
 
 class SystemStartServiceBase {
   checkAvailability(): Promise<boolean> {
@@ -147,12 +148,12 @@ class SystemStartServiceLinux extends SystemStartServiceBase {
   }
 
   _launcherPath() {
-    return path.join('/', 'usr', 'share', 'applications', 'Mailspring.desktop');
+    return path.join('/', 'usr', 'share', 'applications', pkg.desktopName);
   }
 
   _shortcutPath() {
     const configDir = process.env.XDG_CONFIG_HOME || path.join(os.homedir(), '.config');
-    return path.join(configDir, 'autostart', 'Mailspring.desktop');
+    return path.join(configDir, 'autostart', pkg.desktopName);
   }
 }
 

--- a/app/src/utils/package.ts
+++ b/app/src/utils/package.ts
@@ -1,0 +1,5 @@
+import pkg from '../../package.json';
+
+pkg.desktopName = pkg.desktopName || pkg.name ? `${pkg.name}.desktop` : 'Mailspring.desktop';
+
+export default pkg;

--- a/app/src/utils/package.ts
+++ b/app/src/utils/package.ts
@@ -1,5 +1,5 @@
 import pkg from '../../package.json';
 
-pkg.desktopName = pkg.desktopName || pkg.name ? `${pkg.name}.desktop` : 'Mailspring.desktop';
+pkg.desktopName = pkg.desktopName || (pkg.name ? `${pkg.name}.desktop` : 'Mailspring.desktop');
 
 export default pkg;


### PR DESCRIPTION
Do not hardcode it, instead read it from package.json.

Includes a small utility that falls back to `name` + `".desktop"` if `desktopName` is not set. This is is the same behaviour as electron.

This also makes flatpak packaging easier, where the desktop name is `com.getmailspring.Mailspring.desktop`. This way i only have to patch the `package.json`.