### PR TITLE
Fix "Unable to find a DOM node" crash in Slate image attachment renderer

### DIFF
--- a/app/src/components/composer-editor/inline-attachment-plugins.tsx
+++ b/app/src/components/composer-editor/inline-attachment-plugins.tsx
@@ -23,7 +23,7 @@ function ImageNode(props) {
   const { draft } = editor.props.propsForPlugins;
   const file = draft.files.find((f) => contentId === f.contentId);
   if (!file) {
-    return <span />;
+    return <span {...attributes} />;
   }
 
   return (


### PR DESCRIPTION
## Investigation

Sentry issue **MAILSPRING-CLIENT-B** — *"Error: Unable to find a DOM node for '10'. This is often because of forgetting to add `props.attributes` to a custom component."* — was affecting **94 users** in release 1.21.1.

Slate's own error message pointed directly at the problem: a custom node renderer was not spreading `props.attributes` onto its root DOM element. In Slate 0.45.x, `attributes` carries the `data-key` attribute that Slate uses to locate nodes in the DOM (for selection updates, key-press handling, etc.). Any renderer that omits it causes Slate's `findDOMNode` to fail.

Searching `inline-attachment-plugins.tsx`, the `ImageNode` renderer (which handles `IMAGE_TYPE` void inline nodes — inline image attachments in the composer) had **two return paths**:

1. The happy path (line 29+) — spreads `{...attributes}` on `<ImageAttachmentItem>` ✅
2. The fallback path (line 25-27) — returns a bare `<span />` when the image file is not yet present in `draft.files` ❌

```tsx
// Before — Slate cannot find this node in the DOM:
if (!file) {
  return <span />;
}
```

The fallback fires during normal use whenever `draft.files` hasn't yet been populated for an in-flight or recently-pasted image. While the node is in that state, any Slate operation that touches the selection (typing, cursor movement) triggers the DOM lookup and throws.

## Fix

Add `{...attributes}` to the fallback span so Slate can always locate the node:

```tsx
if (!file) {
  return <span {...attributes} />;
}
```

One character change; no behaviour change for the happy path.

## Testing

- Open a draft with an inline image attachment
- The image attachment node should render without errors in the console
- Cursor movement and typing around the node should work normally

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wa5rMERDupj7BbeEMtKXe3)_