### PR TITLE
Stop startup after a fatal config.json load failure

### DIFF
--- a/app/src/browser/application.ts
+++ b/app/src/browser/application.ts
@@ -117,6 +117,16 @@ export default class Application extends EventEmitter {
     const config = new Config();
     this.config = config;
     this.configPersistenceManager = new ConfigPersistenceManager({ configDirPath, resourcePath });
+
+    // If the user's config.json could not be read (eg: corrupted / truncated on disk)
+    // and they chose to quit from the error dialog, ConfigPersistenceManager has
+    // already called app.quit() and left `settings` empty. app.quit() does not halt
+    // synchronous execution, so without this check we'd continue on to config.load(),
+    // which throws because there are no settings to load, reporting a confusing
+    // "this.settings is empty" error on our way out the door. Stop here instead.
+    if (this.configPersistenceManager.userWantsToPreserveErrors) {
+      return;
+    }
     config.load();
 
     this.configMigrator = new ConfigMigrator(this.config);


### PR DESCRIPTION
## Summary

Fixes [MAILSPRING-CLIENT-4Q](https://foundry-376-llc.sentry.io/issues/MAILSPRING-CLIENT-4Q) — `Error: Failed to parse response from getRawValuesString: this.settings is empty`, unresolved, unassigned, 21 users / 198 events over the last month, recurring repeatedly for the same handful of users across many separate launches.

### What I observed

Every event's stack trace was identical and pointed at app startup, not at runtime config access:

```
Application.start (src/browser/application.js:140)
Config.load (src/config.js:91)
Config.getRawValues (src/config.js:314)
ConfigPersistenceManager.getRawValuesString (src/browser/config-persistence-manager.js:46)
```

### Root cause

`ConfigPersistenceManager.load()` (`app/src/browser/config-persistence-manager.ts`) reads and `JSON.parse`s the user's `config.json`. If that fails (corrupted/truncated file on disk), it shows a blocking error dialog with **Quit / Try Again / Reset Configuration**. If the user picks **Quit**:

```ts
if (action === 'quit') {
  this.userWantsToPreserveErrors = true;
  app.quit();
  return;
}
```

`app.quit()` only *requests* shutdown — it does not stop the currently-executing synchronous JS. `load()` returns with `this.settings` still at its initial value of `{}`. Back in `Application.start()` (`app/src/browser/application.ts`), the very next line unconditionally calls `config.load()`, which calls down into `ConfigPersistenceManager.getRawValuesString()`:

```ts
getRawValuesString = () => {
  if (!this.settings || _.isEmpty(this.settings)) {
    throw new Error('this.settings is empty');
  }
  ...
};
```

Since `settings` is still `{}`, this throws — producing a confusing, unactionable error report on the way out the door, for a condition (corrupted config file, user chose to quit) that the app had already correctly surfaced to the user via the dialog. Users who hit this repeatedly (e.g. the same user on 3+ separate days) have a config.json that stays corrupted between launches, so they see the dialog — and this bogus follow-on error — every time they try to open Mailspring.

### Fix

`Application.start()` now checks `configPersistenceManager.userWantsToPreserveErrors` right after constructing it, and returns immediately if the user already chose to quit, instead of continuing on to `config.load()`:

```ts
this.configPersistenceManager = new ConfigPersistenceManager({ configDirPath, resourcePath });

if (this.configPersistenceManager.userWantsToPreserveErrors) {
  return;
}
config.load();
```

This doesn't fix the user's corrupted `config.json` (that's a pre-existing, user-facing recovery flow via the dialog's Try Again/Reset options), but it eliminates the misleading secondary error and the extra initialization work the app was doing while already shutting down.

## Test plan

- [x] Read through the full call chain (`application.ts` → `config.ts` → `config-persistence-manager.ts`) to confirm the only path that leaves `settings` empty after `ConfigPersistenceManager.load()` returns is the `action === 'quit'` branch.
- [x] Confirmed via Sentry that 100% of sampled events for this issue share the identical stack trace pointing at initial startup (not a later runtime config access).
- [ ] Not manually reproduced in a running app (would require corrupting `config.json` and driving the native dialog), but the change is a narrow, low-risk early return gated on an existing flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ombctRt1s9Q1zq6FrbgUt


---
_Generated by [Claude Code](https://claude.ai/code/session_016ombctRt1s9Q1zq6FrbgUt)_