### PR TITLE
Fix ERR_FILE_NOT_FOUND crash in "Show Original" when RFC822 fetch fails

### DIFF
--- a/app/internal_packages/message-list/lib/message-controls.tsx
+++ b/app/internal_packages/message-list/lib/message-controls.tsx
@@ -151,6 +151,17 @@ export default class MessageControls extends React.Component<MessageControlsProp
     });
     Actions.queueTask(task);
     await TaskQueue.waitForPerformRemote(task);
+
+    // The task can reach "complete" status even when it failed remotely (eg.
+    // the message could not be fetched from the server), in which case the
+    // file is never written. Verify it exists before trying to display it.
+    if (!require('fs').existsSync(filepath)) {
+      AppEnv.showErrorDialog(
+        localized('Could not retrieve the original message. Please try again.')
+      );
+      return;
+    }
+
     const { BrowserWindow } = require('@electron/remote');
     const win = new BrowserWindow({
       width: 800,
@@ -161,7 +172,9 @@ export default class MessageControls extends React.Component<MessageControlsProp
         nodeIntegration: false,
       },
     });
-    win.loadURL(`file://${filepath}`);
+    win.loadURL(`file://${filepath}`).catch((err: Error) => {
+      console.error('Show Original window failed to load:', err);
+    });
   };
 
   _onLogData = () => {


### PR DESCRIPTION
## Summary

Fixes [MAILSPRING-CLIENT-3G](https://foundry-376-llc.sentry.io/issues/MAILSPRING-CLIENT-3G) — `Error: ERR_FILE_NOT_FOUND (-6) loading 'file:///.../Temp/<random>'`, unresolved, unassigned, **51 users impacted / 65 occurrences** as of this writing (the highest-impact unassigned issue in the `release:1.21.1-ae68e881` triage view).

### Root cause

`MessageControls._onShowOriginal` (the "Show Original" menu item, which displays the raw RFC822 source of a message in a new window) does this:

```ts
const filepath = path.join(app.getPath('temp'), message.id);
const task = new GetMessageRFC2822Task({ messageId: message.id, accountId: message.accountId, filepath });
Actions.queueTask(task);
await TaskQueue.waitForPerformRemote(task);
// ... unconditionally:
win.loadURL(`file://${filepath}`);
```

`TaskQueue.waitForPerformRemote` only waits for `task.status === Task.Status.Complete` — it does **not** check whether the task actually succeeded. The Mailspring-Sync engine marks a task `complete` (with an `error` populated) even when the remote fetch fails, e.g. when the message has since been deleted/moved on the server, the IMAP fetch errors, or the account is offline. In those cases the RFC822 body is never written to `filepath`.

The code then calls `win.loadURL('file://<path-that-does-not-exist>')` with no `.catch()`. Electron rejects that load with `ERR_FILE_NOT_FOUND`, and because nothing handles the rejection, it surfaces as an unhandled promise rejection that the app's global error handler reports to Sentry — with no message context, which is why the Sentry issue was just the bare Electron error string and hard to diagnose from the report alone.

This exact failure mode (task reports "complete" but the requested file was never written) is already handled correctly elsewhere in the codebase — `message-list.tsx`'s "Forward as Attachment" flow calls `fs.existsSync(tempPath)` after awaiting the same `GetMessageRFC2822Task` and shows a friendly error dialog if the file is missing, instead of proceeding blindly.

### Fix

Apply the same pattern to `_onShowOriginal`:
- After awaiting the task, verify the temp file actually exists before creating the preview window; if not, show a localized error dialog and bail out instead of trying to load a nonexistent file.
- Attach a `.catch()` to the `loadURL()` call as defense in depth, so any other load failure is logged instead of becoming an unhandled rejection.

### Testing

- `npx tsc --noEmit` shows no new type errors introduced by this change.
- Project-wide `npm run lint` is currently broken in this environment due to an unrelated ESLint v10 / legacy `.eslintrc` incompatibility, so I verified the change is minimal and manually reviewed for style consistency instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_0177EtNQQCsq94AZhoJryS3Z)_