### PR TITLE
Stop reporting expected IMAP/SMTP auth and connection failures to Sentry

### DIFF
--- a/app/src/mailsync-process.ts
+++ b/app/src/mailsync-process.ts
@@ -283,7 +283,9 @@ export class MailsyncProcess extends EventEmitter {
               LocalizedErrorStrings,
               response.error
             );
-            let msg = isRecognizedMailsyncError ? LocalizedErrorStrings[response.error] : response.error;
+            let msg = isRecognizedMailsyncError
+              ? LocalizedErrorStrings[response.error]
+              : response.error;
             if (response.error_service) {
               msg = `${msg} (${response.error_service.toUpperCase()})`;
             }

--- a/app/src/mailsync-process.ts
+++ b/app/src/mailsync-process.ts
@@ -82,6 +82,13 @@ export const LocalizedErrorStrings = {
   ),
 };
 
+// LocalizedErrorStrings codes that, despite being "classified" by mailsync,
+// can also indicate a genuine Mailspring defect rather than a server/user
+// condition - a malformed-response parser regression, or corrupted local
+// identity state. These should keep reaching error reporting instead of
+// being treated as expected, user-actionable failures.
+const AMBIGUOUS_MAILSYNC_ERRORS = new Set(['ErrorParse', 'ErrorIdentityMissingFields']);
+
 export class MailsyncProcess extends EventEmitter {
   _proc: ChildProcess = null;
   _win = null;
@@ -272,11 +279,11 @@ export class MailsyncProcess extends EventEmitter {
             resolve({ response, buffer });
           } else {
             // Mailsync executed fine, and this is an mailsync error in JSON format
-            const isKnownMailsyncError = Object.prototype.hasOwnProperty.call(
+            const isRecognizedMailsyncError = Object.prototype.hasOwnProperty.call(
               LocalizedErrorStrings,
               response.error
             );
-            let msg = LocalizedErrorStrings[response.error] || response.error;
+            let msg = isRecognizedMailsyncError ? LocalizedErrorStrings[response.error] : response.error;
             if (response.error_service) {
               msg = `${msg} (${response.error_service.toUpperCase()})`;
             }
@@ -285,10 +292,13 @@ export class MailsyncProcess extends EventEmitter {
             // Errors mailsync explicitly classified (bad credentials, unreachable
             // server, TLS/certificate problems, provider-side rate limits, etc.)
             // describe the mail server or the user's settings, not a bug in
-            // Mailspring. Callers that report unexpected errors to Sentry (e.g.
-            // oauth-signin-page's error handler) check this flag to avoid
-            // flooding error tracking with expected, user-actionable failures.
-            (error as any).isUserError = isKnownMailsyncError;
+            // Mailspring - except for the ambiguous codes above, which we still
+            // want reported if they occur. Callers that report unexpected errors
+            // to Sentry (e.g. oauth-signin-page's error handler) check this flag
+            // to avoid flooding error tracking with expected, user-actionable
+            // failures.
+            (error as any).isUserError =
+              isRecognizedMailsyncError && !AMBIGUOUS_MAILSYNC_ERRORS.has(response.error);
             return reject(error);
           }
         } catch (err) {

--- a/app/src/mailsync-process.ts
+++ b/app/src/mailsync-process.ts
@@ -272,12 +272,23 @@ export class MailsyncProcess extends EventEmitter {
             resolve({ response, buffer });
           } else {
             // Mailsync executed fine, and this is an mailsync error in JSON format
+            const isKnownMailsyncError = Object.prototype.hasOwnProperty.call(
+              LocalizedErrorStrings,
+              response.error
+            );
             let msg = LocalizedErrorStrings[response.error] || response.error;
             if (response.error_service) {
               msg = `${msg} (${response.error_service.toUpperCase()})`;
             }
             const error = new Error(msg);
             (error as any).rawLog = this._stripSecrets(response.log);
+            // Errors mailsync explicitly classified (bad credentials, unreachable
+            // server, TLS/certificate problems, provider-side rate limits, etc.)
+            // describe the mail server or the user's settings, not a bug in
+            // Mailspring. Callers that report unexpected errors to Sentry (e.g.
+            // oauth-signin-page's error handler) check this flag to avoid
+            // flooding error tracking with expected, user-actionable failures.
+            (error as any).isUserError = isKnownMailsyncError;
             return reject(error);
           }
         } catch (err) {


### PR DESCRIPTION
## Sentry issue
[MAILSPRING-CLIENT-2M](https://foundry-376-llc.sentry.io/issues/MAILSPRING-CLIENT-2M) — `Error: Erro de Autenticação - Verifique seu nome de usuário e senha. (IMAP)` — **969 users impacted, 2658 events** over the last 2 months on release 1.21.1/1.22.0. Unassigned, highest-impact unresolved issue in the `is:unresolved release:1.21.1-ae68e881` view. A closely related sibling, [MAILSPRING-CLIENT-4](https://foundry-376-llc.sentry.io/issues/MAILSPRING-CLIENT-4) (`Authentifizierungsfehler ... (SMTP)`, 79 users), is the same bug in the SMTP/German-locale case.

## What I observed

The culprit in every event is `ChildProcess.<anonymous>` in `src/mailsync-process.js`, and `search_events` on the issue turned up many event variants across locales, all sharing one shape: a fully localized, human-readable message with a `(IMAP)`/`(SMTP)` suffix, e.g.:

- `Erro de Autenticação - Verifique seu nome de usuário e senha. (IMAP)` (pt-BR)
- `Chyba ověřování - Zkontrolujte své uživatelské jméno a heslo. (IMAP)` (cs)
- `Erreur d'authentification - Vérifiez votre nom d'utilisateur et votre mot de passe. (IMAP)` (fr)
- `Connection Error - Unable to connect to the server / port you provided. (IMAP)` / `(SMTP)`

That exact `"<localized message> (SERVICE)"` format is produced in exactly one place in the whole codebase: `MailsyncProcess._spawnAndWait()`'s `close` handler in `app/src/mailsync-process.ts`:

```ts
let msg = LocalizedErrorStrings[response.error] || response.error;
if (response.error_service) {
  msg = `${msg} (${response.error_service.toUpperCase()})`;
}
const error = new Error(msg);
...
return reject(error);
```

`_spawnAndWait` backs `MailsyncProcess.test()`, which is called from `finalizeAndValidateAccount()` (`app/internal_packages/onboarding/lib/onboarding-helpers.ts`) whenever an account is validated during setup — including the Gmail/O365 OAuth flow (`buildGmailAccountFromAuthResponse` / `buildMicrosoftAccountFromAuthResponse`).

The OAuth setup UI (`oauth-signin-page.tsx`) is the only caller in that chain that reports these failures to Sentry:

```ts
_onError(err) {
  ...
  // Don't report network errors or user-configuration errors (e.g. account has no mailbox)
  // to Sentry — they are expected and shown directly to the user.
  if (!isNetworkError && !err.isUserError) {
    AppEnv.reportError(err);
  }
}
```

There's already a precedent here for "this isn't really a bug" errors (`isNetworkError`, and `isUserError` for the "no mailbox associated with this account" case in `buildMicrosoftAccountFromAuthResponse`), but `MailsyncProcess.test()` had no way to mark its own classified failures the same way. Since `ErrorAuthentication` and `ErrorConnection` (and the rest of the `LocalizedErrorStrings` table — TLS/certificate issues, Gmail rate limits, etc.) are mailsync explicitly telling us the *user's credentials or server config* are the problem, not an application defect, every one of those got funneled into `reportError` → Sentry as if it were an unexpected crash. Given how many people set up Gmail/Outlook accounts, that adds up to the volume seen here.

## Fix

Tag errors built from a recognized `LocalizedErrorStrings` key as `isUserError`, in `_spawnAndWait`'s `close` handler:

```ts
const isKnownMailsyncError = Object.prototype.hasOwnProperty.call(
  LocalizedErrorStrings,
  response.error
);
...
(error as any).isUserError = isKnownMailsyncError;
```

`oauth-signin-page.tsx`'s existing `!err.isUserError` check now filters these out automatically — no changes needed there. Errors mailsync *doesn't* recognize (`response.error` not in the table) still get `isUserError = false` and are still reported, since those genuinely may indicate a bug.

## Test plan
- [ ] `npm run typecheck` (couldn't run in this sandbox — no `node_modules` installed)
- [ ] Manually trigger a Gmail OAuth signup with an account whose IMAP access is disabled/misconfigured and confirm the error is no longer sent to Sentry but is still shown in the UI
- [ ] Confirm a genuinely unexpected `MailsyncProcess.test()` failure (unrecognized `response.error`) is still reported

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_01BXUwaoPQzodFWT1BDu9M1M

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUwaoPQzodFWT1BDu9M1M)_