### PR TITLE
Fix unhandled fetch errors escaping APIError wrapping in makeRequest

### DIFF
--- a/app/src/flux/mailspring-api-request.ts
+++ b/app/src/flux/mailspring-api-request.ts
@@ -138,7 +138,7 @@ export async function makeRequest({
     throw error;
   }
   try {
-    return resp.json();
+    return await resp.json();
   } catch (invalidJSONError) {
     // We need to wrap this generic JSON error into our APIError class to attach the request
     // description and also to prevent it from being reported to Sentry 7,000 times a month.


### PR DESCRIPTION
## Summary

Fixes [MAILSPRING-CLIENT-G](https://foundry-376-llc.sentry.io/issues/MAILSPRING-CLIENT-G) (687 users impacted, 958 events) and [MAILSPRING-CLIENT-4N](https://foundry-376-llc.sentry.io/issues/MAILSPRING-CLIENT-4N) (50 users, 54 events) — both "Error: Failed to fetch" being reported to Sentry with little to no actionable info.

### What I observed

- `MAILSPRING-CLIENT-G` is the highest-impact unassigned issue in the 14-day `1.21.1-ae68e881` release view, but every sampled event (20/20) had **zero stack frames** ("No stacktrace available") and no culprit — normally a dead end.
- `MAILSPRING-CLIENT-4N` is the same error message, but a fraction of its events *do* carry a stack frame, consistently pointing at `app/src/flux/mailspring-api-request.ts:141` inside `makeRequest()`, called from `IdentityStore.fetchIdentity()`.
- That line is:
  ```ts
  try {
    return resp.json();       // <-- not awaited
  } catch (invalidJSONError) {
    error.message = `${desc} returned invalid JSON: ${invalidJSONError.toString()}`;
    throw error;               // wraps into APIError
  }
  ```
  Because `resp.json()` is `return`ed instead of `await`ed, a rejection of that promise (e.g. the connection dropping mid-stream while reading the response body — which Chromium/Electron's fetch implementation also reports as `TypeError: Failed to fetch`, or a JSON parse failure) happens *after* the try block has already exited. The local `catch` never runs, so the raw, unwrapped error escapes instead of being converted into the intended `APIError`.
- This matters because `AppEnv.reportError()` explicitly filters out `APIError` instances before they reach Sentry (comment in the same file: *"prevent it from being reported to Sentry 7,000 times a month"*). Since the raw error bypasses that wrapping, it isn't filtered.
- `IdentityStore._fetchAndPollRemoteIdentity()` calls `this.fetchIdentity()` (which calls `makeRequest`) on a `setInterval` every 10 minutes for every user in the main window, with no local `.catch()`. Any transient network hiccup (wifi drop, VPN, corporate firewall, sleep/wake) during that call becomes an unhandled promise rejection, caught by the global `window.addEventListener('unhandledrejection', ...)` handler in `app-env.ts` and reported straight to Sentry — which explains the very high, steady volume across almost every user (687 of them) roughly every 10 minutes.
- Whether Sentry ends up with a stack frame or not (grouping G vs. 4N as separate issues) depends on whether V8 preserved an async stack for that particular rejection — same underlying bug either way.

### Fix

One-line change: `await` the `resp.json()` call so its rejection is actually caught by the surrounding `try/catch` and properly wrapped into the pre-built `APIError` (which already carries a real stack trace captured before the request is even made, and correct `error.message`/`statusCode` context). This restores the existing, intended behavior of filtering these expected/offline-related errors out of Sentry instead of reporting them as raw, low-context "Failed to fetch" noise.

```diff
   try {
-    return resp.json();
+    return await resp.json();
   } catch (invalidJSONError) {
```

## Test plan

- [x] `npx tsc --noEmit` passes for the changed file
- [ ] Manual verification: simulate a dropped connection while `IdentityStore.fetchIdentity()` is in flight and confirm the resulting error is an `APIError` that is filtered by `AppEnv.reportError` instead of reaching Sentry as a raw `TypeError`


---
_Generated by [Claude Code](https://claude.ai/code/session_01Hqnyw9EcppsZiZedTrdQjs)_