### PR TITLE
Fix crash when dragging threads to sidebar after a thread is deleted

### DIFF
--- a/app/internal_packages/send-and-archive/lib/send-and-archive-extension.ts
+++ b/app/internal_packages/send-and-archive/lib/send-and-archive-extension.ts
@@ -15,7 +15,7 @@ export function sendActions() {
 
         if (!draft.threadId) return;
 
-        const threads = (await DatabaseStore.modelify(Thread, [draft.threadId])).filter(Boolean);
+        const threads = await DatabaseStore.modelify(Thread, [draft.threadId]);
         const tasks = TaskFactory.tasksForArchiving({
           source: 'Send and Archive',
           threads: threads,

--- a/app/internal_packages/thread-list/lib/thread-list-context-menu.ts
+++ b/app/internal_packages/thread-list/lib/thread-list-context-menu.ts
@@ -35,8 +35,7 @@ export default class ThreadListContextMenu {
   menuItemTemplate() {
     return DatabaseStore.modelify<Thread>(Thread, this.threadIds)
       .then((threads) => {
-        // modelify returns undefined for IDs not found in the DB (e.g. deleted threads)
-        this.threads = threads.filter(Boolean);
+        this.threads = threads;
 
         return Promise.all<TemplateItem>([
           this.findWithFrom(),

--- a/app/spec/stores/database-store-spec.ts
+++ b/app/spec/stores/database-store-spec.ts
@@ -125,6 +125,17 @@ describe('DatabaseStore', function DatabaseStoreSpecs() {
           });
         });
       }));
+
+    describe('when the input contains IDs not present in the database', () =>
+      it('omits missing entries rather than returning undefined', () => {
+        const input = ['local-A', 'does-not-exist', 'local-C'];
+        const expectedOutput = [this.models[0], this.models[2]];
+        return waitsForPromise(() => {
+          return DatabaseStore.modelify(Thread, input).then((output) => {
+            expect(output).toEqual(expectedOutput);
+          });
+        });
+      }));
   });
 
   describe('count', () => {

--- a/app/src/flux/stores/database-store.ts
+++ b/app/src/flux/stores/database-store.ts
@@ -517,7 +517,9 @@ class DatabaseStore extends MailspringStore {
           modelsByString[model.id] = model;
         }
         return Promise.resolve(
-          arr.map((item) => (item instanceof klass ? item : modelsByString[item as any]))
+          arr
+            .map((item) => (item instanceof klass ? item : modelsByString[item as any]))
+            .filter(Boolean)
         ) as any;
       });
   }

--- a/app/src/flux/stores/database-store.ts
+++ b/app/src/flux/stores/database-store.ts
@@ -486,6 +486,10 @@ class DatabaseStore extends MailspringStore {
   // Modelify is efficient and uses a single database query. It resolves Immediately
   // if no query is necessary.
   //
+  // IDs that are not found in the database (e.g. threads deleted between when an
+  // ID was obtained and when modelify is called) are silently omitted from the
+  // result. The result array may therefore be shorter than the input array.
+  //
   // - \`class\` The {Model} class desired.
   // - 'arr' An {Array} with a mix of string model IDs and/or models.
   //


### PR DESCRIPTION
## Root Cause

`DatabaseStore.modelify` returns `undefined` in the result array for any ID not present in the local database (e.g. a thread deleted between when a drag began and when the drop fires). Several callers passed this raw result to `TaskFactory.tasksForThreadsByAccountId`, which has an explicit guard that **throws** on non-Thread values:

```typescript
// task-factory.ts
if (!(thread instanceof Thread)) {
  throw new Error('tasksForThreadsByAccountId: `threads` must be instances of Thread');
}
```

This throw propagated as an unhandled rejection and was reported to Sentry.

## Fix

Move `.filter(Boolean)` into `DatabaseStore.modelify` itself so every caller gets a clean array. After auditing all call sites in `app/src/` and `app/internal_packages/`:
- No call site checks whether the result length matches the input length
- No call site uses positional indexing to correlate results back to input IDs
- No call site treats `undefined` entries as meaningful business logic

Two call sites (`thread-list-context-menu.ts`, `send-and-archive-extension.ts`) already applied `.filter(Boolean)` locally as a workaround — those are cleaned up as now redundant.

## Changes

- **`app/src/flux/stores/database-store.ts`**: Added `.filter(Boolean)` to the `modelify` return value
- **`app/internal_packages/thread-list/lib/thread-list-context-menu.ts`**: Removed redundant local `.filter(Boolean)` and associated comment
- **`app/internal_packages/send-and-archive/lib/send-and-archive-extension.ts`**: Removed redundant local `.filter(Boolean)`

## Notes

The Sentry MCP connector was unavailable in this session (authentication required), so the specific Sentry issue ID could not be retrieved or assigned. The crash pattern was identified by cross-referencing recent fix history.