### PR TITLE
Add mbox export for folders

### DIFF
--- a/app/internal_packages/account-sidebar/lib/main.ts
+++ b/app/internal_packages/account-sidebar/lib/main.ts
@@ -1,10 +1,13 @@
 import { ComponentRegistry, WorkspaceStore } from 'mailspring-exports';
 import AccountSidebar from './components/account-sidebar';
+import { activateMboxExportRunner, deactivateMboxExportRunner } from './mbox-export-runner';
 
 export function activate(state) {
   ComponentRegistry.register(AccountSidebar, { location: WorkspaceStore.Location.RootSidebar });
+  activateMboxExportRunner();
 }
 
 export function deactivate(state) {
   ComponentRegistry.unregister(AccountSidebar);
+  deactivateMboxExportRunner();
 }

--- a/app/internal_packages/account-sidebar/lib/mbox-export-runner.ts
+++ b/app/internal_packages/account-sidebar/lib/mbox-export-runner.ts
@@ -1,0 +1,173 @@
+import fs from 'fs';
+import { localized, Task, TaskQueue, GetManyRFC2822Task, MboxUtils } from 'mailspring-exports';
+
+/*
+ * Finishes mbox folder exports. The sync engine's half of an export (fetching
+ * each message to a .eml file in the staging directory) is a persisted task
+ * that survives restarts, so the client half — assembling the staged files
+ * into the final mbox — must too. This runner watches the TaskQueue and
+ * advances any mbox export whose staging directory exists, whether the task
+ * was queued this session or resumed from a previous one.
+ *
+ * Assembly is incremental to keep disk usage down: each time the engine
+ * persists export progress (every 50 messages), the staged files covered by
+ * that progress are appended to the mbox and deleted, so the staging
+ * directory holds a ~50-message window rather than a full second copy of the
+ * folder. The engine writes staged files in export order with sorted names
+ * and reports progress only after a chunk is fully on disk, so files within
+ * the reported count are complete. Two gates keep this safe:
+ *
+ * - progress.exported bounds how many staged files are consumed; anything
+ *   past it may still be mid-write by the engine.
+ * - If any message failed (progress.failed > 0), incremental consumption
+ *   stops and the remaining staging is assembled only at completion: after a
+ *   restart the engine reuses filename index prefixes of failed messages, so
+ *   name order stops being trustworthy while files are still being written.
+ *   (Deferred assembly still consumes in bounded sub-batches, so peak disk
+ *   stays near folder size even then — see appendStagedMessages.)
+ *
+ * Assembly writes to a `<destination>.incomplete` working file; the file the
+ * user chose is created only by an atomic rename at successful completion,
+ * so a partially assembled mailbox can never be mistaken for a finished one
+ * (deferred assembly can run for a while after the fetch completes), and a
+ * pre-existing file at the destination survives cancellation and failure.
+ * Completion assembles whatever remains, renames, and removes the staging
+ * directory; cancellation discards the staging directory and the working
+ * file. A failed assembly keeps the working file and staging — together they
+ * hold every fetched message — and resumes at the next launch.
+ */
+
+const inFlight = new Set<string>();
+// Failed assemblies must not retry on every queue change — the user was
+// already shown the error. The staging dir and manifest persist, so the next
+// launch retries once.
+const failedThisSession = new Set<string>();
+// progress.exported at the last append per task, so sweeps triggered by
+// unrelated queue changes don't re-scan the staging directory.
+const lastAppendedAt = new Map<string, number>();
+
+let unlisten: (() => void) | null = null;
+
+export function activateMboxExportRunner() {
+  unlisten = TaskQueue.listen(sweep);
+  sweep();
+}
+
+export function deactivateMboxExportRunner() {
+  if (unlisten) {
+    unlisten();
+    unlisten = null;
+  }
+}
+
+async function sweep() {
+  for (const task of TaskQueue.allTasks()) {
+    if (!(task instanceof GetManyRFC2822Task)) {
+      continue;
+    }
+    const { id, status, format, mboxPath, outputDir, progress } = task;
+    if (format !== 'mbox' || !mboxPath || !outputDir) {
+      continue;
+    }
+    if (inFlight.has(id) || failedThisSession.has(id)) {
+      continue;
+    }
+    if (!fs.existsSync(outputDir)) {
+      lastAppendedAt.delete(id);
+      continue;
+    }
+
+    // Assembly happens in a working file beside the destination; the file the
+    // user chose appears only via an atomic rename once the export is
+    // complete. Until then there is nothing at the chosen path that could be
+    // mistaken for a finished mailbox, and a pre-existing file there is
+    // replaced only by a successful export. The working file is derived from
+    // the per-export staging directory (not from mboxPath) so it, too, is
+    // unique to this task.
+    const workingPath = outputDir.replace(/\.partial$/, '.incomplete');
+
+    inFlight.add(id);
+    try {
+      // A mid-export cancel surfaces as status "complete" with
+      // progress.cancelled set (the engine maps shouldCancel to the
+      // cancelled status only before the export starts), so status alone
+      // can't distinguish a finished export from one stopped on request.
+      const wasCancelled =
+        status === Task.Status.Cancelled || Boolean(progress && progress.cancelled);
+      const finished = status === Task.Status.Complete || status === Task.Status.Cancelled;
+
+      if (wasCancelled) {
+        if (finished) {
+          await fs.promises.rm(workingPath, { force: true }).catch(() => {});
+          await fs.promises.rm(outputDir, { recursive: true, force: true });
+          lastAppendedAt.delete(id);
+        }
+        // not finished yet: the engine is wrapping up — the sweep after the
+        // status flip performs the cleanup
+      } else if (status === Task.Status.Complete) {
+        // A prior run may have already renamed the working file onto the
+        // destination and crashed before removing staging — only cleanup is
+        // left in that case.
+        const alreadyInstalled =
+          MboxUtils.readMboxExportManifest(outputDir) !== null &&
+          !fs.existsSync(workingPath) &&
+          fs.existsSync(mboxPath);
+
+        if (!alreadyInstalled) {
+          await MboxUtils.appendStagedMessages(outputDir, workingPath, null);
+
+          // Only replace the destination with a genuinely complete export:
+          // every message accounted for, none failed, not cancelled. This is
+          // what keeps a failed/aborted/empty export from destroying a file
+          // the user already had at that path.
+          const result = task.result || {};
+          const cleanSuccess =
+            Boolean(task.result) &&
+            (result.failed || 0) === 0 &&
+            (result.exported || 0) === (result.total || 0);
+          const workingSize = (await fs.promises.stat(workingPath)).size;
+          const destinationExists = fs.existsSync(mboxPath);
+
+          if (cleanSuccess && (workingSize > 0 || !destinationExists)) {
+            // Complete export (or a legitimately empty folder to a new path).
+            await fs.promises.rename(workingPath, mboxPath);
+          } else if (!cleanSuccess) {
+            // Preserve whatever is at the destination; keep the assembled
+            // messages in the working file so nothing fetched is lost.
+            failedThisSession.add(id);
+            AppEnv.showErrorDialog(
+              localized(
+                'The mbox export did not complete, so the existing file at the destination was left unchanged. The messages exported so far are in %@.',
+                workingPath
+              )
+            );
+          } else {
+            // Clean but empty, and a file already exists at the destination —
+            // there is nothing to replace it with. Leave it untouched.
+            await fs.promises.rm(workingPath, { force: true }).catch(() => {});
+          }
+        }
+        await fs.promises.rm(outputDir, { recursive: true, force: true });
+        lastAppendedAt.delete(id);
+      } else {
+        const exported = (progress && progress.exported) || 0;
+        const failed = (progress && progress.failed) || 0;
+        if (exported === 0 || failed > 0 || lastAppendedAt.get(id) === exported) {
+          continue;
+        }
+        await MboxUtils.appendStagedMessages(outputDir, workingPath, exported);
+        lastAppendedAt.set(id, exported);
+      }
+    } catch (err) {
+      failedThisSession.add(id);
+      AppEnv.showErrorDialog(
+        localized(
+          'Could not write the mbox file. The export will finish the next time Mailspring launches; the messages fetched so far remain in %@.',
+          outputDir
+        )
+      );
+    } finally {
+      inFlight.delete(id);
+    }
+  }
+}

