### PR TITLE
Fix unhelpful mailsync crash message and Sentry noise from OAuth SSL failures

### DIFF
--- a/app/internal_packages/onboarding/lib/oauth-signin-page.tsx
+++ b/app/internal_packages/onboarding/lib/oauth-signin-page.tsx
@@ -105,7 +105,7 @@ export default class OAuthSignInPage extends React.Component<
   }
 
   _onError(err) {
-    const isNetworkError = err.message?.includes('Failed to fetch');
+    const isNetworkError = err.message?.includes('Failed to fetch') || err.isNetworkError;
     this.setState({
       authStage: 'error',
       errorMessage: isNetworkError

--- a/app/src/mailsync-process.ts
+++ b/app/src/mailsync-process.ts
@@ -261,7 +261,7 @@ export class MailsyncProcess extends EventEmitter {
             // and may contain system errors (shared library issues, etc). Include this
             // in the logs so users can fix on their own or report detailed bugs.
             const rawLog = this._stripSecrets(buffer.toString());
-            return reject(this._buildCrashError(code, signal, rawLog));
+            return reject(this._buildCrashError(mode, code, signal, rawLog));
           }
 
           if (code === 0) {
@@ -278,7 +278,7 @@ export class MailsyncProcess extends EventEmitter {
           }
         } catch (err) {
           const rawLog = this._stripSecrets(buffer.toString());
-          return reject(this._buildCrashError(code, signal, rawLog));
+          return reject(this._buildCrashError(mode, code, signal, rawLog));
         }
       });
     });
