### PR TITLE
fix: guard nativeTheme @electron/remote access against GC'd remote object

### DIFF
--- a/app/internal_packages/system-tray/lib/system-tray-icon-store.ts
+++ b/app/internal_packages/system-tray/lib/system-tray-icon-store.ts
@@ -25,6 +25,7 @@ Current / Intended Behavior:
 class SystemTrayIconStore {
   _windowBackgrounded = false;
   _unsubscribers: (() => void)[];
+  _onNativeThemeUpdated = () => this._updateIcon();
 
   activate() {
     this._updateIcon();
@@ -40,12 +41,11 @@ class SystemTrayIconStore {
       window.removeEventListener('browser-window-focus', this._onWindowFocus);
       window.removeEventListener('browser-window-hide', this._onWindowBackgrounded);
       window.removeEventListener('browser-window-blur', this._onWindowBackgrounded);
+      nativeTheme.removeListener('updated', this._onNativeThemeUpdated);
     });
 
     // If the theme changes from bright to dark mode or vice versa, we need to update the tray icon
-    nativeTheme.on('updated', () => {
-      this._updateIcon();
-    });
+    nativeTheme.on('updated', this._onNativeThemeUpdated);
   }
 
   deactivate() {
@@ -70,7 +70,13 @@ class SystemTrayIconStore {
   // Returns '-dark' when we need a light icon (for dark backgrounds).
   _dark = () => {
     if (process.platform === 'win32') {
-      return nativeTheme.shouldUseDarkColors ? '-dark' : '';
+      // nativeTheme is accessed via @electron/remote; guard against the remote
+      // object being GC'd during window teardown (Sentry MAILSPRING-CLIENT-49).
+      try {
+        return nativeTheme.shouldUseDarkColors ? '-dark' : '';
+      } catch {
+        return '';
+      }
     }
     if (process.platform === 'linux') {
       const traySystemTheme = AppEnv.config.get('core.workspace.traySystemTheme') || 'automatic';
@@ -87,7 +93,11 @@ class SystemTrayIconStore {
       if (desktop.includes('GNOME') || desktop.includes('UNITY')) {
         return '-dark';
       }
-      return nativeTheme.shouldUseDarkColors ? '-dark' : '';
+      try {
+        return nativeTheme.shouldUseDarkColors ? '-dark' : '';
+      } catch {
+        return '';
+      }
     }
     return '';
   };


### PR DESCRIPTION
## Problem

Sentry issue **MAILSPRING-CLIENT-49** — *"Cannot get property 'shouldUseDarkColors' on missing remote object"* — has affected **21 users** with **144 events** in the current release.

In `SystemTrayIconStore`, `nativeTheme` is imported from `@electron/remote` (renderer-side proxy to the main-process `nativeTheme` object):

```ts
const { nativeTheme } = require('@electron/remote');
```

Two bugs combine to produce the crash:

1. **Listener leak**: `nativeTheme.on('updated', handler)` was registered in `activate()` with an anonymous function, so it could never be removed in `deactivate()`. After the window is torn down, the listener remains alive and fires, calling `_updateIcon()` → `_dark()` → `nativeTheme.shouldUseDarkColors`.

2. **Unguarded remote access**: By the time the stale listener fires (or in any race between window teardown and a queued IPC round-trip), the main-process backing object for `nativeTheme` may already be garbage-collected. `@electron/remote` then throws `"Cannot get property 'shouldUseDarkColors' on missing remote object <id>"` from the main-process RPC server, which propagates back to the renderer as an unhandled error and is captured by Sentry.

## Fix

1. **Named handler** (`_onNativeThemeUpdated`): store the listener as a class field so `deactivate()` can call `nativeTheme.removeListener('updated', this._onNativeThemeUpdated)`, stopping the listener before the renderer is fully torn down.

2. **try/catch guard**: wrap both `nativeTheme.shouldUseDarkColors` accesses in `_dark()` (one for `win32`, one for `linux`) so that any unavoidable race (e.g. a mid-flight IPC call when the GC fires) degrades gracefully to the light icon instead of crashing.

## Sentry

Fixes https://foundry-376-llc.sentry.io/issues/MAILSPRING-CLIENT-49

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01431scVXjdTi5cWgYxVYN6k

---
_Generated by [Claude Code](https://claude.ai/code/session_01431scVXjdTi5cWgYxVYN6k)_