--- a/app/internal_packages/account-sidebar/lib/sidebar-item.ts
+++ b/app/internal_packages/account-sidebar/lib/sidebar-item.ts
@@ -1,5 +1,6 @@
 import { imapUtf7 } from 'mailspring-exports';
 
+import fs from 'fs';
 import _str from 'underscore.string';
 import { OutlineViewItem } from 'mailspring-component-kit';
 import {
@@ -12,6 +13,7 @@ import {
   Actions,
   RegExpUtils,
   localized,
+  TaskQueue,
 } from 'mailspring-exports';
 
 import * as SidebarActions from './sidebar-actions';
@@ -101,6 +103,63 @@ const onExportFolder = function (item: ISidebarItem) {
           folderId: category.id,
           folderPath: category.path,
           outputDir,
+        })
+      );
+    }
+  );
+};
+
+const onExportMboxFolder = function (item: ISidebarItem) {
+  const category = item.perspective.category();
+  if (!category) {
+    return;
+  }
+
+  const defaultName = `${(category.displayName || 'folder').replace(/[/?<>\\:*|"]/g, '_')}.mbox`;
+
+  AppEnv.showSaveDialog(
+    {
+      title: localized('Export folder as .mbox file'),
+      buttonLabel: localized('Export'),
+      defaultPath: defaultName,
+      filters: [{ name: 'mbox', extensions: ['mbox'] }],
+    },
+    (mboxPath: string) => {
+      if (!mboxPath) {
+        return;
+      }
+
+      // Two exports feeding one destination would fight over the staging
+      // directory and interleave appends into the same file.
+      const running = TaskQueue.findTasks(GetManyRFC2822Task, (t: GetManyRFC2822Task) => {
+        return t.format === 'mbox' && t.mboxPath === mboxPath;
+      });
+      if (running.length > 0) {
+        AppEnv.showErrorDialog(localized('An mbox export to this file is already in progress.'));
+        return;
+      }
+
+      // The sync engine writes one .eml file per message into a staging
+      // directory beside the destination file (same volume as the export the
+      // user sized, and discoverable if something goes wrong); the mbox
+      // export runner incrementally assembles it into the mbox as the export
+      // progresses — including across app restarts. The staging path carries a
+      // per-export token so a new export never shares a directory (or working
+      // file) with an earlier, still-lingering completed task for the same
+      // destination — that collision would let the old task finalize against
+      // the new export's staging and overwrite the destination.
+      const token = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+      const stagingDir = `${mboxPath}.${token}.partial`;
+      fs.mkdirSync(stagingDir, { recursive: true });
+
+      Actions.queueTask(
+        new GetManyRFC2822Task({
+          accountId: category.accountId,
+          folderId: category.id,
+          folderPath: category.path,
+          outputDir: stagingDir,
+          format: 'mbox',
+          mboxPath,
         })
       );
     }
@@ -217,6 +276,7 @@ export default class SidebarItem {
         onDelete: opts.deletable ? onDeleteItem : undefined,
         onEdited: opts.editable ? onEditItem : undefined,
         onExport: opts.exportable ? onExportFolder : undefined,
+        onExportMbox: opts.exportable ? onExportMboxFolder : undefined,
         onCreateChild: opts.editable ? onCreateChild : undefined,
         onCollapseToggled: toggleItemCollapsed,
 

--- a/app/internal_packages/account-sidebar/lib/types.ts
+++ b/app/internal_packages/account-sidebar/lib/types.ts
@@ -14,6 +14,7 @@ export interface ISidebarItem {
   onDelete?: () => void;
   onEdited?: (item, name: string) => void;
   onExport?: () => void;
+  onExportMbox?: () => void;
   onCreateChild?: (item, childName: string) => void;
   onCollapseToggled: () => void;
   onDrop: (item, event) => void;

--- a/app/spec/services/mbox-utils-spec.ts
+++ b/app/spec/services/mbox-utils-spec.ts
@@ -1,0 +1,230 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import {
+  mboxFromLine,
+  senderFromEml,
+  transformEmlToMbox,
+  appendStagedMessages,
+  readMboxExportManifest,
+} from '../../src/services/mbox-utils';
+
+describe('mbox-utils', function () {
+  describe('mboxFromLine', () => {
+    it('formats an asctime-style UTC timestamp', () => {
+      const date = new Date(Date.UTC(2026, 0, 15, 9, 5, 3));
+      expect(mboxFromLine('user@example.com', date)).toEqual(
+        'From user@example.com Thu Jan 15 09:05:03 2026\n'
+      );
+    });
+
+    it('space-pads single-digit days of the month', () => {
+      const date = new Date(Date.UTC(2026, 0, 1, 0, 0, 0));
+      expect(mboxFromLine('user@example.com', date)).toEqual(
+        'From user@example.com Thu Jan  1 00:00:00 2026\n'
+      );
+    });
+  });
+
+  describe('senderFromEml', () => {
+    it('prefers Return-Path over From', () => {
+      const raw =
+        'Return-Path: <bounce@example.com>\r\nFrom: Alice <alice@example.com>\r\n\r\nBody';
+      expect(senderFromEml(raw)).toEqual('bounce@example.com');
+    });
+
+    it('extracts a bracketed address from the From header', () => {
+      const raw = 'From: "Alice A." <alice@example.com>\r\nSubject: Hi\r\n\r\nBody';
+      expect(senderFromEml(raw)).toEqual('alice@example.com');
+    });
+
+    it('extracts a bare address from the From header', () => {
+      const raw = 'From: alice@example.com\r\nSubject: Hi\r\n\r\nBody';
+      expect(senderFromEml(raw)).toEqual('alice@example.com');
+    });
+
+    it('handles folded headers', () => {
+      const raw =
+        'From: A very long display name\r\n <alice@example.com>\r\nSubject: Hi\r\n\r\nBody';
+      expect(senderFromEml(raw)).toEqual('alice@example.com');
+    });
+
+    it('does not read addresses from the message body', () => {
+      const raw = 'Subject: Hi\r\n\r\nContact me at someone@example.com';
+      expect(senderFromEml(raw)).toEqual('MAILER-DAEMON');
+    });
+
+    it('falls back to MAILER-DAEMON when no address is present', () => {
+      const raw = 'Subject: Hi\r\n\r\nBody';
+      expect(senderFromEml(raw)).toEqual('MAILER-DAEMON');
+    });
+  });
+
+  describe('transformEmlToMbox', () => {
+    it('converts CRLF line endings to LF', () => {
+      expect(transformEmlToMbox('Subject: Hi\r\n\r\nBody\r\n')).toEqual('Subject: Hi\n\nBody\n');
+    });
+
+    it('quotes body lines beginning with "From "', () => {
+      const raw = 'Subject: Hi\r\n\r\nFrom the desk of Alice\r\n';
+      expect(transformEmlToMbox(raw)).toEqual('Subject: Hi\n\n>From the desk of Alice\n');
+    });
+
+    it('quotes already-quoted From lines again (mboxrd)', () => {
+      const raw = 'Subject: Hi\r\n\r\n>From before\r\n>>From way before\r\n';
+      expect(transformEmlToMbox(raw)).toEqual('Subject: Hi\n\n>>From before\n>>>From way before\n');
+    });
+
+    it('does not quote lines merely containing "From "', () => {
+      const raw = 'Subject: Hi\r\n\r\nA note From Alice\r\nFromage is cheese\r\n';
+      expect(transformEmlToMbox(raw)).toEqual(
+        'Subject: Hi\n\nA note From Alice\nFromage is cheese\n'
+      );
+    });
+
+    it('ensures the message ends with a newline', () => {
+      expect(transformEmlToMbox('Subject: Hi\r\n\r\nBody')).toEqual('Subject: Hi\n\nBody\n');
+    });
+  });
+
+  describe('appendStagedMessages', () => {
+    let dir: string;
+    let staging: string;
+    let mbox: string;
+
+    const stageFile = (index: number, subject: string, body: string, date: Date) => {
+      const name = `${String(index).padStart(5, '0')} - ${subject} - 2026-01-01.eml`;
+      const filepath = path.join(staging, name);
+      fs.writeFileSync(
+        filepath,
+        Buffer.from(`From: a <a@example.com>\r\nSubject: ${subject}\r\n\r\n${body}\r\n`, 'latin1')
+      );
+      fs.utimesSync(filepath, new Date(), date);
+      return name;
+    };
+
+    const expectedMessage = (subject: string, body: string, date: Date) =>
+      mboxFromLine('a@example.com', date) +
+      transformEmlToMbox(`From: a <a@example.com>\r\nSubject: ${subject}\r\n\r\n${body}\r\n`) +
+      '\n';
+
+    const date = new Date(Date.UTC(2026, 2, 10, 12, 0, 0));
+
+    beforeEach(() => {
+      dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mbox-utils-spec-'));
+      staging = path.join(dir, 'staging');
+      mbox = path.join(dir, 'out.mbox');
+      fs.mkdirSync(staging);
+    });
+
+    afterEach(() => {
+      fs.rmSync(dir, { recursive: true, force: true });
+    });
+
+    it('appends only files covered by exportedCount and deletes them', async () => {
+      stageFile(0, 'zero', 'body0', date);
+      stageFile(1, 'one', 'body1', date);
+      stageFile(2, 'inflight', 'body2', date);
+
+      const remaining = await appendStagedMessages(staging, mbox, 2);
+
+      expect(remaining).toEqual(1);
+      expect(readMboxExportManifest(staging).consumedCount).toEqual(2);
+      expect(fs.readdirSync(staging).filter((f) => f.endsWith('.eml')).length).toEqual(1);
+      expect(fs.readFileSync(mbox).toString('latin1')).toEqual(
+        expectedMessage('zero', 'body0', date) + expectedMessage('one', 'body1', date)
+      );
+    });
+
+    it('consumes everything when exportedCount is null', async () => {
+      stageFile(0, 'zero', 'body0', date);
+      stageFile(1, 'one', 'body1', date);
+
+      const remaining = await appendStagedMessages(staging, mbox, null);
+
+      expect(remaining).toEqual(0);
+      expect(fs.readdirSync(staging).filter((f) => f.endsWith('.eml')).length).toEqual(0);
+    });
+
+    it('truncates a torn tail left by a crash before the manifest write', async () => {
+      stageFile(0, 'zero', 'body0', date);
+      await appendStagedMessages(staging, mbox, 1);
+
+      // a batch was appended but the crash happened before the manifest
+      // recorded it — the source file is still staged
+      fs.appendFileSync(mbox, 'TORN PARTIAL MESSAGE');
+      stageFile(1, 'one', 'body1', date);
+      await appendStagedMessages(staging, mbox, 2);
+
+      expect(fs.readFileSync(mbox).toString('latin1')).toEqual(
+        expectedMessage('zero', 'body0', date) + expectedMessage('one', 'body1', date)
+      );
+    });
+
+    it('deletes consumed leftovers instead of re-appending them', async () => {
+      const name = stageFile(0, 'zero', 'body0', date);
+      await appendStagedMessages(staging, mbox, 1);
+
+      // the manifest recorded the append but the crash happened before the
+      // consumed file was deleted
+      stageFile(0, 'zero', 'body0', date);
+      stageFile(1, 'one', 'body1', date);
+      await appendStagedMessages(staging, mbox, 2);
+
+      expect(fs.existsSync(path.join(staging, name))).toBe(false);
+      expect(fs.readFileSync(mbox).toString('latin1')).toEqual(
+        expectedMessage('zero', 'body0', date) + expectedMessage('one', 'body1', date)
+      );
+    });
+
+    it('throws if the mbox is shorter than the manifest offset', async () => {
+      stageFile(0, 'zero', 'body0', date);
+      await appendStagedMessages(staging, mbox, 1);
+      fs.truncateSync(mbox, 3);
+      stageFile(1, 'one', 'body1', date);
+
+      let threw = null;
+      try {
+        await appendStagedMessages(staging, mbox, 2);
+      } catch (err) {
+        threw = err;
+      }
+      expect(threw).not.toBe(null);
+    });
+
+    it('consumes large accumulations across multiple crash-safe sub-batches', async () => {
+      const count = 120; // spans three 50-file sub-batches
+      let expected = '';
+      for (let i = 0; i < count; i++) {
+        stageFile(i, `m${i}`, `body${i}`, date);
+        expected += expectedMessage(`m${i}`, `body${i}`, date);
+      }
+
+      const remaining = await appendStagedMessages(staging, mbox, null);
+
+      expect(remaining).toEqual(0);
+      expect(readMboxExportManifest(staging).consumedCount).toEqual(count);
+      expect(fs.readdirSync(staging).filter((f) => f.endsWith('.eml')).length).toEqual(0);
+      expect(fs.readFileSync(mbox).toString('latin1')).toEqual(expected);
+    });
+
+    it('creates an empty mbox for an export with no messages', async () => {
+      const remaining = await appendStagedMessages(staging, mbox, null);
+
+      expect(remaining).toEqual(0);
+      expect(fs.existsSync(mbox)).toBe(true);
+      expect(fs.statSync(mbox).size).toEqual(0);
+    });
+
+    it('overwrites a pre-existing file at the destination', async () => {
+      fs.writeFileSync(mbox, 'OLD CONTENTS THE USER AGREED TO OVERWRITE');
+      stageFile(0, 'zero', 'body0', date);
+
+      await appendStagedMessages(staging, mbox, null);
+
+      expect(fs.readFileSync(mbox).toString('latin1')).toEqual(
+        expectedMessage('zero', 'body0', date)
+      );
+    });
+  });
+});

--- a/app/src/components/outline-view-item.tsx
+++ b/app/src/components/outline-view-item.tsx
@@ -175,6 +175,7 @@ class OutlineViewItem extends Component<OutlineViewItemProps, OutlineViewItemSta
       this.props.item.onDelete != null ||
       this.props.item.onEdited != null ||
       this.props.item.onExport != null ||
+      this.props.item.onExportMbox != null ||
       this.props.item.onCreateChild != null
     );
   };
@@ -305,6 +306,15 @@ class OutlineViewItem extends Component<OutlineViewItemProps, OutlineViewItemSta
         new MenuItem({
           label: localized(`Export folder as .eml files...`),
           click: () => this._runCallback('onExport'),
+        })
+      );
+    }
+
+    if (this.props.item.onExportMbox) {
+      menu.append(
+        new MenuItem({
+          label: localized(`Export folder as .mbox file...`),
+          click: () => this._runCallback('onExportMbox'),
         })
       );
     }

