### PR TITLE
Fix null crash in translation plugin when iframe contentDocument is not yet loaded

### DIFF
--- a/app/internal_packages/translation/lib/message-header.tsx
+++ b/app/internal_packages/translation/lib/message-header.tsx
@@ -135,7 +135,7 @@ export class TranslateMessageHeader extends React.Component<
     const el = ReactDOM.findDOMNode(this) as Element;
     const messageEl = el && el.closest('.message-item-area');
     const iframeEl = messageEl && messageEl.querySelector('iframe');
-    if (!iframeEl || !this.props.message.body) return;
+    if (!iframeEl || !iframeEl.contentDocument?.body || !this.props.message.body) return;
 
     let text = iframeEl.contentDocument.body.innerText;
     if (text.length > 1000) text = text.slice(0, 1000);


### PR DESCRIPTION
## Summary

Fixes Sentry issue [MAILSPRING-CLIENT-1J](https://foundry-376-llc.sentry.io/issues/MAILSPRING-CLIENT-1J) — **17 users, 40 events**, last seen today (2026-06-16).

## Root Cause

In `TranslateMessageHeader._detectLanguageIfReady`, after the 1-second delay the code finds the `<iframe>` that renders the message body and reads `iframeEl.contentDocument.body.innerText` to extract plain text for language detection.

The guard at the top of that block was:

```ts
if (!iframeEl || !this.props.message.body) return;
```

This does **not** check whether `iframeEl.contentDocument` exists. An iframe's `contentDocument` property can be `null` before the frame has finished loading (e.g. if the user clicks a message and the 1-second delay expires while the iframe is still initialising). Accessing `.body` on that `null` value throws:

> `Cannot read properties of null (reading 'body')`

## Fix

Extend the guard to also bail out when `contentDocument` or its `body` are not yet available:

```ts
// Before
if (!iframeEl || !this.props.message.body) return;

// After
if (!iframeEl || !iframeEl.contentDocument?.body || !this.props.message.body) return;
```

The optional-chaining `?.` means the expression evaluates to `undefined` (falsy) when either `contentDocument` is null or `body` is absent, so the early-return fires and we never attempt to access `innerText` on a null document.

## Test plan

- [ ] Open a message that triggers language detection (non-native-locale email) — translation banner should appear normally
- [ ] Rapidly switch between messages (stress-tests the 1-second delay path) — no crash
- [ ] Confirm no new events in Sentry for MAILSPRING-CLIENT-1J after deploy

https://claude.ai/code/session_011NaQUh61L5Q3VnyG7dRyc3

---
_Generated by [Claude Code](https://claude.ai/code/session_011NaQUh61L5Q3VnyG7dRyc3)_