### PR TITLE
Fix uncaught 'error' event crash in MailsyncProcess.sync()

### DIFF
--- a/app/src/mailsync-process.ts
+++ b/app/src/mailsync-process.ts
@@ -333,9 +333,17 @@ export class MailsyncProcess extends EventEmitter {
         }
       });
     }
+    // Note: we intentionally do not re-emit this as an 'error' event on `this`.
+    // Nothing in the codebase attaches an 'error' listener to a MailsyncProcess
+    // instance, and Node's EventEmitter throws synchronously when an 'error'
+    // event has no listeners. That throw happened inside this same 'error'
+    // callback on `_proc`, which aborted the remaining `_proc.on('error', ...)`
+    // listener below (the one that actually cleans up and reports failure via
+    // 'close') before it could run — so a transient spawn failure (e.g. EIO)
+    // both crashed the app and prevented MailsyncBridge from ever marking the
+    // account as errored or retrying.
     this._proc.on('error', (err: Error) => {
       console.log(`Sync worker exited with ${err}`);
-      this.emit('error', err);
     });
 
     let cleanedUp = false;


### PR DESCRIPTION
## Summary

Fixes [MAILSPRING-CLIENT-4R](https://foundry-376-llc.sentry.io/issues/MAILSPRING-CLIENT-4R) (`Error: spawn EIO`), an unresolved, unassigned Sentry issue impacting 6+ users across releases 1.21.x/1.22.0, still recurring as recently as today.

## What I observed

The Sentry stack trace pointed at `MailsyncProcess._spawnProcess` via `MailsyncBridge._launchClient` → `client.sync()`. `spawn EIO` is emitted **asynchronously** by Node's `child_process` as an `'error'` event on the child process — Node just preserves the original `spawn()` call site in the error's stack trace, which is why the trace looked like a synchronous throw.

In `MailsyncProcess.sync()` (`app/src/mailsync-process.ts`), two separate listeners were registered for `_proc`'s `'error'` event:

1. One that logged the error and then called `this.emit('error', err)` — re-emitting it as an `'error'` event on the `MailsyncProcess` instance itself.
2. One that performs cleanup (`cleanedUp = true`) and reports the failure via `this.emit('close', { code: -1, error, signal: null })`.

Nothing in the codebase (`MailsyncBridge._launchClient`, or any other caller) ever attaches an `'error'` listener to a `MailsyncProcess` instance — only `'deltas'` and `'close'` are handled. Node's `EventEmitter` throws synchronously when an `'error'` event is emitted with no listeners attached. Because listener #1 ran first and threw, listener #2 (the one that actually reports the failure and lets `MailsyncBridge` mark the account `SYNC_STATE_ERROR` / retry) never got a chance to run.

Net effect: any transient `spawn()` failure (EIO, and potentially others) crashed the app outright instead of being handled by the existing recovery path, and was reported to Sentry with a misleading "crash in `_spawnProcess`" signature.

## Fix

Removed the redundant `this.emit('error', err)` re-emit (keeping the diagnostic `console.log`), so the existing cleanup listener always runs and the failure is routed through the normal `'close'` → `MailsyncBridge` error-handling path instead of crashing.

## Test plan

- [ ] Confirm mailsync failures (e.g. simulate `spawn` throwing `EIO`/`ENOENT`) no longer crash the app and instead surface via the account's `syncState`/`syncError`.
- CI: lint/build could not be run locally in this sandbox (no `node_modules` installed); please confirm CI passes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VTFpVcKymjR1B1zpstKkr4)_