--- a/app/src/components/outline-view.tsx
+++ b/app/src/components/outline-view.tsx
@@ -27,6 +27,7 @@ export interface IOutlineViewItem {
   onDelete?: (...args: any[]) => any;
   onEdited?: (...args: any[]) => any;
   onExport?: (...args: any[]) => any;
+  onExportMbox?: (...args: any[]) => any;
   onCreateChild?: (...args: any[]) => any;
 }
 

--- a/app/src/flux/tasks/get-many-rfc2822-task.ts
+++ b/app/src/flux/tasks/get-many-rfc2822-task.ts
@@ -7,6 +7,11 @@ export interface ExportResult {
   exported?: number;
   failed?: number;
   outputDir?: string;
+  // Set by the sync engine when the export stopped on a cancel request. The
+  // task's status still ends up "complete" in that case (performRemote only
+  // maps shouldCancel to the cancelled status before the export starts), so
+  // consumers must check this flag to distinguish a cancelled export.
+  cancelled?: boolean;
   errors?: Array<{ messageId: string; subject: string; error: string }>;
 }
 
@@ -23,6 +28,16 @@ export class GetManyRFC2822Task extends Task {
     outputDir: Attributes.String({
       modelKey: 'outputDir',
     }),
+    // 'eml' (default) or 'mbox'. Only read by the client — the sync engine
+    // always writes individual .eml files to outputDir, and for mbox exports
+    // the client incrementally assembles them into mboxPath as the export
+    // progresses (see mbox-export-runner in the account-sidebar package).
+    format: Attributes.String({
+      modelKey: 'format',
+    }),
+    mboxPath: Attributes.String({
+      modelKey: 'mboxPath',
+    }),
     progress: Attributes.Obj({
       modelKey: 'progress',
     }),
@@ -34,6 +49,8 @@ export class GetManyRFC2822Task extends Task {
   folderId: string;
   folderPath: string;
   outputDir: string;
+  format: 'eml' | 'mbox';
+  mboxPath: string;
   progress: ExportResult;
   result: ExportResult;
 
@@ -49,6 +66,6 @@ export class GetManyRFC2822Task extends Task {
       }
       return `Exporting ${exported || 0} / ${total}`;
     }
-    return 'Exporting folder as .eml files';
+    return this.format === 'mbox' ? 'Exporting folder as mbox' : 'Exporting folder as .eml files';
   }
 }

