### PR TITLE
Fix Sentry noise: downgrade unknown-feature warning from reportError to console.warn

### DIFF
--- a/app/internal_packages/composer-grammar-check/lib/grammar-check-store.ts
+++ b/app/internal_packages/composer-grammar-check/lib/grammar-check-store.ts
@@ -101,7 +101,11 @@ class _GrammarCheckStore extends MailspringStore {
   }
 
   markDirty(draftId: string, blockKey: string, blockText: string) {
-    if (!this._enabled || !FeatureUsageStore.isUsable(GRAMMAR_CHECK_FEATURE_ID) || !IdentityStore.identity()) {
+    if (
+      !this._enabled ||
+      !FeatureUsageStore.isUsable(GRAMMAR_CHECK_FEATURE_ID) ||
+      !IdentityStore.identity()
+    ) {
       return;
     }
     let draftDirty = this._dirtyBlocks.get(draftId);

--- a/app/spec/stores/feature-usage-store-spec.ts
+++ b/app/spec/stores/feature-usage-store-spec.ts
@@ -37,9 +37,9 @@ describe('FeatureUsageStore', function featureUsageStoreSpec() {
     });
 
     it('returns true if no quota is present for the feature', () => {
-      spyOn(AppEnv, 'reportError');
+      spyOn(console, 'warn');
       expect(FeatureUsageStore.isUsable('unsupported')).toBe(true);
-      expect(AppEnv.reportError).toHaveBeenCalled();
+      expect(console.warn).toHaveBeenCalled();
     });
   });
 

--- a/app/src/flux/stores/feature-usage-store.tsx
+++ b/app/src/flux/stores/feature-usage-store.tsx
@@ -159,7 +159,9 @@ class _FeatureUsageStore extends MailspringStore {
     if (!usage[feature]) {
       // Feature not yet in server identity (expected during new-feature rollout). Do
       // not report to Sentry — this is a transient state, not an application error.
-      console.warn(`FeatureUsageStore: no usage data for feature "${feature}", defaulting to allowed`);
+      console.warn(
+        `FeatureUsageStore: no usage data for feature "${feature}", defaulting to allowed`
+      );
       return EMPTY_FEATURE_USAGE;
     }
     return usage[feature];

--- a/app/src/flux/stores/feature-usage-store.tsx
+++ b/app/src/flux/stores/feature-usage-store.tsx
@@ -157,7 +157,9 @@ class _FeatureUsageStore extends MailspringStore {
 
     const usage = identity.featureUsage || {};
     if (!usage[feature]) {
-      AppEnv.reportError(new Error(`Warning: No usage information available for ${feature}`));
+      // Feature not yet in server identity (expected during new-feature rollout). Do
+      // not report to Sentry — this is a transient state, not an application error.
+      console.warn(`FeatureUsageStore: no usage data for feature "${feature}", defaulting to allowed`);
       return EMPTY_FEATURE_USAGE;
     }
     return usage[feature];


### PR DESCRIPTION
## What was observed

`FeatureUsageStore._dataForFeature()` called `AppEnv.reportError()` — which routes to Sentry — whenever a feature key was absent from the user's identity `featureUsage` map:

```typescript
if (!usage[feature]) {
  AppEnv.reportError(new Error(`Warning: No usage information available for ${feature}`));
  return EMPTY_FEATURE_USAGE;
}
```

`GrammarCheckToggle.render()` calls `FeatureUsageStore.isUsable('grammar-check')` on every render. Since `grammar-check` is a newly shipped feature, the server may not have added it to all existing users' identity objects yet. This means **every logged-in user who opens the composer** generates a `"Warning: No usage information available for grammar-check"` Sentry event on each render, until their identity is refreshed from the server.

The same pattern would fire for any other feature that is added to the app before the server adds it to the identity schema.

## Root cause

`AppEnv.reportError` was used here to catch coding mistakes (e.g. a typo in a feature ID), but it is too aggressive for production. A feature being absent from the identity is an **expected transient state** during new-feature rollout, not an application error. Using `reportError` floods Sentry with noise that obscures real issues.

## Fix

Downgrade to `console.warn` so the warning is still visible in DevTools without reaching Sentry. The return value (`EMPTY_FEATURE_USAGE`, which causes `isUsable` to return `true`) is unchanged, so the feature defaults to "usable" during the rollout window — the correct behaviour.

## Test plan
- [ ] Open a composer while logged in — no Sentry event for "No usage information available for grammar-check"
- [ ] Verify `console.warn` still appears in DevTools when a feature is missing from identity
- [ ] Existing feature-usage-store specs still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wa5rMERDupj7BbeEMtKXe3

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wa5rMERDupj7BbeEMtKXe3)_