### PR TITLE
Correctly handle XDG paths

### DIFF
--- a/app/src/browser/mailspring-window.ts
+++ b/app/src/browser/mailspring-window.ts
@@ -4,6 +4,7 @@ import fs from 'fs';
 import url from 'url';
 import { EventEmitter } from 'events';
 import { isWaylandSession } from './is-wayland';
+import { XDG_DATA_PATHS, getFirstExistingPath } from '../utils/xdg-paths';
 
 let WindowIconPath = null;
 let idNum = 0;
@@ -126,8 +127,11 @@ export default class MailspringWindow extends EventEmitter {
     // taskbar's icon. See https://github.com/atom/atom/issues/4811 for more.
     if (process.platform === 'linux') {
       if (!WindowIconPath) {
-        WindowIconPath = path.resolve('/usr', 'share', 'pixmaps', 'mailspring.png');
-        if (!fs.existsSync(WindowIconPath)) {
+        WindowIconPath = getFirstExistingPath(
+          XDG_DATA_PATHS,
+          path.join('pixmaps', 'mailspring.png')
+        );
+        if (!WindowIconPath) {
           WindowIconPath = path.resolve(this.resourcePath, 'static', 'images', 'mailspring.png');
         }
       }

--- a/app/src/browser/notification-ipc.ts
+++ b/app/src/browser/notification-ipc.ts
@@ -1,6 +1,5 @@
 import { Notification, IpcMain, IpcMainInvokeEvent, nativeImage } from 'electron';
 import path from 'path';
-import os from 'os';
 import { UrlWithParsedQuery } from 'url';
 import { ICON_PATHS } from '../utils/xdg-paths';
 

--- a/app/src/browser/notification-ipc.ts
+++ b/app/src/browser/notification-ipc.ts
@@ -2,6 +2,7 @@ import { Notification, IpcMain, IpcMainInvokeEvent, nativeImage } from 'electron
 import path from 'path';
 import os from 'os';
 import { UrlWithParsedQuery } from 'url';
+import { XDG_DATA_PATHS } from '../utils/xdg-paths';
 
 interface NotificationOptions {
   id: string;
@@ -57,13 +58,10 @@ const validateIconPath = (iconPath: string | undefined): string | null => {
 
   // On Linux, also allow system icon directories and temp directory
   if (platform === 'linux') {
-    const allowedLinuxPaths = [
-      '/usr/share/icons',
-      '/usr/share/pixmaps',
-      path.join(os.homedir(), '.local', 'share', 'icons'),
-      path.join(os.homedir(), '.icons'),
-      os.tmpdir(),
-    ];
+    const allowedLinuxPaths = XDG_DATA_PATHS.flatMap((dataPath) => [
+      path.join(dataPath, 'icons'),
+      path.join(dataPath, 'pixmaps'),
+    ]).concat([os.tmpdir()]);
 
     for (const allowedPath of allowedLinuxPaths) {
       const resolvedAllowed = path.resolve(allowedPath);

--- a/app/src/browser/notification-ipc.ts
+++ b/app/src/browser/notification-ipc.ts
@@ -2,7 +2,7 @@ import { Notification, IpcMain, IpcMainInvokeEvent, nativeImage } from 'electron
 import path from 'path';
 import os from 'os';
 import { UrlWithParsedQuery } from 'url';
-import { XDG_DATA_PATHS } from '../utils/xdg-paths';
+import { ICON_PATHS } from '../utils/xdg-paths';
 
 interface NotificationOptions {
   id: string;
@@ -58,14 +58,8 @@ const validateIconPath = (iconPath: string | undefined): string | null => {
 
   // On Linux, also allow system icon directories and temp directory
   if (platform === 'linux') {
-    const allowedLinuxPaths = XDG_DATA_PATHS.flatMap((dataPath) => [
-      path.join(dataPath, 'icons'),
-      path.join(dataPath, 'pixmaps'),
-    ]).concat([os.tmpdir()]);
-
-    for (const allowedPath of allowedLinuxPaths) {
-      const resolvedAllowed = path.resolve(allowedPath);
-      if (resolvedIcon.startsWith(resolvedAllowed + path.sep)) {
+    for (const allowedPath of ICON_PATHS) {
+      if (resolvedIcon.startsWith(allowedPath + path.sep)) {
         return resolvedIcon;
       }
     }

--- a/app/src/linux-theme-utils.ts
+++ b/app/src/linux-theme-utils.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import fs from 'fs';
 import { execSync } from 'child_process';
 import ini from 'ini';
-import { XDG_DATA_PATHS } from './utils/xdg-paths';
+import { ICON_PATHS } from './utils/xdg-paths';
 
 const Context = {
   ACTIONS: 'actions',
@@ -19,8 +19,6 @@ const Context = {
   PLACES: 'places',
   STATUS: 'status',
 };
-
-const ICON_THEME_PATHS = XDG_DATA_PATHS.map((dataPath) => path.join(dataPath, 'icons'));
 
 const DESKTOP = process.env.XDG_CURRENT_DESKTOP;
 
@@ -126,7 +124,7 @@ function __parseIconTheme(themePath: string): IconThemeData | null {
 function getIconTheme(themeName: string): IconTheme {
   if (!themeName) return null;
 
-  for (const themesPath of ICON_THEME_PATHS) {
+  for (const themesPath of ICON_PATHS) {
     const themePath = path.join(themesPath, themeName);
     const parsed = __parseIconTheme(themePath);
     if (parsed != null) {

--- a/app/src/linux-theme-utils.ts
+++ b/app/src/linux-theme-utils.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import fs from 'fs';
 import { execSync } from 'child_process';
 import ini from 'ini';
+import { XDG_DATA_PATHS } from './utils/xdg-paths';
 
 const Context = {
   ACTIONS: 'actions',
@@ -19,14 +20,7 @@ const Context = {
   STATUS: 'status',
 };
 
-const HOME = os.homedir();
-
-const ICON_THEME_PATHS = [
-  path.join(HOME, '.local/share/icons'),
-  path.join(HOME, '.icons'),
-  '/usr/share/icons',
-  '/usr/local/share/icons',
-];
+const ICON_THEME_PATHS = XDG_DATA_PATHS.map((dataPath) => path.join(dataPath, 'icons'));
 
 const DESKTOP = process.env.XDG_CURRENT_DESKTOP;
 

--- a/app/src/native-notifications.ts
+++ b/app/src/native-notifications.ts
@@ -7,7 +7,6 @@ import { getDoNotDisturb as getWindowsDoNotDisturb } from './dnd-utils-windows';
 import pkg from './utils/package';
 import path from 'path';
 import fs from 'fs';
-import os from 'os';
 import { XDG_DATA_PATHS } from './utils/xdg-paths';
 
 const platform = process.platform;

--- a/app/src/native-notifications.ts
+++ b/app/src/native-notifications.ts
@@ -8,6 +8,7 @@ import pkg from './utils/package';
 import path from 'path';
 import fs from 'fs';
 import os from 'os';
+import { XDG_DATA_PATHS } from './utils/xdg-paths';
 
 const platform = process.platform;
 const DEFAULT_ICON = path.resolve(
@@ -143,13 +144,9 @@ class NativeNotifications {
     if (platform !== 'linux') {
       return undefined;
     }
-    const desktopBaseDirs = [
-      os.homedir() + '/.local/share/applications/',
-      '/usr/share/applications/',
-    ];
-    // check the applications directories, the user directory has a higher priority
-    for (const baseDir of desktopBaseDirs) {
-      const filePath = path.join(baseDir, pkg.desktopName);
+
+    const filePaths = XDG_DATA_PATHS.map((dir) => path.join(dir, 'applications', pkg.desktopName));
+    for (const filePath of filePaths) {
       const desktopIcon = this.readIconFromDesktopFile(filePath);
       if (!desktopIcon) {
         continue;

--- a/app/src/system-start-service.ts
+++ b/app/src/system-start-service.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import fs from 'fs';
-import os from 'os';
 import pkg from './utils/package';
+import { getFirstExistingPath, XDG_CONFIG_PATHS, XDG_DATA_PATHS } from './utils/xdg-paths';
 
 class SystemStartServiceBase {
   checkAvailability(): Promise<boolean> {
@@ -106,53 +106,50 @@ class SystemStartServiceWin32 extends SystemStartServiceBase {
 }
 
 class SystemStartServiceLinux extends SystemStartServiceBase {
-  checkAvailability() {
-    return new Promise<boolean>((resolve) => {
-      fs.access(this._launcherPath(), fs.constants.R_OK, (err: NodeJS.ErrnoException | null) => {
-        if (err) {
-          resolve(false);
-        } else {
-          resolve(true);
-        }
-      });
-    });
+  async checkAvailability(): Promise<boolean> {
+    return this._launcherPath() !== null;
   }
 
-  doesLaunchOnSystemStart() {
-    return new Promise<boolean>((resolve) => {
-      fs.access(
-        this._shortcutPath(),
-        fs.constants.R_OK | fs.constants.W_OK,
-        (err: NodeJS.ErrnoException | null) => {
-          if (err) {
-            resolve(false);
-          } else {
-            resolve(true);
-          }
-        }
-      );
-    });
+  async doesLaunchOnSystemStart(): Promise<boolean> {
+    const shortcutPath = this._shortcutPath();
+    try {
+      await fs.promises.access(shortcutPath, fs.constants.R_OK);
+      return true;
+    } catch (err) {
+      return false;
+    }
   }
 
   configureToLaunchOnSystemStart() {
-    fs.readFile(this._launcherPath(), 'utf8', (error, data) => {
-      // Append the --background flag before the Exec key
-      const parsedData = data.replace('%U', '--background %U');
+    (async () => {
+      try {
+        const launcherPath = this._launcherPath();
+        if (!launcherPath) {
+          throw new Error('Launcher path not found');
+        }
 
-      fs.writeFile(this._shortcutPath(), parsedData, () => {});
-    });
+        const data = await fs.promises.readFile(launcherPath, 'utf8');
+        const parsedData = data.replace('%U', '--background %U');
+
+        const shortcutPath = this._shortcutPath();
+        await fs.promises.mkdir(path.dirname(shortcutPath), { recursive: true });
+        await fs.promises.writeFile(shortcutPath, parsedData, 'utf8');
+      } catch (error) {
+        console.error('Error configuring to launch on system start:', error);
+      }
+    })();
   }
 
   dontLaunchOnSystemStart() {
-    return fs.unlink(this._shortcutPath(), () => {});
+    fs.unlink(this._shortcutPath(), () => {});
   }
 
-  _launcherPath() {
-    return path.join('/', 'usr', 'share', 'applications', pkg.desktopName);
+  _launcherPath(): string | null {
+    return getFirstExistingPath(XDG_DATA_PATHS, path.join('applications', pkg.desktopName));
   }
 
-  _shortcutPath() {
-    const configDir = process.env.XDG_CONFIG_HOME || path.join(os.homedir(), '.config');
+  _shortcutPath(): string {
+    const configDir = XDG_CONFIG_PATHS[0];
     return path.join(configDir, 'autostart', pkg.desktopName);
   }
 }

--- a/app/src/utils/xdg-paths.ts
+++ b/app/src/utils/xdg-paths.ts
@@ -27,14 +27,14 @@ function buildPathsArray(
 
 export const XDG_CONFIG_PATHS = buildPathsArray(
   'XDG_CONFIG_HOME',
-  `${HOME}/.config`,
+  path.join(HOME, '.config'),
   'XDG_CONFIG_DIRS',
   '/etc/xdg'
 );
 
 export const XDG_DATA_PATHS = buildPathsArray(
   'XDG_DATA_HOME',
-  `${HOME}/.local/share`,
+  path.join(HOME, '.local/share'),
   'XDG_DATA_DIRS',
   '/usr/local/share:/usr/share'
 );
@@ -50,6 +50,6 @@ export function getFirstExistingPath(baseDirs: string[], subPath: fs.PathLike): 
 }
 
 export const ICON_PATHS = XDG_DATA_PATHS.flatMap((dataPath) => [
-  `${dataPath}/icons`,
-  `${dataPath}/pixmaps`,
-]).concat([`${HOME}/.icons`, os.tmpdir()]);
+  path.join(dataPath, 'icons'),
+  path.join(dataPath, 'pixmaps'),
+]).concat([path.join(HOME, '.icons'), os.tmpdir()]);

--- a/app/src/utils/xdg-paths.ts
+++ b/app/src/utils/xdg-paths.ts
@@ -48,3 +48,8 @@ export function getFirstExistingPath(baseDirs: string[], subPath: fs.PathLike): 
   }
   return null;
 }
+
+export const ICON_PATHS = XDG_DATA_PATHS.flatMap((dataPath) => [
+  `${dataPath}/icons`,
+  `${dataPath}/pixmaps`,
+]).concat([`${HOME}/.icons`, os.tmpdir()]);

--- a/app/src/utils/xdg-paths.ts
+++ b/app/src/utils/xdg-paths.ts
@@ -1,0 +1,55 @@
+import path from 'path';
+import os from 'os';
+import fs from 'fs';
+
+const HOME = os.homedir();
+
+function buildPathsArray(
+  homeEnvName: string,
+  dirsEnvName: string,
+  fallbackDirs: string[]
+): string[] {
+  const paths: string[] = [];
+
+  const homeEnv = process.env[homeEnvName];
+  if (homeEnv) {
+    paths.push(homeEnv);
+  }
+
+  process.env[dirsEnvName]?.split(':').forEach((dir) => {
+    if (dir && !paths.includes(dir)) {
+      paths.push(dir);
+    }
+  });
+
+  return paths.length > 0 ? paths : fallbackDirs;
+}
+
+export const XDG_CONFIG_PATHS = buildPathsArray('XDG_CONFIG_HOME', 'XDG_CONFIG_DIRS', [
+  path.join(HOME, '.config'),
+  '/etc/xdg',
+]);
+
+export const XDG_DATA_PATHS = buildPathsArray('XDG_DATA_HOME', 'XDG_DATA_DIRS', [
+  path.join(HOME, '.local', 'share'),
+  '/usr/local/share',
+  '/usr/share',
+]);
+
+export const XDG_CACHE_PATHS = buildPathsArray('XDG_CACHE_HOME', 'XDG_CACHE_DIRS', [
+  path.join(HOME, '.cache'),
+]);
+
+export const XDG_STATE_PATHS = buildPathsArray('XDG_STATE_HOME', 'XDG_STATE_DIRS', [
+  path.join(HOME, '.local', 'state'),
+]);
+
+export function getFirstExistingPath(baseDirs: string[], subPath: fs.PathLike): string | null {
+  for (const baseDir of baseDirs) {
+    const fullPath = path.join(baseDir, subPath.toString());
+    if (fs.existsSync(fullPath)) {
+      return fullPath;
+    }
+  }
+  return null;
+}

--- a/app/src/utils/xdg-paths.ts
+++ b/app/src/utils/xdg-paths.ts
@@ -6,43 +6,38 @@ const HOME = os.homedir();
 
 function buildPathsArray(
   homeEnvName: string,
+  homeFallback: string,
   dirsEnvName: string,
-  fallbackDirs: string[]
+  dirsFallback: string
 ): string[] {
   const paths: string[] = [];
 
   const homeEnv = process.env[homeEnvName];
-  if (homeEnv) {
-    paths.push(homeEnv);
-  }
+  paths.push(homeEnv && path.isAbsolute(homeEnv) ? homeEnv : homeFallback);
 
-  process.env[dirsEnvName]?.split(':').forEach((dir) => {
-    if (dir && !paths.includes(dir)) {
+  const dirsEnv = process.env[dirsEnvName] || dirsFallback;
+  dirsEnv.split(path.delimiter).forEach((dir) => {
+    if (dir && path.isAbsolute(dir) && !paths.includes(dir)) {
       paths.push(dir);
     }
   });
 
-  return paths.length > 0 ? paths : fallbackDirs;
+  return paths;
 }
 
-export const XDG_CONFIG_PATHS = buildPathsArray('XDG_CONFIG_HOME', 'XDG_CONFIG_DIRS', [
-  path.join(HOME, '.config'),
-  '/etc/xdg',
-]);
+export const XDG_CONFIG_PATHS = buildPathsArray(
+  'XDG_CONFIG_HOME',
+  `${HOME}/.config`,
+  'XDG_CONFIG_DIRS',
+  '/etc/xdg'
+);
 
-export const XDG_DATA_PATHS = buildPathsArray('XDG_DATA_HOME', 'XDG_DATA_DIRS', [
-  path.join(HOME, '.local', 'share'),
-  '/usr/local/share',
-  '/usr/share',
-]);
-
-export const XDG_CACHE_PATHS = buildPathsArray('XDG_CACHE_HOME', 'XDG_CACHE_DIRS', [
-  path.join(HOME, '.cache'),
-]);
-
-export const XDG_STATE_PATHS = buildPathsArray('XDG_STATE_HOME', 'XDG_STATE_DIRS', [
-  path.join(HOME, '.local', 'state'),
-]);
+export const XDG_DATA_PATHS = buildPathsArray(
+  'XDG_DATA_HOME',
+  `${HOME}/.local/share`,
+  'XDG_DATA_DIRS',
+  '/usr/local/share:/usr/share'
+);
 
 export function getFirstExistingPath(baseDirs: string[], subPath: fs.PathLike): string | null {
   for (const baseDir of baseDirs) {


### PR DESCRIPTION
Correctly handle XDG Paths, as configured by the user.

This is relevant for flatpak, where for example files in `/app/share` should take precedence over files in `/usr/share`.