### PR TITLE
fix: prevent onboarding crash when back-navigation empties page stack

### DIFF
--- a/app/internal_packages/onboarding/lib/onboarding-root.tsx
+++ b/app/internal_packages/onboarding/lib/onboarding-root.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { CSSTransition, TransitionGroup } from 'react-transition-group';
-import { Account, AccountStore } from 'mailspring-exports';
+import { Account } from 'mailspring-exports';
 import OnboardingStore from './onboarding-store';
 import PageTopBar from './page-top-bar';
 
@@ -79,14 +79,7 @@ export default class OnboardingRoot extends React.Component<
   render() {
     const Component = PageComponents[this.state.page];
     if (!Component) {
-      // Guard against empty page stack (e.g. rapid back-button clicks draining the stack).
-      // Close or quit rather than throwing an unhandled error.
-      if (AccountStore.accounts().length === 0) {
-        AppEnv.quit();
-      } else {
-        AppEnv.close();
-      }
-      return null;
+      throw new Error(`Cannot find component for page: ${this.state.page}`);
     }
 
     return (

--- a/app/internal_packages/onboarding/lib/onboarding-root.tsx
+++ b/app/internal_packages/onboarding/lib/onboarding-root.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { CSSTransition, TransitionGroup } from 'react-transition-group';
-import { Account } from 'mailspring-exports';
+import { Account, AccountStore } from 'mailspring-exports';
 import OnboardingStore from './onboarding-store';
 import PageTopBar from './page-top-bar';
 
@@ -79,7 +79,14 @@ export default class OnboardingRoot extends React.Component<
   render() {
     const Component = PageComponents[this.state.page];
     if (!Component) {
-      throw new Error(`Cannot find component for page: ${this.state.page}`);
+      // Guard against empty page stack (e.g. rapid back-button clicks draining the stack).
+      // Close or quit rather than throwing an unhandled error.
+      if (AccountStore.accounts().length === 0) {
+        AppEnv.quit();
+      } else {
+        AppEnv.close();
+      }
+      return null;
     }
 
     return (

--- a/app/internal_packages/onboarding/lib/onboarding-store.ts
+++ b/app/internal_packages/onboarding/lib/onboarding-store.ts
@@ -112,6 +112,7 @@ class OnboardingStore extends MailspringStore {
   };
 
   _onMoveToPreviousPage = () => {
+    if (this._pageStack.length <= 1) return;
     this._pageStack.pop();
     this.trigger();
   };


### PR DESCRIPTION
## Summary

Fixes Sentry issue [MAILSPRING-CLIENT-26](https://foundry-376-llc.sentry.io/issues/MAILSPRING-CLIENT-26) — **23 users affected**, 59 occurrences.

**Error:** `Cannot find component for page: undefined`
**Location:** `OnboardingRoot.render()` in `onboarding-root.tsx`

### Root Cause

`OnboardingStore._onMoveToPreviousPage` pops from `_pageStack` with no bounds check. If the action fires when only one page is on the stack (e.g. rapid back-button double-clicks, or any duplicate dispatch of `moveToPreviousPage`), the stack becomes empty. `page()` then returns `undefined`, and `OnboardingRoot.render()` throws an unhandled error instead of degrading gracefully.

The stale-closure risk in `PageTopBar`: `closeAction` captures `pageDepth` from props at render time. A rapid double-click could fire both handlers with `pageDepth = 2` before the re-render reflecting the first pop, triggering `moveToPreviousPage()` twice in succession and draining the stack to zero.

### Fix (two layers)

1. **`onboarding-store.ts`** — Guard in `_onMoveToPreviousPage`: bail out early if the stack has only one page, making it impossible to empty the stack via back-navigation.

2. **`onboarding-root.tsx`** — Defensive fallback in `render()`: if `page` is somehow still undefined (any future unknown cause), close/quit the window gracefully instead of throwing an unhandled exception that reaches Sentry.

## Test plan

- [ ] Launch onboarding as a new user (welcome page). Verify the X button closes the window and does not crash.
- [ ] Navigate forward to account-choose, then rapidly double-click the back button. Verify no crash — should land on welcome page or close gracefully.
- [ ] Normal onboarding flow completes without regression.

https://claude.ai/code/session_01PGz7rfpJU4fs2QMeT7sdYw

---
_Generated by [Claude Code](https://claude.ai/code/session_01PGz7rfpJU4fs2QMeT7sdYw)_