### PR TITLE
Fix composer cut crash + suppress third-party plugin Sentry noise

### DIFF
--- a/app/src/components/composer-editor/composer-editor.tsx
+++ b/app/src/components/composer-editor/composer-editor.tsx
@@ -222,10 +222,14 @@ export class ComposerEditor extends React.Component<ComposerEditorProps, Compose
   };
 
   onCut = (event, editor: Editor, next: () => void) => {
-    this.onCopy(event, editor, next);
+    // Run our clipboard setup without advancing the slate plugin chain.
+    // We must call next() exactly once below — onCopy would call it a second
+    // time if we passed the real next, causing cloneFragment to run twice and
+    // crash with "Cannot read properties of undefined (reading 'firstChild')".
+    this.onCopy(event, editor, () => {});
 
-    // Allow slate to attach it's own data, which it can use to paste nicely
-    // if the paste target is the editor. Note: Slate also cuts the selection.
+    // Advance the chain once so Slate can attach its fragment data and delete
+    // the selected text (the actual "cut" behavior).
     next();
   };
 

--- a/app/src/package-manager.ts
+++ b/app/src/package-manager.ts
@@ -150,11 +150,20 @@ export default class PackageManager {
         d.dispose();
       }
       pkg.disposables = [];
-      AppEnv.reportError(
-        new Error(
-          localized(`Failed to activate plugin %@: %@`, pkg.name, err.message || err.toString())
-        )
+      const message = localized(
+        `Failed to activate plugin %@: %@`,
+        pkg.name,
+        err.message || err.toString()
       );
+      // Only report activation failures for built-in packages. User-installed
+      // third-party plugins can fail for many reasons outside our control
+      // (stale APIs, missing deps, etc.) and reporting them to Sentry creates
+      // noise that we cannot act on.
+      if (pkg.directory.startsWith(this.resourcePath)) {
+        AppEnv.reportError(new Error(message));
+      } else {
+        console.error(message, err);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes two Sentry issues found in the 1.22.0 release:

### MAILSPRING-CLIENT-42 — Composer cut crashes with "Cannot read properties of undefined (reading 'firstChild')" (17 users, 41 events)

**Root cause:** `onCut` passed the real `next` callback to `onCopy`, which called `next()` once internally. Then `onCut` called `next()` a second time. This double-invocation caused slate-react's `cloneFragment` to run twice: the first time worked fine, but on the second invocation the DOM selection had already been modified by the cut, so `firstChild` was `undefined`.

```
slate-react:1740 (cloneFragment)  ← crashes here (second invocation)
slate-react:2357 (onCut)
slate:11430 (next)                ← second next() call, from onCut
composer-editor.tsx:221 (onCopy)  → next()  ← first next() call
slate:11430 (next)
composer-editor.tsx:225 (onCut)   → this.onCopy(event, editor, next)
slate-react:3011 (onCut)
```

**Fix:** Pass a no-op callback to `onCopy` from `onCut`, then call `next()` exactly once in `onCut`. `onCopy` still sets the `text/html` and `text/plain` clipboard data; the single `next()` call lets Slate attach its fragment and perform the text deletion.

### MAILSPRING-CLIENT-3 — "Failed to activate plugin mailspring-avatars" (35 users, 475 events)

**Root cause:** `mailspring-avatars` is a user-installed third-party plugin (not in `internal_packages`). It fails with `Cannot read properties of undefined (reading 'string')` during activation — likely because it relies on a deprecated API (e.g. `React.PropTypes.string`). We have no control over this plugin's code.

**Fix:** In `package-manager.ts`, only report activation failures to Sentry for built-in packages (those whose directory is under `resourcePath`). For user-installed plugins, the error is still logged to the console but no longer sent to Sentry, where it is not actionable.

## Test plan

- [ ] Open the composer, write some text, select it, and press Ctrl+X (Cut) — text should be cut to clipboard without a crash
- [ ] Confirm Ctrl+C (Copy) still works normally
- [ ] Confirm paste from cut works correctly in both composer and other apps
- [ ] Install a broken third-party plugin and confirm its activation error appears in the DevTools console but NOT in Sentry

## Sentry links
- https://foundry-376-llc.sentry.io/issues/MAILSPRING-CLIENT-42
- https://foundry-376-llc.sentry.io/issues/MAILSPRING-CLIENT-3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HgZZbFxdx38Ngc9vpanNow

---
_Generated by [Claude Code](https://claude.ai/code/session_01HgZZbFxdx38Ngc9vpanNow)_