--- a/app/src/global/mailspring-exports.d.ts
+++ b/app/src/global/mailspring-exports.d.ts
@@ -209,6 +209,8 @@ export type MenuHelpers = typeof import('../menu-helpers');
 export const MenuHelpers: MenuHelpers;
 export type EmlUtils = typeof import('../services/eml-utils');
 export const EmlUtils: EmlUtils;
+export type MboxUtils = typeof import('../services/mbox-utils');
+export const MboxUtils: MboxUtils;
 export type VirtualDOMUtils = typeof import('../virtual-dom-utils').default;
 export const VirtualDOMUtils: VirtualDOMUtils;
 export type Spellchecker = typeof import('../spellchecker').default;

--- a/app/src/global/mailspring-exports.js
+++ b/app/src/global/mailspring-exports.js
@@ -195,6 +195,7 @@ lazyLoad(`MessageUtils`, 'flux/models/message-utils');
 
 // Services
 lazyLoad(`EmlUtils`, 'services/eml-utils');
+lazyLoad(`MboxUtils`, 'services/mbox-utils');
 lazyLoad(`KeyManager`, 'key-manager');
 lazyLoad(`SoundRegistry`, 'registries/sound-registry');
 lazyLoad(`MailRulesTemplates`, 'mail-rules-templates');

