### PR TITLE
Add Office 365 shared mailbox support

### DIFF
--- a/app/internal_packages/onboarding/lib/oauth-signin-page.tsx
+++ b/app/internal_packages/onboarding/lib/oauth-signin-page.tsx
@@ -34,6 +34,7 @@ interface OAuthSignInPageProps {
   onTryAgain: () => void;
   providerConfig: (typeof AccountProviders)[0];
   serviceName: string;
+  children?: React.ReactNode;
 }
 
 interface OAuthSignInPageState {
@@ -238,6 +239,7 @@ export default class OAuthSignInPage extends React.Component<
         </div>
         {this._renderHeader()}
         {this._renderNote()}
+        {this.state.authStage === 'initial' && this.props.children}
         {this._renderAlternative()}
       </div>
     );

--- a/app/internal_packages/onboarding/lib/onboarding-helpers.ts
+++ b/app/internal_packages/onboarding/lib/onboarding-helpers.ts
@@ -256,8 +256,11 @@ export async function buildGmailAccountFromAuthResponse(code: string) {
   return account;
 }
 
-export async function buildO365AccountFromAuthResponse(code: string) {
-  return buildMicrosoftAccountFromAuthResponse(code, 'office365');
+export async function buildO365AccountFromAuthResponse(
+  code: string,
+  sharedMailboxAddress?: string
+) {
+  return buildMicrosoftAccountFromAuthResponse(code, 'office365', sharedMailboxAddress);
 }
 
 export async function buildOutlookAccountFromAuthResponse(code: string) {
@@ -266,7 +269,8 @@ export async function buildOutlookAccountFromAuthResponse(code: string) {
 
 export async function buildMicrosoftAccountFromAuthResponse(
   code: string,
-  provider: 'outlook' | 'office365'
+  provider: 'outlook' | 'office365',
+  sharedMailboxAddress?: string
 ) {
   /// Exchange code for an access token
   const { access_token, refresh_token, id_token } = await fetchPostWithFormBody<TokenResponse>(
@@ -323,15 +327,33 @@ export async function buildMicrosoftAccountFromAuthResponse(
     throw err;
   }
 
+  // A shared mailbox has no credentials of its own — it is accessed with the signed-in
+  // user's OAuth refresh token. IMAP accepts the shared mailbox as the XOAUTH2 identity
+  // (requires "Full Access"), but SMTP AUTH only accepts the signed-in user, who then
+  // submits mail as the shared address (requires "Send As"). So the shared address
+  // becomes the account email / IMAP username, while smtp_username stays the owner.
+  // smtp_verification: 'login' keeps the account-add test from sending a test email:
+  // reading a shared mailbox must not require send rights, and the test email would be
+  // visible to every member of the mailbox. create_helper_folders: false keeps the
+  // sync engine from provisioning "Mailspring/Snoozed" in the shared mailbox, which
+  // would also be visible to every member (snoozing is unavailable in that account).
+  const settings: any = {
+    refresh_client_id: O365_CLIENT_ID,
+    refresh_token: refresh_token,
+  };
+  if (sharedMailboxAddress) {
+    settings.smtp_username = emailAddress;
+    settings.smtp_verification = 'login';
+    settings.create_helper_folders = false;
+    emailAddress = sharedMailboxAddress;
+  }
+
   const account = await expandAccountWithCommonSettings(
     new Account({
       name: me.displayName,
       emailAddress: emailAddress,
       provider: provider,
-      settings: {
-        refresh_client_id: O365_CLIENT_ID,
-        refresh_token: refresh_token,
-      },
+      settings,
     })
   );
 

--- a/app/internal_packages/onboarding/lib/page-account-settings-o365.tsx
+++ b/app/internal_packages/onboarding/lib/page-account-settings-o365.tsx
@@ -1,34 +1,175 @@
 import React from 'react';
 
-import { Account } from 'mailspring-exports';
+import { Account, localized, localizedReactFragment, RegExpUtils } from 'mailspring-exports';
+import { RetinaImg } from 'mailspring-component-kit';
 import { buildO365AccountFromAuthResponse, buildO365AuthURL } from './onboarding-helpers';
 
 import OAuthSignInPage from './oauth-signin-page';
+import FormErrorMessage from './form-error-message';
 import * as OnboardingActions from './onboarding-actions';
 import AccountProviders from './account-providers';
 
-export default class AccountSettingsPageO365 extends React.Component<{ account: Account }> {
+interface AccountSettingsPageO365State {
+  sharedMailbox: string;
+  showSharedMailboxForm: boolean;
+  fieldValue: string;
+  errorMessage: string | null;
+}
+
+export default class AccountSettingsPageO365 extends React.Component<
+  { account: Account },
+  AccountSettingsPageO365State
+> {
   static displayName = 'AccountSettingsPageO365';
 
   _authUrl = buildO365AuthURL();
+
+  state: AccountSettingsPageO365State = {
+    sharedMailbox: '',
+    // Preferences > Accounts > "Add Shared Mailbox..." opens the onboarding window
+    // with this flag so the user lands directly on the shared mailbox form.
+    showSharedMailboxForm: !!AppEnv.getWindowProps().o365SharedMailbox,
+    fieldValue: '',
+    errorMessage: null,
+  };
 
   onSuccess(account) {
     OnboardingActions.finishAndAddAccount(account);
   }
 
+  _onSubmitSharedMailbox = () => {
+    const address = this.state.fieldValue.trim();
+    if (!RegExpUtils.emailRegex().test(address)) {
+      this.setState({
+        errorMessage: localized('Please provide a valid email address.'),
+      });
+      return;
+    }
+    this.setState({
+      sharedMailbox: address,
+      showSharedMailboxForm: false,
+      errorMessage: null,
+    });
+  };
+
+  _onFieldKeyPress = (event: React.KeyboardEvent) => {
+    if (['Enter', 'Return'].includes(event.key)) {
+      this._onSubmitSharedMailbox();
+    }
+  };
+
+  _renderSharedMailboxForm(providerConfig) {
+    return (
+      <div className="page account-setup office 365">
+        <div className="logo-container">
+          <RetinaImg
+            name={providerConfig.headerIcon}
+            style={{ backgroundColor: providerConfig.color, borderRadius: 44 }}
+            mode={RetinaImg.Mode.ContentPreserve}
+            className="logo"
+          />
+        </div>
+        <h2>{localized('Connect a shared mailbox')}</h2>
+        <div className="message empty note">
+          {localized(
+            `Enter the address of the shared mailbox, then sign in with your own Office 365 account. Your account needs "Full Access" permission on the shared mailbox to read mail, and "Send As" permission to send from its address. Without "Send As", the mailbox connects read-only and sending will fail.`
+          )}
+        </div>
+        <form
+          className="settings"
+          onSubmit={(e) => {
+            e.preventDefault();
+            this._onSubmitSharedMailbox();
+          }}
+        >
+          <FormErrorMessage message={this.state.errorMessage} />
+          <span>
+            <label htmlFor="sharedMailbox">{localized('Shared mailbox address')}:</label>
+            <input
+              type="text"
+              id="sharedMailbox"
+              className={this.state.errorMessage ? 'error' : ''}
+              spellCheck={false}
+              autoFocus
+              value={this.state.fieldValue}
+              onKeyPress={this._onFieldKeyPress}
+              onChange={(e) => this.setState({ fieldValue: e.target.value })}
+            />
+          </span>
+        </form>
+        <div>
+          <button
+            className="btn btn-large btn-gradient btn-add-account"
+            onClick={this._onSubmitSharedMailbox}
+          >
+            {localized('Continue')}
+          </button>
+        </div>
+        <div style={{ marginTop: 20 }}>
+          <a
+            onClick={() => {
+              if (this.state.sharedMailbox) {
+                // Came back here from the sign-in screen via "Change" — return to it.
+                this.setState({ showSharedMailboxForm: false, errorMessage: null });
+              } else {
+                OnboardingActions.moveToPreviousPage();
+              }
+            }}
+          >
+            {localized('Cancel')}
+          </a>
+        </div>
+      </div>
+    );
+  }
+
+  _renderSharedMailboxConfirmation() {
+    // Shared mailboxes are connected from Preferences > Accounts (matching Outlook,
+    // which has no shared mailbox path in first-run setup), so this only confirms
+    // the pending shared address during the OAuth sign-in. Rendered in flow just
+    // below the provider note — the bottom of the page is occupied by the
+    // "Page didn't open?" fallback UI.
+    if (!this.state.sharedMailbox) {
+      return undefined;
+    }
+    return (
+      <div>
+        <div className="shared-mailbox-confirmation">
+          {localizedReactFragment(
+            'Shared mailbox: %@',
+            <strong>{this.state.sharedMailbox}</strong>
+          )}
+          <a onClick={() => this.setState({ showSharedMailboxForm: true })}>
+            {localized('Change')}
+          </a>
+        </div>
+      </div>
+    );
+  }
+
   render() {
     const providerConfig = AccountProviders.find((a) => a.provider === this.props.account.provider);
+
+    if (this.state.showSharedMailboxForm) {
+      return this._renderSharedMailboxForm(providerConfig);
+    }
+
     const goBack = () => OnboardingActions.moveToPreviousPage();
+    const { sharedMailbox } = this.state;
 
     return (
       <OAuthSignInPage
         serviceName="Office 365"
         providerAuthPageUrl={this._authUrl}
         providerConfig={providerConfig}
-        buildAccountFromAuthResponse={buildO365AccountFromAuthResponse}
+        buildAccountFromAuthResponse={(code) =>
+          buildO365AccountFromAuthResponse(code, sharedMailbox || undefined)
+        }
         onSuccess={this.onSuccess}
         onTryAgain={goBack}
-      />
+      >
+        {this._renderSharedMailboxConfirmation()}
+      </OAuthSignInPage>
     );
   }
 }

--- a/app/internal_packages/onboarding/styles/onboarding.less
+++ b/app/internal_packages/onboarding/styles/onboarding.less
@@ -307,6 +307,22 @@
     padding-top: 20px;
     margin: auto;
   }
+  .shared-mailbox-confirmation {
+    display: inline-block;
+    margin-top: 22px;
+    padding: 7px 16px;
+    background: rgba(0, 0, 0, 0.035);
+    border: 1px solid #d8d8d8;
+    border-radius: 15px;
+    color: #555;
+    strong {
+      font-weight: 500;
+      color: #333;
+    }
+    a {
+      margin-left: 10px;
+    }
+  }
   .twocol {
     display: flex;
     flex-direction: row;
@@ -368,6 +384,15 @@
 .page.account-setup.AccountOnboardingSuccess {
   .logo-container {
     padding-top: 160px;
+  }
+}
+
+// The Office 365 pages stack more content (the IMAP/SMTP requirements note, the
+// shared mailbox confirmation / form) than the other OAuth pages — with the full
+// 160px the "Page didn't open?" fallback gets pushed past the fixed window height.
+.page.account-setup.office {
+  .logo-container {
+    padding-top: 70px;
   }
 }
 

--- a/app/internal_packages/preferences/lib/tabs/preferences-account-details.tsx
+++ b/app/internal_packages/preferences/lib/tabs/preferences-account-details.tsx
@@ -166,6 +166,15 @@ class PreferencesAccountDetails extends Component<
     AppEnv.mailsyncBridge.resetCacheForAccount(this.state.account);
   };
 
+  _onAddSharedMailbox = () => {
+    // Intentionally omits account secrets — the shared mailbox flow runs a fresh
+    // OAuth sign-in and only needs the provider to route to the right settings page.
+    ipcRenderer.send('command', 'application:add-account', {
+      existingAccountJSON: this.state.account.toJSON(),
+      o365SharedMailbox: true,
+    });
+  };
+
   _onManageContacts = () => {
     ipcRenderer.send('command', 'application:show-contacts', {});
   };
@@ -355,13 +364,20 @@ class PreferencesAccountDetails extends Component<
           </div>
         </div>
         <h6>{localized('Account Settings')}</h6>
-        <div className="btn" onClick={this._onManageContacts}>
-          {localized('Manage Contacts')}
-        </div>
-        <div className="btn" style={{ marginLeft: 6 }} onClick={this._onReconnect}>
-          {account.provider === 'gmail'
-            ? localized('Re-authenticate...')
-            : localized('Update Connection Settings...')}
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+          <div className="btn" onClick={this._onManageContacts}>
+            {localized('Manage Contacts')}
+          </div>
+          <div className="btn" onClick={this._onReconnect}>
+            {account.provider === 'gmail'
+              ? localized('Re-authenticate...')
+              : localized('Update Connection Settings...')}
+          </div>
+          {account.provider === 'office365' && (
+            <div className="btn" onClick={this._onAddSharedMailbox}>
+              {localized('Add Shared Mailbox...')}
+            </div>
+          )}
         </div>
         <h6>{localized('Local Data')}</h6>
         <div className="btn" onClick={this._onResetCache}>

--- a/app/src/browser/application.ts
+++ b/app/src/browser/application.ts
@@ -401,14 +401,14 @@ export default class Application extends EventEmitter {
       }
     });
 
-    this.on('application:add-account', ({ existingAccountJSON } = {}) => {
+    this.on('application:add-account', ({ existingAccountJSON, o365SharedMailbox } = {}) => {
       const onboarding = this.windowManager.get(WindowManager.ONBOARDING_WINDOW);
       if (onboarding) {
         onboarding.show();
         onboarding.focus();
       } else {
         this.windowManager.ensureWindow(WindowManager.ONBOARDING_WINDOW, {
-          windowProps: { addingAccount: true, existingAccountJSON },
+          windowProps: { addingAccount: true, existingAccountJSON, o365SharedMailbox },
           title: localized('Add Account'),
         });
       }


### PR DESCRIPTION
## Summary

Adds the ability to connect an **Office 365 shared mailbox** as its own account, using the signed-in user's OAuth credentials — no separate credentials exist for shared mailboxes. This follows the pattern established by Outlook and other clients: shared mailboxes are added from account settings after your own account exists, not during first-run setup.

**Pairs with Foundry376/Mailspring-Sync#116**, which adds engine support for `smtp_username` on XOAUTH2 accounts, `smtp_verification: "login"`, and `create_helper_folders: false`. Until a mailsync build containing #116 ships, adding a shared mailbox fails at account validation (SMTP 535); all existing account types are unaffected by either PR.

## UX

- **Preferences → Accounts** shows an "Add Shared Mailbox..." button on O365 accounts. It opens the onboarding window directly on a one-field form (new `o365SharedMailbox` window prop), which explains the permission model: "Full Access" to read, "Send As" to send, read-only otherwise.
- Continuing runs the normal O365 OAuth flow, with a confirmation chip ("Shared mailbox: address — Change") shown during sign-in.
- The shared mailbox appears as its own account; the sender name defaults to the signed-in user's display name (Graph `/me` cannot read the shared mailbox's name) and can be edited in Preferences.

## How it works

The shared address becomes the account `emailAddress` and therefore the IMAP XOAUTH2 identity, while `smtp_username` stays the signed-in user (O365's SMTP AUTH rejects shared addresses — verified on a live tenant). Two engine-honored settings avoid side effects on a mailbox other people share: the account-add test verifies SMTP credentials without transmitting the "Mailspring SMTP Test Email", and the engine skips provisioning `Mailspring/Snoozed` in the shared mailbox (snooze is unavailable for these accounts; a follow-up could hide the snooze UI there).

Incidental fixes in the same surface: `OAuthSignInPage` accepts `children` rendered below the provider note; the O365 pages use tighter logo padding so their taller content stack fits the fixed-size onboarding window; the Preferences → Accounts action buttons wrap in a flex row instead of overlapping when narrow.

## Testing

Verified against a live O365 tenant: shared mailbox with Full Access connects and syncs (folders, inbox); no test email is sent to the shared mailbox; no helper folder is created in it; normal O365/Gmail/IMAP onboarding unchanged. `npm run typecheck` and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)