### PR TITLE
Fix composer crash when grammar-check decorations apply mid-composition

### DIFF
--- a/app/src/components/composer-editor/grammar-check-plugins.tsx
+++ b/app/src/components/composer-editor/grammar-check-plugins.tsx
@@ -613,10 +613,13 @@ const plugins: ComposerEditorPlugin[] = [
         const draft = (editor as any).props?.propsForPlugins?.draft ?? null;
         if (draft && pendingApplyByDraft.has(draft.headerMessageId)) {
           pendingApplyByDraft.delete(draft.headerMessageId);
-          // Defer to a microtask so this runs after slate-react's own
-          // compositionend reconciliation for this event has fully settled,
-          // rather than in the same synchronous dispatch.
-          queueMicrotask(() => {
+          // Defer to the next animation frame — slate-react's own
+          // compositionend DOM/model reconciliation is itself scheduled via
+          // requestAnimationFrame, and a microtask would still run before
+          // that, i.e. before reconciliation actually settles. next() above
+          // registers slate-react's rAF first, so ours runs after it within
+          // the same frame.
+          requestAnimationFrame(() => {
             try {
               applyGrammarDecorations(editor as any, draft.headerMessageId);
             } catch (err) {

--- a/app/src/components/composer-editor/grammar-check-plugins.tsx
+++ b/app/src/components/composer-editor/grammar-check-plugins.tsx
@@ -47,6 +47,7 @@ export function clearGrammarCheckStore() {
 export function cleanupDraft(draftId: string) {
   previousDocumentByDraft.delete(draftId);
   latestEditorByDraft.delete(draftId);
+  pendingApplyByDraft.delete(draftId);
   const entry = debounceTimers.get(draftId);
   if (entry) {
     clearTimeout(entry.timer);
@@ -84,6 +85,15 @@ function _scheduleCheck(draftId: string, editor: Editor, delayMs: number, start 
     if (!grammarCheckStore) return;
     grammarCheckStore.checkDirtyBlocks(draftId).then((completed) => {
       if (!completed) return; // superseded by a newer check — it will apply its own decorations
+      if (composingWeakmap.get(editor)) {
+        // The user is mid-composition (e.g. composing an accented character via a
+        // dead key/compose sequence). Applying decorations now would change the
+        // document's text-node structure while Slate's DOM reconciliation is still
+        // tracking the live, uncommitted composition — that mismatch is what causes
+        // `Node.assertPath` to crash on a stale key. Defer until composition ends.
+        pendingApplyByDraft.add(draftId);
+        return;
+      }
       try {
         applyGrammarDecorations(editor, draftId);
       } catch (err) {
@@ -118,6 +128,9 @@ const composingWeakmap = new WeakMap<object, number>();
 const previousDocumentByDraft = new Map<string, any>();
 const debounceTimers = new Map<string, { timer: ReturnType<typeof setTimeout>; start: number }>();
 const latestEditorByDraft = new Map<string, Editor>();
+// Drafts whose decorations finished computing while composition was in progress —
+// applied once composition ends (see onCompositionEnd below).
+const pendingApplyByDraft = new Set<string>();
 
 // --- Category to underline color mapping ---
 function underlineColorForCategory(category: string): string {
@@ -592,7 +605,20 @@ const plugins: ComposerEditorPlugin[] = [
       next();
     },
     onCompositionEnd: (event, editor, next) => {
-      composingWeakmap.set(editor, Math.max(0, (composingWeakmap.get(editor) || 0) - 1));
+      const remaining = Math.max(0, (composingWeakmap.get(editor) || 0) - 1);
+      composingWeakmap.set(editor, remaining);
+
+      if (remaining === 0) {
+        const draft = (editor as any).props?.propsForPlugins?.draft ?? null;
+        if (draft && pendingApplyByDraft.has(draft.headerMessageId)) {
+          pendingApplyByDraft.delete(draft.headerMessageId);
+          try {
+            applyGrammarDecorations(editor as any, draft.headerMessageId);
+          } catch (err) {
+            console.warn('Grammar check: failed to apply decorations', err);
+          }
+        }
+      }
       next();
     },
   },

--- a/app/src/components/composer-editor/grammar-check-plugins.tsx
+++ b/app/src/components/composer-editor/grammar-check-plugins.tsx
@@ -607,19 +607,24 @@ const plugins: ComposerEditorPlugin[] = [
     onCompositionEnd: (event, editor, next) => {
       const remaining = Math.max(0, (composingWeakmap.get(editor) || 0) - 1);
       composingWeakmap.set(editor, remaining);
+      next();
 
       if (remaining === 0) {
         const draft = (editor as any).props?.propsForPlugins?.draft ?? null;
         if (draft && pendingApplyByDraft.has(draft.headerMessageId)) {
           pendingApplyByDraft.delete(draft.headerMessageId);
-          try {
-            applyGrammarDecorations(editor as any, draft.headerMessageId);
-          } catch (err) {
-            console.warn('Grammar check: failed to apply decorations', err);
-          }
+          // Defer to a microtask so this runs after slate-react's own
+          // compositionend reconciliation for this event has fully settled,
+          // rather than in the same synchronous dispatch.
+          queueMicrotask(() => {
+            try {
+              applyGrammarDecorations(editor as any, draft.headerMessageId);
+            } catch (err) {
+              console.warn('Grammar check: failed to apply decorations', err);
+            }
+          });
         }
       }
-      next();
     },
   },
 ];


### PR DESCRIPTION
## Summary

Fixes [MAILSPRING-CLIENT-2K](https://foundry-376-llc.sentry.io/issues/MAILSPRING-CLIENT-2K): `` Error: `Node.assertPath` could not find node with path or key: null `` — 25 users affected, still recurring on the latest release (1.22.0), overwhelmingly on Linux with French/other accented-locale geographies.

### Root cause

The grammar-check Slate plugin (`app/src/components/composer-editor/grammar-check-plugins.tsx`) recomputes spelling/grammar-error decorations on a debounce timer (300–800ms after the user stops typing) and applies them via `editor.setDecorations(...)`. Applying decorations restructures the document's text nodes — a single text run gets split into "before-error / error / after-error" spans wherever an underline needs to render.

That timer fires independent of whether the user is currently mid-IME-composition (e.g. composing an accented character via a dead-key/compose sequence — common on Linux/French keyboards — or a CJK IME). If the timer lands while a composition is in progress:

1. The live contenteditable DOM still shows the browser's uncommitted composition text.
2. Slate's document model gets restructured by the decoration split underneath it.
3. When the composition later commits, slate-react's native-input reconciliation tries to locate the DOM node for a key that no longer matches the (now-restructured) live DOM.
4. `Node.assertPath` throws with a null path/key, crashing the composer.

This lines up with the observed data: the crash's stack trace goes through `removeTextByKey` via native input reconciliation (not through any decoration-only code path), the plugin already tracks composition state (`composingWeakmap`) for its `onChange` handler but never checked it before firing the async decoration-apply, and the affected users are disproportionately typing accented/composed characters.

### Fix

Guard the async decoration-apply path the same way `onChange` already guards live re-checks:
- If the debounced check's decorations finish computing while a composition is in progress, defer applying them (`pendingApplyByDraft`) instead of calling `setDecorations` immediately.
- Once composition ends (`onCompositionEnd`) and no composition is nested/pending, flush the deferred decorations.
- Clean up the pending-apply state in `cleanupDraft`.

This is a minimal, targeted guard — it doesn't change any user-visible behavior except that grammar-error underlines may appear a moment later if the user is actively composing text when the check completes.

## Test plan

- [x] `npx tsc -p app/tsconfig.json --noEmit` — no errors in the changed file
- [x] `npx eslint -c .eslintrc app/src/components/composer-editor/grammar-check-plugins.tsx` — clean
- [ ] Manual repro (Linux, French/dead-key input) not performed in this environment — recommend verifying with the grammar-check feature enabled while typing accented text rapidly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TFLAkqzJztbuDc2gPZR2v5

---
_Generated by [Claude Code](https://claude.ai/code/session_01TFLAkqzJztbuDc2gPZR2v5)_