--- a/app/src/services/mbox-utils.ts
+++ b/app/src/services/mbox-utils.ts
@@ -1,0 +1,316 @@
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * Utilities for assembling an mbox file from a directory of raw RFC 2822
+ * (.eml) files produced by GetManyRFC2822Task.
+ *
+ * Assembly is incremental: batches of staged messages are appended to the
+ * mbox and their .eml files deleted as the export progresses, so the staging
+ * directory never holds more than the not-yet-appended window of the export
+ * (rather than a full second copy of the folder). A manifest file in the
+ * staging directory records how far assembly has gotten; appends are ordered
+ * append → fsync → manifest → delete so that a crash at any point is
+ * recoverable without losing or duplicating messages (see
+ * appendStagedMessages).
+ *
+ * The variant written is "mboxrd": message bodies are stored with LF line
+ * endings, and any body line matching /^>*From / is quoted with an extra ">"
+ * so the "From " separator lines remain unambiguous. This is the most widely
+ * compatible dialect (Thunderbird, mutt, Google Takeout all read it).
+ *
+ * All file contents are treated as latin1 so message bytes pass through
+ * unmodified regardless of charset or Content-Transfer-Encoding.
+ */
+
+const DAY_NAMES = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+const MONTH_NAMES = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec',
+];
+
+/**
+ * Build an mbox "From " separator line. The timestamp uses the traditional
+ * asctime layout in UTC ("Thu Jan  1 00:00:00 2026") — the day of month is
+ * space-padded, which some strict parsers require.
+ */
+export function mboxFromLine(sender: string, date: Date): string {
+  const day = DAY_NAMES[date.getUTCDay()];
+  const month = MONTH_NAMES[date.getUTCMonth()];
+  const dom = String(date.getUTCDate()).padStart(2, ' ');
+  const hh = String(date.getUTCHours()).padStart(2, '0');
+  const mm = String(date.getUTCMinutes()).padStart(2, '0');
+  const ss = String(date.getUTCSeconds()).padStart(2, '0');
+  return `From ${sender} ${day} ${month} ${dom} ${hh}:${mm}:${ss} ${date.getUTCFullYear()}\n`;
+}
+
+/**
+ * Extract the envelope sender for the "From " line from a raw message's
+ * headers, preferring Return-Path over From. Returns MAILER-DAEMON when no
+ * address can be found, mirroring what MTAs write for bounces.
+ */
+export function senderFromEml(raw: string): string {
+  const normalized = raw.replace(/\r\n/g, '\n');
+  const headerEnd = normalized.indexOf('\n\n');
+  const headers = (headerEnd === -1 ? normalized : normalized.substring(0, headerEnd))
+    // unfold continuation lines
+    .replace(/\n[ \t]+/g, ' ');
+
+  // The result lands on the "From " separator line, whose format relies on
+  // space-delimited fields — strip control characters so a crafted header
+  // can't inject bytes that confuse mbox parsers. (Whitespace is already
+  // excluded by the regexes below.)
+  const sanitize = (addr: string) =>
+    // eslint-disable-next-line no-control-regex
+    addr.replace(/[\u0000-\u001f\u007f]/g, '');
+
+  for (const name of ['return-path', 'from']) {
+    const match = headers.match(new RegExp(`^${name}:(.*)$`, 'im'));
+    if (!match) {
+      continue;
+    }
+    const value = match[1];
+    const bracketed = value.match(/<([^<>\s]+@[^<>\s]+)>/);
+    if (bracketed) {
+      return sanitize(bracketed[1]);
+    }
+    const bare = value.match(/([^\s<>,;:"'()]+@[^\s<>,;:"'()]+)/);
+    if (bare) {
+      return sanitize(bare[1]);
+    }
+  }
+  return 'MAILER-DAEMON';
+}
+
+/**
+ * Convert a raw RFC 2822 message to its mboxrd body form: LF line endings,
+ * ">"-quoted From lines, and a guaranteed trailing newline.
+ */
+export function transformEmlToMbox(raw: string): string {
+  let body = raw.replace(/\r\n/g, '\n');
+  body = body.replace(/^(>*From )/gm, '>$1');
+  if (!body.endsWith('\n')) {
+    body += '\n';
+  }
+  return body;
+}
+
+const MANIFEST_NAME = 'mbox-export-manifest.json';
+
+// Files consumed (appended + deleted) per crash-safe cycle. Bounds the disk
+// held by staged files during large catch-up assemblies; matches the sync
+// engine's export chunk size.
+const SUB_BATCH_SIZE = 50;
+
+export interface MboxExportManifest {
+  version: 1;
+  // Byte length of the mbox covering every consumed message; anything beyond
+  // this offset is a torn append from a crash and is truncated on recovery.
+  mboxBytes: number;
+  // How many staged files have been appended to the mbox so far.
+  consumedCount: number;
+  // Filename of the last appended file. Staged filenames sort in export
+  // order, so any staged file <= this name was already appended (its delete
+  // didn't complete) and is removed on recovery rather than re-appended.
+  lastConsumedName: string;
+}
+
+export function readMboxExportManifest(stagingDir: string): MboxExportManifest | null {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(path.join(stagingDir, MANIFEST_NAME), 'utf8');
+  } catch (err) {
+    // no manifest — no assembly has happened yet
+    return null;
+  }
+  // An unreadable manifest must NOT be treated as a fresh export: that would
+  // truncate the mbox to zero even though consumed messages exist only there.
+  // Failing loudly preserves both the mbox and the remaining staged files.
+  let parsed = null;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    // fall through to the error below
+  }
+  if (!parsed || parsed.version !== 1 || typeof parsed.mboxBytes !== 'number') {
+    throw new Error(`Unrecognized mbox export manifest in ${stagingDir}`);
+  }
+  return parsed as MboxExportManifest;
+}
+
+async function writeManifest(stagingDir: string, manifest: MboxExportManifest) {
+  const dest = path.join(stagingDir, MANIFEST_NAME);
+  const tmp = `${dest}.tmp`;
+  const fh = await fs.promises.open(tmp, 'w');
+  try {
+    await fh.writeFile(JSON.stringify(manifest), 'utf8');
+    await fh.sync();
+  } finally {
+    await fh.close();
+  }
+  await fs.promises.rename(tmp, dest);
+  // Make the rename durable before the caller deletes consumed files: on
+  // power loss the deletes must never outlive the manifest that records
+  // them. Directories can't be fsynced on Windows — best effort there.
+  try {
+    const dirHandle = await fs.promises.open(stagingDir, 'r');
+    try {
+      await dirHandle.sync();
+    } finally {
+      await dirHandle.close();
+    }
+  } catch (err) {
+    // EISDIR/EPERM on platforms that can't open directories
+  }
+}
+
+/**
+ * Append staged .eml files to the mbox in export order, then delete them.
+ * Files are processed in lexicographic order — GetManyRFC2822Task names them
+ * with a zero-padded index prefix, so this preserves the original mailbox
+ * (UID) order. Each file's mtime is the message date (set by the export task)
+ * and becomes the separator-line timestamp.
+ *
+ * `exportedCount` is the engine's persisted count of successfully exported
+ * messages (task.progress.exported): staged files past that count may still
+ * be mid-write by the sync engine and are left for a later call. Pass null
+ * once the task has finished to consume everything that remains.
+ *
+ * Each call first recovers from any earlier interruption (truncates a torn
+ * tail, deletes consumed leftovers), then consumes the eligible files in
+ * crash-safe sub-batches: append the sub-batch, fsync, record the manifest,
+ * and only then delete the consumed files. A crash before the manifest write
+ * leaves the source files in place (the torn tail is truncated and
+ * re-appended next time); a crash after it leaves only already-recorded
+ * files to delete. Messages are therefore never lost or duplicated, and
+ * because consumed files are deleted between sub-batches, disk usage beyond
+ * the mbox itself stays bounded by the sub-batch window no matter how many
+ * files have accumulated (e.g. when assembly was deferred and runs at
+ * completion).
+ *
+ * Returns the number of staged messages remaining. The manifest and staging
+ * directory are left in place; the caller removes them when the export ends.
+ */
+export async function appendStagedMessages(
+  stagingDir: string,
+  mboxPath: string,
+  exportedCount: number | null
+): Promise<number> {
+  const manifest = readMboxExportManifest(stagingDir) || {
+    version: 1 as const,
+    mboxBytes: 0,
+    consumedCount: 0,
+    lastConsumedName: '',
+  };
+
+  let files = (await fs.promises.readdir(stagingDir))
+    .filter((f) => f.toLowerCase().endsWith('.eml'))
+    .sort();
+
+  // Recovery: files at or before lastConsumedName are already in the mbox —
+  // their deletion was interrupted. Remove them instead of re-appending.
+  if (manifest.lastConsumedName) {
+    for (const file of files) {
+      if (file <= manifest.lastConsumedName) {
+        await fs.promises.rm(path.join(stagingDir, file), { force: true });
+      }
+    }
+    files = files.filter((f) => f > manifest.lastConsumedName);
+  }
+
+  const maxCount = exportedCount == null ? files.length : exportedCount - manifest.consumedCount;
+  const batch = files.slice(0, Math.max(0, maxCount));
+
+  // Recovery: reconcile the mbox with the manifest before appending.
+  let mboxSize = 0;
+  try {
+    mboxSize = (await fs.promises.stat(mboxPath)).size;
+  } catch (err) {
+    // no mbox yet
+  }
+  if (mboxSize < manifest.mboxBytes) {
+    throw new Error(
+      `The mbox file is shorter than the ${manifest.mboxBytes} bytes already exported — it was moved or modified while the export was running.`
+    );
+  }
+
+  // Read-write (not append) mode with explicitly positioned writes: append
+  // mode would be simpler, but on Windows Node opens 'a' handles without
+  // write-data access and the recovery truncate below can fail on them, and
+  // O_APPEND positioning after ftruncate is exactly the kind of cross-
+  // platform subtlety this file shouldn't depend on.
+  const fh = await fs.promises.open(mboxPath, fs.constants.O_RDWR | fs.constants.O_CREAT);
+  let offset = manifest.mboxBytes;
+  let consumedCount = manifest.consumedCount;
+  let lastConsumedName = manifest.lastConsumedName;
+  try {
+    if (mboxSize > manifest.mboxBytes) {
+      // torn append from a crash (or a pre-existing file being overwritten,
+      // when the manifest is fresh) — drop the unrecorded bytes
+      await fh.truncate(manifest.mboxBytes);
+    }
+    for (let i = 0; i < batch.length; i += SUB_BATCH_SIZE) {
+      const subBatch = batch.slice(i, i + SUB_BATCH_SIZE);
+      for (const file of subBatch) {
+        const filepath = path.join(stagingDir, file);
+        const [buf, stat] = await Promise.all([
+          fs.promises.readFile(filepath),
+          fs.promises.stat(filepath),
+        ]);
+        const raw = buf.toString('latin1');
+        const message =
+          mboxFromLine(senderFromEml(raw), stat.mtime) + transformEmlToMbox(raw) + '\n';
+        const chunk = Buffer.from(message, 'latin1');
+        // write() may write fewer bytes than requested; the manifest offset
+        // must reflect what actually reached the file
+        let written = 0;
+        while (written < chunk.length) {
+          const { bytesWritten } = await fh.write(
+            chunk,
+            written,
+            chunk.length - written,
+            offset + written
+          );
+          written += bytesWritten;
+        }
+        offset += chunk.length;
+      }
+      await fh.sync();
+      consumedCount += subBatch.length;
+      lastConsumedName = subBatch[subBatch.length - 1];
+      await writeManifest(stagingDir, {
+        version: 1,
+        mboxBytes: offset,
+        consumedCount,
+        lastConsumedName,
+      });
+      for (const file of subBatch) {
+        await fs.promises.rm(path.join(stagingDir, file), { force: true }).catch(() => {});
+      }
+    }
+  } finally {
+    await fh.close();
+  }
+
+  if (batch.length === 0 && (mboxSize !== manifest.mboxBytes || manifest.consumedCount === 0)) {
+    // nothing consumed, but record the truncation / claim a fresh mbox file
+    await writeManifest(stagingDir, {
+      version: 1,
+      mboxBytes: offset,
+      consumedCount,
+      lastConsumedName,
+    });
+  }
+
+  return files.length - batch.length;
+}


### PR DESCRIPTION
# Add mbox export for folders

## Summary

Adds **"Export Folder as .mbox File..."** to the folder context menu in the sidebar, alongside the `.eml` export added in #2652. The user picks a destination `.mbox` file; Mailspring exports the folder into it with live progress in the activity sidebar and resume-across-restarts — all the way to a single portable mailbox file that imports cleanly into Apple Mail, mutt, and anything else that reads mbox.

**This PR touches only the Mailspring client — zero sync-engine changes.** It reuses `GetManyRFC2822Task` exactly as it ships today: the engine fetches each message to a `.eml` file in a staging directory (with its existing progress reporting, resume cursor, and cancellation), and the client assembles those files into the mbox. The task's two new fields (`format`, `mboxPath`) are client-only and simply ride along in the task JSON.

## How it works

1. The context-menu handler prompts for a destination (e.g. `Archive.mbox`) and queues a `GetManyRFC2822Task` pointed at a staging directory beside it (`Archive.mbox.partial/`).
2. A small runner in the `account-sidebar` package watches the TaskQueue. Each time the engine persists export progress (every 50 messages), the runner appends the staged files covered by that progress to a working file (`Archive.mbox.incomplete`) and deletes them — so **peak disk usage stays near 1× folder size** (staging holds a ~50-message window), instead of a full second copy of the folder plus the mbox.
3. When the task completes, the runner assembles whatever remains and **atomically renames the working file to the chosen destination** — but only for a genuinely complete export (every message accounted for, none failed, not cancelled). The file the user picked never exists in a partial state, and a pre-existing file at that path is **replaced only by a complete export**: a cancelled, failed, or empty export leaves the existing file untouched (the fetched messages stay in the working file, and the user is told where). The staging directory carries a per-export token, so a fresh export never shares a directory or working file with an earlier still-lingering completed task for the same destination.

Because the fetch half of an export is a persisted task that survives app restarts, the assembly half is too: the runner advances any mbox export whose staging directory still exists, whether the export completes live or resumes after a restart or crash.

<details>
<summary><b>Crash-safety design (for reviewers who want the details)</b></summary>

Every append cycle is: *write sub-batch at explicitly tracked offsets → fsync → record a manifest (`mboxBytes`, `consumedCount`, `lastConsumedName`) in the staging directory via tmp-file + rename, made durable with a directory sync → delete the consumed `.eml` files.*

On recovery:
- bytes in the working file beyond the manifest offset are a torn append — truncated and re-appended (their source files still exist, since deletes only happen after the manifest is durable);
- staged files at or before `lastConsumedName` were already appended (their deletes were interrupted) — removed, not re-appended.

So an interruption at any point loses and duplicates nothing. Two deliberate safety valves:
- **An unreadable manifest aborts assembly with an error** instead of restarting from scratch — restarting would truncate a working file that is now the only copy of already-consumed messages.
- The staged filenames' sorted order is trusted for incremental consumption **only while `progress.failed == 0`**: after a restart the engine resumes its filename counter at the *exported* count, so failed messages make index prefixes non-unique and name order can no longer distinguish complete files from in-flight ones. In that rare case, the remainder is assembled at completion (when nothing is in-flight) — still in bounded sub-batches, preserving the disk ceiling.

The working file is opened read-write with positioned writes rather than `O_APPEND`, because Windows append-mode handles don't reliably support the recovery truncation.

Concurrent exports to the same destination are refused with a dialog (they would fight over the staging directory).

</details>

## Format

The mbox is written in the **mboxrd** dialect for maximum compatibility (Thunderbird, mutt, Google Takeout all read it): LF line endings, `>`-quoting of `/^>*From /` lines, `From ` separator lines with asctime-style UTC timestamps taken from the message date. The envelope sender is parsed from `Return-Path` (falling back to `From`, then `MAILER-DAEMON`) and stripped of control characters. Message bytes are handled as latin1 throughout, so content passes through unmodified regardless of charset or Content-Transfer-Encoding.

## Testing

- **13 Jasmine specs** (`app/spec/services/mbox-utils-spec.ts`) cover the separator/escaping/sender functions plus the assembler: barrier-gated consumption, both crash windows (torn tail re-append; interrupted deletes), external-truncation detection, destination overwrite, empty-folder export, and the >50-file multi-sub-batch path. Format mechanics (mboxrd `>From ` escaping, asctime separators, byte-exact latin1 round-trip of 8-bit bodies) are additionally verified in the specs against fixture messages.
- **Manual verification (macOS):** exported real folders and confirmed the resulting `.mbox` opens correctly in **Apple Mail** and **mutt** (`mutt -f`); verified that re-exporting over an existing `.mbox` replaces it cleanly and that an incomplete/failed export leaves an existing file untouched.
- **Windows:** the assembly code deliberately uses only ordinary positioned I/O, but this was developed and tested on macOS — a Windows CI pass / smoke test of one export would be appreciated.

## Known limitations / possible follow-ups

- **Gmail labels export empty** — `folderId` is the label id, but the engine filters messages by `remoteFolderId`, which for Gmail only ever points at All Mail/Spam/Trash. This is pre-existing behavior shared with the `.eml` export in #2652 (same code path); I'd like to fix both together in a small follow-up PR rather than mix it in here.
- **No progress indicator during deferred assembly** — if messages failed mid-export, final assembly happens after the task completes and the activity indicator has cleared. The atomic rename means there's never a misleading partial file at the destination (the export visibly isn't done until the file appears), but a progress signal would be nicer. Kept out of this PR to avoid touching the notifications package.
- **Mid-export cancellation is broken in the engine (pre-existing, affects the `.eml` export too)** — `performRemoteGetManyRFC2822` saves progress from its long-lived in-memory task copy every chunk, which clobbers the `should_cancel` flag that `TaskProcessor::cancel` persists from the main thread, so the loop's own cancellation check almost never sees it; and even when it does, `performRemote` unconditionally stamps the task `complete` afterward. Fixed in Mailspring-Sync#118. This PR is engine-independent — its runner already handles both cancel signals correctly (`status == cancelled` and `complete` + `progress.cancelled`): it discards the staging directory and working file, and never installs a partial mailbox at the destination. (A cancel button in the export progress UI is a small follow-up once the engine fix ships in a published build.)
- **Optional one-line engine improvement** — if `performRemoteGetManyRFC2822` resumed its filename counter at `exported + failed` instead of `exported`, staged filename prefixes would stay unique across restarts and incremental assembly could run even for exports with failures. Could ride along with the cancellation fix above; this PR doesn't depend on it.