@@ -288,19 +288,23 @@ export class MailsyncProcess extends EventEmitter {
   // JSON response - either it crashed outright, or was terminated by a signal
   // (in which case `code` is null and the message would otherwise be a useless
   // "mailsync: null"). One common cause is an uncaught C++ exception while making
-  // an HTTPS request (e.g. refreshing an OAuth token): mailsync logs a
-  // `"offline":true,"retryable":true` marker for these before crashing, since
-  // they're almost always a local network/TLS interception issue rather than a
-  // bug we can act on. Detect that signature and surface a friendly, localized,
-  // network-flagged error instead so callers can avoid reporting it to Sentry.
-  _buildCrashError(code: number, signal: string, rawLog: string) {
-    const isNetworkFailure = /"offline"\s*:\s*true/.test(rawLog);
+  // an HTTPS request during the `test` mode used to validate a new account (e.g.
+  // refreshing an OAuth token): mailsync logs a `"offline":true,"retryable":true`
+  // marker for these before crashing, since they're almost always a local
+  // network/TLS interception issue rather than a bug we can act on. Detect that
+  // signature - scoped to `test`, since `migrate`/`resetCache` don't make network
+  // requests and shouldn't have unrelated crashes reclassified this way - and
+  // surface a friendly, localized, network-flagged error so callers can avoid
+  // reporting it to Sentry.
+  _buildCrashError(mode: string, code: number | null, signal: NodeJS.Signals | null, rawLog: string) {
+    const isNetworkFailure = mode === 'test' && /"offline"\s*:\s*true/.test(rawLog);
+    const exitDescription = signal ? `signal ${signal}` : `${code}`;
     const error = isNetworkFailure
       ? new Error(LocalizedErrorStrings.ErrorConnection)
       : new Error(
           `${localized(
             `An unknown error has occurred`
-          )} mailsync: ${code} (signal: ${signal}). ${rawLog}`
+          )} mailsync: ${exitDescription}. ${rawLog}`
         );
     (error as any).rawLog = rawLog;
     (error as any).isNetworkError = isNetworkFailure;

--- a/app/src/mailsync-process.ts
+++ b/app/src/mailsync-process.ts
@@ -307,9 +307,7 @@ export class MailsyncProcess extends EventEmitter {
     const error = isNetworkFailure
       ? new Error(LocalizedErrorStrings.ErrorConnection)
       : new Error(
-          `${localized(
-            `An unknown error has occurred`
-          )} mailsync: ${exitDescription}. ${rawLog}`
+          `${localized(`An unknown error has occurred`)} mailsync: ${exitDescription}. ${rawLog}`
         );
     (error as any).rawLog = rawLog;
     (error as any).isNetworkError = isNetworkFailure;

--- a/app/src/mailsync-process.ts
+++ b/app/src/mailsync-process.ts
@@ -249,7 +249,7 @@ export class MailsyncProcess extends EventEmitter {
         reject(err);
       });
 
-      this._proc.on('close', (code) => {
+      this._proc.on('close', (code, signal) => {
         try {
           const lastLine = buffer.toString('utf-8').split('\n').pop();
 
@@ -261,11 +261,7 @@ export class MailsyncProcess extends EventEmitter {
             // and may contain system errors (shared library issues, etc). Include this
             // in the logs so users can fix on their own or report detailed bugs.
             const rawLog = this._stripSecrets(buffer.toString());
-            const error = new Error(
-              `${localized(`An unknown error has occurred`)} mailsync: ${code}. ${rawLog}`
-            );
-            (error as any).rawLog = rawLog;
-            return reject(error);
+            return reject(this._buildCrashError(code, signal, rawLog));
           }
 
           if (code === 0) {
@@ -282,14 +278,33 @@ export class MailsyncProcess extends EventEmitter {
           }
         } catch (err) {
           const rawLog = this._stripSecrets(buffer.toString());
-          const error = new Error(
-            `${localized(`An unknown error has occurred`)} (mailsync: ${code})`
-          );
-          (error as any).rawLog = rawLog;
-          return reject(error);
+          return reject(this._buildCrashError(code, signal, rawLog));
         }
       });
     });
+  }
+
+  // Called when the mailsync child process exits without producing a well-formed
+  // JSON response - either it crashed outright, or was terminated by a signal
+  // (in which case `code` is null and the message would otherwise be a useless
+  // "mailsync: null"). One common cause is an uncaught C++ exception while making
+  // an HTTPS request (e.g. refreshing an OAuth token): mailsync logs a
+  // `"offline":true,"retryable":true` marker for these before crashing, since
+  // they're almost always a local network/TLS interception issue rather than a
+  // bug we can act on. Detect that signature and surface a friendly, localized,
+  // network-flagged error instead so callers can avoid reporting it to Sentry.
+  _buildCrashError(code: number, signal: string, rawLog: string) {
+    const isNetworkFailure = /"offline"\s*:\s*true/.test(rawLog);
+    const error = isNetworkFailure
+      ? new Error(LocalizedErrorStrings.ErrorConnection)
+      : new Error(
+          `${localized(
+            `An unknown error has occurred`
+          )} mailsync: ${code} (signal: ${signal}). ${rawLog}`
+        );
+    (error as any).rawLog = rawLog;
+    (error as any).isNetworkError = isNetworkFailure;
+    return error;
   }
 
   kill() {

--- a/app/src/mailsync-process.ts
+++ b/app/src/mailsync-process.ts
@@ -296,7 +296,12 @@ export class MailsyncProcess extends EventEmitter {
   // requests and shouldn't have unrelated crashes reclassified this way - and
   // surface a friendly, localized, network-flagged error so callers can avoid
   // reporting it to Sentry.
-  _buildCrashError(mode: string, code: number | null, signal: NodeJS.Signals | null, rawLog: string) {
+  _buildCrashError(
+    mode: string,
+    code: number | null,
+    signal: NodeJS.Signals | null,
+    rawLog: string
+  ) {
     const isNetworkFailure = mode === 'test' && /"offline"\s*:\s*true/.test(rawLog);
     const exitDescription = signal ? `signal ${signal}` : `${code}`;
     const error = isNetworkFailure


### PR DESCRIPTION
Fixes MAILSPRING-CLIENT-Q

## What I observed

Sentry issue [MAILSPRING-CLIENT-Q](https://foundry-376-llc.sentry.io/issues/MAILSPRING-CLIENT-Q) ("An unknown error has occurred mailsync: null.") had 121 occurrences across 35 users over 30 days. Sampling ~15 individual events showed:

- Every single one has the identical culprit/stack: `MailsyncProcess._spawnAndWait`'s `close` handler in `app/src/mailsync-process.ts`, triggered from the OAuth onboarding flow (`onboarding-helpers.ts` → `finalizeAndValidateAccount` → `proc.test()`).
- The embedded mailsync log always shows the same failure signature:
  ```
  info: Fetching XOAuth2 access token (outlook) for ...
  critical: *** An exception occurred during program execution:
  *** {"debuginfo":"https://login.microsoftonline.com/common/oauth2/v2.0/token","key":"SSL connect error","offline":true,"retryable":true,"what":"std::exception"}
  ```
  with a C++ stack trace through `MakeOAuthRefreshRequest` → `PerformRequest` → `ValidateRequestResp(CURLcode, ...)`.
- ~13 of 15 sampled events came from users in mainland China (remaining from Russia / DR Congo) — consistent with local network interference/TLS interception blocking `login.microsoftonline.com`, not an app bug.
- Because mailsync crashes on this uncaught exception instead of exiting cleanly, the Node `close` event fires with `code === null` and no JSON response. `_spawnAndWait`'s handler only read the `code` param (ignoring `signal`), so the resulting error was a useless `"An unknown error has occurred mailsync: null. <raw crash log>"` — no signal info, and a wall of C++ stack trace text as the "message".
- That raw error then reached Sentry because `oauth-signin-page.tsx`'s `_onError` already has a precedent for skipping Sentry on expected network errors (`err.message.includes('Failed to fetch')`) and user-config errors (`err.isUserError`), but had no way to recognize this mailsync-originated network failure, so it reported it every time.

## The fix

`app/src/mailsync-process.ts`:
- `_spawnAndWait`'s `close` listener now captures `signal` in addition to `code`, so any future non-network crash includes the signal in its message instead of a bare `null`.
- Added `_buildCrashError(code, signal, rawLog)`: detects the `"offline":true` marker mailsync logs for this class of exception and, when present, builds a friendly, localized `ErrorConnection` message tagged with `error.isNetworkError = true` instead of dumping the raw crash log as the error message.

`app/internal_packages/onboarding/lib/oauth-signin-page.tsx`:
- `_onError` now also treats `err.isNetworkError` as a network error (skips `AppEnv.reportError`, same as the existing `Failed to fetch` case), and shows the friendlier "check your internet connection" message to the user instead of the raw crash dump.

This doesn't fix the underlying TLS/network condition (that's outside the app's control), but it stops non-actionable, expected connectivity failures from generating Sentry noise, and makes any real future crash in this path show the signal that killed the process instead of `null`.

## Test plan

- [x] `npx tsc --noEmit` passes for the changed files.
- [ ] (Manual, not verifiable in this environment) confirm the onboarding OAuth flow still surfaces its normal error UI when `proc.test()` rejects for other reasons (e.g. bad credentials), since `LocalizedErrorStrings.ErrorConnection` and the JSON-response error path are unchanged for those cases.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ndr7sjz8nxt9VhvGb7DueH)_