### PR TITLE
Fix null crashes in SendDraftTask, thread-sharing, and send-and-archive

### DIFF
--- a/app/internal_packages/composer-grammar-check/lib/grammar-check-store.ts
+++ b/app/internal_packages/composer-grammar-check/lib/grammar-check-store.ts
@@ -101,7 +101,11 @@ class _GrammarCheckStore extends MailspringStore {
   }
 
   markDirty(draftId: string, blockKey: string, blockText: string) {
-    if (!this._enabled || !FeatureUsageStore.isUsable(GRAMMAR_CHECK_FEATURE_ID) || !IdentityStore.identity()) {
+    if (
+      !this._enabled ||
+      !FeatureUsageStore.isUsable(GRAMMAR_CHECK_FEATURE_ID) ||
+      !IdentityStore.identity()
+    ) {
       return;
     }
     let draftDirty = this._dirtyBlocks.get(draftId);

--- a/app/internal_packages/send-and-archive/lib/send-and-archive-extension.ts
+++ b/app/internal_packages/send-and-archive/lib/send-and-archive-extension.ts
@@ -15,7 +15,7 @@ export function sendActions() {
 
         if (!draft.threadId) return;
 
-        const threads = await DatabaseStore.modelify(Thread, [draft.threadId]);
+        const threads = (await DatabaseStore.modelify(Thread, [draft.threadId])).filter(Boolean);
         const tasks = TaskFactory.tasksForArchiving({
           source: 'Send and Archive',
           threads: threads,

--- a/app/internal_packages/thread-sharing/lib/main.tsx
+++ b/app/internal_packages/thread-sharing/lib/main.tsx
@@ -44,6 +44,7 @@ export function sharingURLForThread(thread: Thread) {
     return null;
   }
   const identity = IdentityStore.identity();
+  if (!identity) return null;
   return `https://shared.getmailspring.com/thread/${identity.id}/${metadata.key}`;
 }
 
@@ -112,7 +113,9 @@ export const syncThreadToWeb = async (thread: Thread) => {
     }
   }
 
-  const { firstName, lastName, emailAddress } = IdentityStore.identity();
+  const identity = IdentityStore.identity();
+  if (!identity) return;
+  const { firstName, lastName, emailAddress } = identity;
 
   // next, post the JSON for the entire thread
   await MailspringAPIRequest.postStaticAsset({

--- a/app/src/flux/tasks/send-draft-task.ts
+++ b/app/src/flux/tasks/send-draft-task.ts
@@ -117,11 +117,10 @@ export class SendDraftTask extends Task {
   }
 
   willBeQueued() {
-    const account = AccountStore.accountForEmail(this.draft.from[0].email);
-
     if (!this.draft.from[0]) {
       throw new Error('SendDraftTask - you must populate `from` before sending.');
     }
+    const account = AccountStore.accountForEmail(this.draft.from[0].email);
     if (!account) {
       throw new Error('SendDraftTask - you can only send drafts from a configured account.');
     }


### PR DESCRIPTION
## Summary

Three null-crash bugs found by reviewing patterns similar to issues fixed since 1.21.1 (MAILSPRING-CLIENT-S, the DraftEditingSession fix in 2f1f38c, and the modelify `.filter(Boolean)` fix in 3b50544).

### 1. `SendDraftTask.willBeQueued()` — null `from[0]` before property access (most impactful)

**Root cause:** `willBeQueued()` accessed `this.draft.from[0].email` on line 120 and then checked `if (!this.draft.from[0])` on line 122. The guard was dead code — if `from` is empty, JavaScript returns `undefined` for `from[0]`, and `undefined.email` throws `TypeError: Cannot read properties of undefined (reading 'email')` before the guard ever runs.

This is the exact same pattern fixed in `DraftEditingSession.ensureCorrectAccount()` (commit 2f1f38c) but that fix missed `send-draft-task.ts`. The fix moves the null guard before the property access, mirroring the `ensureCorrectAccount` fix.

When it fires: when a user tries to send a draft whose `from` array is empty — most likely when they had an account configured at draft-creation time that was subsequently removed before sending.

### 2. `thread-sharing/main.tsx` — `IdentityStore.identity()` accessed without null check

**Root cause:** Two call sites:
- `sharingURLForThread()` (line 46-47): `identity.id` accessed directly on the result of `IdentityStore.identity()` which returns null when logged out.
- `syncThreadToWeb()` (line 115): destructures `{ firstName, lastName, emailAddress }` from `IdentityStore.identity()` — throws `TypeError: Cannot destructure property 'firstName' of null`.

The background listener `_onDatabaseChange` fires `syncThreadToWebSoon()` automatically for any thread flagged as shared, so a user who had shared threads and then logged out would trigger this crash without any deliberate action.

### 3. `send-and-archive` — missing `.filter(Boolean)` after `modelify`

**Root cause:** `DatabaseStore.modelify(Thread, [draft.threadId])` returns `undefined` in the array for any thread ID not found in the database. `TaskFactory.tasksForArchiving` calls `tasksForThreadsByAccountId` which throws `Error: 'threads' must be instances of Thread` when it encounters `undefined`. Adding `.filter(Boolean)` matches the pattern applied to `thread-list-context-menu.ts` in PR #2740.

## Fixes

- `send-draft-task.ts`: moved `if (!this.draft.from[0])` guard before the `AccountStore.accountForEmail(this.draft.from[0].email)` call
- `thread-sharing/main.tsx`: added `if (!identity) return null` in `sharingURLForThread` and `if (!identity) return` in `syncThreadToWeb` 
- `send-and-archive-extension.ts`: added `.filter(Boolean)` after `modelify` call

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y74MDbCThQnQAZuCE3qyFr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y74MDbCThQnQAZuCE3qyFr)_