### PR TITLE
Fix null-crash in three IPC handlers when BrowserWindow.fromWebContents() returns null

### DIFF
--- a/app/internal_packages/composer-grammar-check/lib/grammar-check-store.ts
+++ b/app/internal_packages/composer-grammar-check/lib/grammar-check-store.ts
@@ -101,7 +101,11 @@ class _GrammarCheckStore extends MailspringStore {
   }
 
   markDirty(draftId: string, blockKey: string, blockText: string) {
-    if (!this._enabled || !FeatureUsageStore.isUsable(GRAMMAR_CHECK_FEATURE_ID) || !IdentityStore.identity()) {
+    if (
+      !this._enabled ||
+      !FeatureUsageStore.isUsable(GRAMMAR_CHECK_FEATURE_ID) ||
+      !IdentityStore.identity()
+    ) {
       return;
     }
     let draftDirty = this._dirtyBlocks.get(draftId);

--- a/app/src/browser/application.ts
+++ b/app/src/browser/application.ts
@@ -679,6 +679,7 @@ export default class Application extends EventEmitter {
 
     ipcMain.on('window-command', (event, command, ...args) => {
       const win = BrowserWindow.fromWebContents(event.sender);
+      if (!win) return;
       win.emit(command, ...args);
     });
 
@@ -701,6 +702,7 @@ export default class Application extends EventEmitter {
         return;
       }
       const win = BrowserWindow.fromWebContents(event.sender);
+      if (!win) return;
       if (!win[method]) {
         console.error(`Method ${method} does not exist on BrowserWindow!`);
         return;
@@ -864,6 +866,7 @@ export default class Application extends EventEmitter {
 
     ipcMain.on('resize-window', (event, params) => {
       const sourceWindow = BrowserWindow.fromWebContents(event.sender);
+      if (!sourceWindow) return;
       sourceWindow.setSize(params.width, params.height);
     });
 


### PR DESCRIPTION
## Summary

Three IPC handlers in the main process (`window-command`, `call-window-method`, `resize-window`) were missing a null guard on the result of `BrowserWindow.fromWebContents(event.sender)`. When a BrowserWindow closes before the main process services an in-flight IPC message, `fromWebContents()` returns `null`, and the next property access throws a `TypeError` that is reported to Sentry.

This is the same class of bug that was fixed for `update-application-menu` in b2393e8 (Sentry MAILSPRING-CLIENT-4F). That prior fix guarded only that one handler; the remaining three were overlooked.

**Root cause observed in the code:**

- `window-command`: `win.emit(command, ...args)` crashes when `win` is `null`
- `call-window-method`: `win[method]` on line after the allowed-method check crashes when `win` is `null`; this handler is called for **all** common window ops (focus, maximize, minimize, center, show/hide, setFullScreen, setPosition) — highest exposure
- `resize-window`: `sourceWindow.setSize(...)` crashes when `sourceWindow` is `null`

**Fix:** Add `if (!win) return` / `if (!sourceWindow) return` immediately after each `fromWebContents()` call, exactly as was done for the already-fixed handler.

## Investigation note

The Sentry MCP OAuth token was expired at investigation time, so I couldn't pull the exact Sentry issue IDs or user counts. This fix is inferred from the identical pattern to MAILSPRING-CLIENT-4F and the fact that `call-window-method` is invoked for every window focus/maximize/minimize/hide action across the app.

## Test plan
- [ ] Open Mailspring and maximize/minimize the main window — no crash in the main process
- [ ] Open a composer window, then close it rapidly while the window is loading — no crash
- [ ] Resize the main window — no crash
- [ ] Check Sentry for `TypeError: Cannot read properties of null (reading 'emit')` / `(reading 'maximize')` etc. — should stop occurring

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013HQ1mLdWyfQjQcNKqxx73n

---
_Generated by [Claude Code](https://claude.ai/code/session_013HQ1mLdWyfQjQcNKqxx73n)_