### PR TITLE
Fix navigator.clipboard.writeText in @electron/remote MenuItem handlers

### DIFF
--- a/app/internal_packages/main-calendar/lib/core/event-attendees-input.tsx
+++ b/app/internal_packages/main-calendar/lib/core/event-attendees-input.tsx
@@ -119,15 +119,13 @@ export class EventAttendeesInput extends React.Component<EventAttendeesInputProp
     // Warning: Menu is already initialized as Menu.cjsx!
     const MenuClass = require('@electron/remote').Menu;
     const MenuItem = require('@electron/remote').MenuItem;
+    const clipboard = require('@electron/remote').clipboard;
 
     const menu = new MenuClass();
     menu.append(
       new MenuItem({
         label: `${localized(`Copy`)} ${participant.email}`,
-        click: () =>
-          navigator.clipboard
-            .writeText(participant.email)
-            .catch((err) => console.error('Failed to copy to clipboard:', err)),
+        click: () => clipboard.writeText(participant.email),
       })
     );
     menu.append(

--- a/app/internal_packages/message-list/lib/message-controls.tsx
+++ b/app/internal_packages/message-list/lib/message-controls.tsx
@@ -180,9 +180,7 @@ export default class MessageControls extends React.Component<MessageControlsProp
       Thread ID: ${thread.id}
       Thread Metadata: ${JSON.stringify(thread.pluginMetadata, null, '  ')}
     `;
-    navigator.clipboard
-      .writeText(data)
-      .catch((err) => console.error('Failed to copy to clipboard:', err));
+    require('@electron/remote').clipboard.writeText(data);
   };
 
   render() {

--- a/app/internal_packages/message-list/lib/message-participants.tsx
+++ b/app/internal_packages/message-list/lib/message-participants.tsx
@@ -3,7 +3,7 @@ import classnames from 'classnames';
 import React from 'react';
 import { localized, Actions, Contact } from 'mailspring-exports';
 
-const { Menu, MenuItem } = require('@electron/remote');
+const { Menu, MenuItem, clipboard } = require('@electron/remote');
 const MAX_COLLAPSED = 5;
 
 interface MessageParticipantsProps {
@@ -74,7 +74,7 @@ export default class MessageParticipants extends React.Component<MessageParticip
         ? new MenuItem({ role: 'copy' })
         : new MenuItem({
             label: `${localized(`Copy`)} "${contact.email}"`,
-            click: () => navigator.clipboard.writeText(contact.email),
+            click: () => clipboard.writeText(contact.email),
           })
     );
     menu.append(

--- a/app/internal_packages/thread-list/lib/thread-list-context-menu.ts
+++ b/app/internal_packages/thread-list/lib/thread-list-context-menu.ts
@@ -325,9 +325,7 @@ export default class ThreadListContextMenu {
         const id = this.threadIds[0];
         const thread = await DatabaseStore.findBy<Thread>(Thread, { id }).limit(1);
         if (!thread) return;
-        navigator.clipboard
-          .writeText(thread.getMailboxPermalink())
-          .catch((err) => console.error('Failed to copy to clipboard:', err));
+        require('@electron/remote').clipboard.writeText(thread.getMailboxPermalink());
       },
     };
   }

--- a/app/src/components/evented-iframe.tsx
+++ b/app/src/components/evented-iframe.tsx
@@ -305,7 +305,7 @@ export class EventedIFrame extends React.Component<
     event.preventDefault();
 
     const { shell, ipcRenderer } = require('electron');
-    const { Menu, MenuItem } = require('@electron/remote');
+    const { Menu, MenuItem, clipboard } = require('@electron/remote');
     const menu = new Menu();
 
     // Menu actions for links
@@ -325,9 +325,7 @@ export class EventedIFrame extends React.Component<
           new MenuItem({
             label: localized('Copy Email Address'),
             click() {
-              navigator.clipboard
-                .writeText(href.split('mailto:').pop())
-                .catch((err) => console.error('Failed to copy to clipboard:', err));
+              clipboard.writeText(href.split('mailto:').pop());
             },
           })
         );
@@ -344,9 +342,7 @@ export class EventedIFrame extends React.Component<
           new MenuItem({
             label: localized('Copy Link Address'),
             click() {
-              navigator.clipboard
-                .writeText(href)
-                .catch((err) => console.error('Failed to copy to clipboard:', err));
+              clipboard.writeText(href);
             },
           })
         );
@@ -433,9 +429,7 @@ export class EventedIFrame extends React.Component<
         new MenuItem({
           label: localized('Copy'),
           click() {
-            navigator.clipboard
-              .writeText(text)
-              .catch((err) => console.error('Failed to copy to clipboard:', err));
+            clipboard.writeText(text);
           },
         })
       );

--- a/app/src/components/participants-text-field.tsx
+++ b/app/src/components/participants-text-field.tsx
@@ -175,15 +175,13 @@ export default class ParticipantsTextField extends React.Component<ParticipantsT
     // Warning: Menu is already initialized as Menu.ts!
     const MenuClass = require('@electron/remote').Menu;
     const MenuItem = require('@electron/remote').MenuItem;
+    const clipboard = require('@electron/remote').clipboard;
 
     const menu = new MenuClass();
     menu.append(
       new MenuItem({
         label: `${localized(`Copy`)} ${participant.email}`,
-        click: () =>
-          navigator.clipboard
-            .writeText(participant.email)
-            .catch((err) => console.error('Failed to copy to clipboard:', err)),
+        click: () => clipboard.writeText(participant.email),
       })
     );
     menu.append(


### PR DESCRIPTION
## Sentry Issue

[MAILSPRING-CLIENT-2R](https://foundry-376-llc.sentry.io/issues/MAILSPRING-CLIENT-2R) — 16 users affected, 30 events, ongoing since May 2026

## Root Cause

When a user right-clicks on a contact name/email in the message header, a context menu appears with a "Copy email address" item. Clicking it called `navigator.clipboard.writeText(contact.email)`, which reported `Error: Unknown error` to Sentry.

The context menu's `click` handler is invoked via `@electron/remote` IPC — the main process calls back into the renderer via IPC after the menu item is selected. At that point:

1. The rendering window no longer has focus (it lost focus when the OS-native context menu appeared)
2. `navigator.clipboard.writeText()` is a Web Clipboard API that requires both a transient user gesture **and** an active, focused browsing context
3. When called through an IPC callback, neither condition is guaranteed, causing the browser to reject the write with "Unknown error"

## Fix

Replace `navigator.clipboard.writeText()` with `@electron/remote`'s `clipboard.writeText()`, which routes through Electron's main-process clipboard API and works regardless of window focus. As a bonus, the call is now synchronous so there's no unhandled promise rejection.

This pattern was present in five files — all fixed in this PR:

- `app/internal_packages/message-list/lib/message-participants.tsx` — Copy contact email (original Sentry report)
- `app/internal_packages/main-calendar/lib/core/event-attendees-input.tsx` — Copy event attendee email
- `app/src/components/participants-text-field.tsx` — Copy participant email
- `app/src/components/evented-iframe.tsx` — Copy Email Address / Copy Link Address / Copy selected text
- `app/internal_packages/thread-list/lib/thread-list-context-menu.ts` — Copy mailbox permalink

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqXVeX65b7daqB5rU4jTuJ