### PR TITLE
Fix crash in EventRSVPTask when attendee ICS data goes stale

### DIFF
--- a/app/internal_packages/events/lib/event-header.tsx
+++ b/app/internal_packages/events/lib/event-header.tsx
@@ -102,6 +102,7 @@ export class EventHeader extends React.Component<EventHeaderProps, EventHeaderSt
         try {
           this.setState({
             icsEvent: CalendarUtils.parseICSString(calEvent.ics).event,
+            icsOriginalData: calEvent.ics,
           });
         } catch (e) {
           console.warn(`EventHeader: Could not parse ICS data from calendar event: ${e.message}`);
@@ -277,6 +278,24 @@ export class EventHeader extends React.Component<EventHeaderProps, EventHeaderSt
         localized(
           "Sorry, this event does not have an organizer or the organizer's address is not a valid email address: %@",
           icsEvent.organizer || '(none)'
+        )
+      );
+      return;
+    }
+
+    // Guard against stale/mismatched ICS data: the attendee list in `icsOriginalData`
+    // (the emailed .ics attachment) can differ from the one used to decide whether to
+    // show these buttons if a synced calendar Event later replaced `icsEvent`. If we
+    // can't find ourselves as an attendee in the data we're actually about to send,
+    // bail out with a clear message instead of crashing inside EventRSVPTask.
+    const me = CalendarUtils.selfParticipant(
+      CalendarUtils.parseICSString(icsOriginalData).event,
+      this.props.message.accountId
+    );
+    if (!me) {
+      AppEnv.showErrorDialog(
+        localized(
+          "Sorry, we couldn't find your email address in this event's attendee list, so an RSVP reply could not be sent."
         )
       );
       return;

--- a/app/internal_packages/events/lib/event-header.tsx
+++ b/app/internal_packages/events/lib/event-header.tsx
@@ -283,16 +283,22 @@ export class EventHeader extends React.Component<EventHeaderProps, EventHeaderSt
       return;
     }
 
-    // Guard against stale/mismatched ICS data: the attendee list in `icsOriginalData`
-    // (the emailed .ics attachment) can differ from the one used to decide whether to
-    // show these buttons if a synced calendar Event later replaced `icsEvent`. If we
-    // can't find ourselves as an attendee in the data we're actually about to send,
-    // bail out with a clear message instead of crashing inside EventRSVPTask.
-    const me = CalendarUtils.selfParticipant(
-      CalendarUtils.parseICSString(icsOriginalData).event,
-      this.props.message.accountId
-    );
-    if (!me) {
+    // The attendee list in `icsOriginalData` (the emailed .ics attachment) can differ
+    // from the one used to decide whether to show these buttons if a synced calendar
+    // Event later replaced `icsEvent`. EventRSVPTask.forReplying throws if it can't
+    // find us as an attendee in the data it's actually replying with; catch that here
+    // instead of letting it crash the click handler.
+    let task: EventRSVPTask;
+    try {
+      task = EventRSVPTask.forReplying({
+        accountId: this.props.message.accountId,
+        messageId: this.props.message.id,
+        icsOriginalData,
+        icsRSVPStatus: status,
+        to: organizerEmail,
+      });
+    } catch (e) {
+      console.warn(`EventHeader: Could not build RSVP reply: ${e.message}`);
       AppEnv.showErrorDialog(
         localized(
           "Sorry, we couldn't find your email address in this event's attendee list, so an RSVP reply could not be sent."
@@ -302,16 +308,7 @@ export class EventHeader extends React.Component<EventHeaderProps, EventHeaderSt
     }
 
     this.setState({ inflight: status });
-
-    Actions.queueTask(
-      EventRSVPTask.forReplying({
-        accountId: this.props.message.accountId,
-        messageId: this.props.message.id,
-        icsOriginalData,
-        icsRSVPStatus: status,
-        to: organizerEmail,
-      })
-    );
+    Actions.queueTask(task);
   };
 }
 

--- a/app/src/flux/tasks/event-rsvp-task.ts
+++ b/app/src/flux/tasks/event-rsvp-task.ts
@@ -57,6 +57,11 @@ export class EventRSVPTask extends Task {
   }) {
     const { event, root } = CalendarUtils.parseICSString(icsOriginalData);
     const me = CalendarUtils.selfParticipant(event, accountId);
+    if (!me) {
+      throw new Error(
+        `EventRSVPTask.forReplying: could not find an attendee matching account ${accountId} in this event's ICS data.`
+      );
+    }
 
     // Update the replying attendee's participation status
     me.component.setParameter('partstat', icsRSVPStatus);


### PR DESCRIPTION
## Summary

Fixes [MAILSPRING-CLIENT-50](https://foundry-376-llc.sentry.io/issues/MAILSPRING-CLIENT-50) — `Error: Cannot read properties of undefined (reading 'component')` in `EventRSVPTask.forReplying`, which had impacted 10 users / 32 events over the past two months.

### Root cause

`EventHeader` (`app/internal_packages/events/lib/event-header.tsx`) keeps two pieces of state derived from a calendar invite:

- `icsOriginalData` — the raw `.ics` text from the emailed attachment, set once in `componentDidMount` and never updated again.
- `icsEvent` — the parsed event used for rendering. If a matching `Event` later shows up in the local calendar DB (synced separately from the mail sync engine), the `DatabaseStore` subscription in `componentDidMount` **replaces `icsEvent`** with a version parsed from that synced calendar entry's own ICS data — but leaves `icsOriginalData` untouched.

`_renderRSVP()` decides whether to show the Accept/Maybe/Decline buttons using the (possibly newer, synced) `icsEvent`. But `_onRSVP()` builds the reply from the stale `icsOriginalData`, which `EventRSVPTask.forReplying` re-parses independently and uses to look up the current account in the attendee list via `CalendarUtils.selfParticipant()`.

When the synced calendar version and the original mailed attachment disagree about whether the current account is listed as an attendee (e.g. the sync engine normalizes/adds the recipient's identity while the original mailed `.ics` still lists a distribution list or resource address), the render-time check passes (buttons show) but the click-time reconstruction finds no matching attendee. `selfParticipant()` returns `undefined`, and `me.component.setParameter(...)` throws with the exact stack trace seen in Sentry.

### Fix

- Keep `icsOriginalData` in sync whenever a synced calendar `Event` replaces `icsEvent`, so both reflect the same source data (the actual root cause).
- Add a guard in `_onRSVP` that re-checks `selfParticipant()` against the data about to be sent and shows a clear error dialog instead of crashing if it's still missing for any reason.
- Add a guard in `EventRSVPTask.forReplying` itself so any other caller gets a clear, descriptive thrown error instead of an opaque `TypeError` if this ever happens again.

## Test plan

- [x] `npx eslint --fix` on both changed files — clean.
- [ ] Manual verification wasn't possible in this environment (sandboxed, no network access to build native Electron modules for `npm start`), so I was unable to click through the RSVP flow in a running app. The fix is a narrow, defensive change that mirrors the existing organizer-email guard already present in `_onRSVP`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01345f99enfPhTi96dovzu8D


---
_Generated by [Claude Code](https://claude.ai/code/session_01345f99enfPhTi96dovzu8D)_