### PR TITLE
Fix EPIPE crash loop in uncaughtException handler on Linux

### DIFF
--- a/app/src/browser/main.js
+++ b/app/src/browser/main.js
@@ -5,6 +5,25 @@ const util = require('util');
 
 const fs = require('fs');
 
+// On Linux, writes to process.stdout/stderr use a synchronous fast path when
+// the fd is a pipe. If the reader end of that pipe has gone away (eg. the
+// terminal or launcher that started Mailspring has exited), the write fails
+// with EPIPE and — because there's no 'error' listener on the stream — Node
+// throws it synchronously instead of emitting it. When this happens inside
+// our `uncaughtException` handler (which itself logs via console.error), the
+// thrown EPIPE re-enters the same handler, producing an infinite crash loop.
+// Swallowing EPIPE here lets writes to a dead stdout/stderr silently no-op.
+for (const stream of [process.stdout, process.stderr]) {
+  if (stream) {
+    stream.on('error', error => {
+      if (error && error.code === 'EPIPE') {
+        return;
+      }
+      throw error;
+    });
+  }
+}
+
 console.inspect = function consoleInspect(val) {
   console.log(util.inspect(val, true, 7, true));
 };

--- a/app/src/error-logger.js
+++ b/app/src/error-logger.js
@@ -125,7 +125,15 @@ module.exports = ErrorLogger = (function () {
     } else {
       this._notifyExtensions('reportError', error, extra);
     }
-    console.error(error, extra);
+    // console.error can itself throw (eg. EPIPE writing to a closed
+    // stdout/stderr pipe on Linux). Since reportError is called from our
+    // top-level uncaughtException handler, an uncaught throw here would
+    // re-enter that same handler and loop forever. Never let this fail.
+    try {
+      console.error(error, extra);
+    } catch (loggingError) {
+      // ignore
+    }
   };
 
   /////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Summary

Fixes [MAILSPRING-CLIENT-1V](https://foundry-376-llc.sentry.io/issues/MAILSPRING-CLIENT-1V) — `Error: write EPIPE`, which had **24,607 occurrences from 19 users** on Linux (release `1.21.1-ae68e881`), by far the highest event count of any unresolved issue in that release.

### What I observed

The Sentry event's stack trace pinpoints the crash to `error-logger.js:128`, inside `ErrorLogger.reportError`:

```
app:///src/error-logger.js:128:13 (module.exports.ErrorLogger.reportError)
    console.error(error, extra);
    at console.error (node:internal/console/constructor:444:26)
    ...
    at Socket._write (node:net:1037:8)
    ...
```

with `extra.origin: "uncaughtException"` — meaning this error was thrown *from inside* our own top-level exception handler (`app/src/browser/main.js`):

```js
process.on('uncaughtException', (error, origin) => errorLogger.reportError(error, { origin }));
```

**Root cause:** On Linux, when `process.stdout`/`process.stderr` is a pipe (e.g. Mailspring launched from a terminal/script whose reader has since exited, or wrapped by some Linux packaging/launchers), Node uses a synchronous fast-write path for pipes. If the reader end is gone, that write fails with `EPIPE` and — because nothing was listening for the stream's `'error'` event — Node throws it *synchronously* rather than emitting it.

`reportError`'s last line unconditionally called `console.error(error, extra)` to log the error it was reporting. When stdout/stderr was a dead pipe, that call itself threw `EPIPE`. Since this happened inside the `uncaughtException` handler, the thrown error re-entered `process.on('uncaughtException', ...)`, which called `reportError` again, which called `console.error` again, which threw `EPIPE` again — an unbounded self-sustaining crash loop. This explains the huge occurrence-to-user ratio (~1,295 events/user): a handful of users with a broken stdout pipe generated tens of thousands of events each, persisting for the app's lifetime (May–July).

### The fix

1. **`app/src/browser/main.js`** — Register `'error'` listeners on `process.stdout`/`process.stderr` early in startup that swallow `EPIPE` (and rethrow anything else), so a dead pipe never produces a synchronous throw in the first place.
2. **`app/src/error-logger.js`** — Wrap the `console.error(error, extra)` call in `reportError` in a `try/catch` as defense-in-depth, so a failed log write can never escape the error handler and re-trigger itself, regardless of where the write failure originates.

## Test plan

- [x] `node --check` on both modified files
- [x] Isolated script confirming an `EPIPE`-tagged error emitted on `process.stdout`/`process.stderr` is swallowed by the new listener, while non-EPIPE errors still throw/propagate as before
- [x] Isolated script confirming `reportError`'s console.error try/catch prevents a thrown logging failure from escaping
- [ ] Could not reproduce the exact broken-pipe condition in this sandboxed environment (requires closing the reader end of Mailspring's inherited stdout/stderr pipe on Linux), so this was verified via targeted unit-level scripts of the exact code paths rather than a full end-to-end repro

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AvTGU6aSbyRV9vEMRG8tN8


---
_Generated by [Claude Code](https://claude.ai/code/session_01AvTGU6aSbyRV9vEMRG8tN8)_