### PR TITLE
Fix composer crash on quoted emails with inline images (Void.renderText)

### DIFF
--- a/app/src/components/composer-editor/conversion.tsx
+++ b/app/src/components/composer-editor/conversion.tsx
@@ -370,7 +370,11 @@ export function convertFromHTML(html: string) {
   - Ensure `block` elements have an empty text node child.
   */
   const optimizeTextNodesForNormalization = (node: DocumentJSON | NodeJSON) => {
-    if (!('nodes' in node)) return;
+    if (node.object === 'text') return;
+    // Void inlines (eg: emoji, template variables) are sometimes deserialized
+    // without a `nodes` array at all rather than an explicit empty one - treat
+    // both the same so the empty-text-child fix below always applies to them.
+    if (!('nodes' in node) || !node.nodes) node.nodes = [];
     node.nodes.forEach(optimizeTextNodesForNormalization);
 
     // Convert adjacent text nodes into a single text node with all the leaves
@@ -389,8 +393,12 @@ export function convertFromHTML(html: string) {
     }
     node.nodes = cleanChildren;
 
-    // Ensure `block` elements have an empty text node child
-    if (node.object === 'block' && node.nodes.length === 0) {
+    // Ensure `block` and `inline` elements have an empty text node child.
+    // This matters most for void inlines (eg: inline `cid:` images, which are
+    // deserialized with `nodes: []`) - Slate's Void.renderText reads
+    // `node.getFirstText().key` and throws if the void node has no text
+    // descendant at all.
+    if ((node.object === 'block' || node.object === 'inline') && node.nodes.length === 0) {
       node.nodes = [
         {
           object: 'text',


### PR DESCRIPTION
## Sentry issue
Fixes [MAILSPRING-CLIENT-2Z](https://foundry-376-llc.sentry.io/issues/MAILSPRING-CLIENT-2Z) — `Error: Cannot read properties of undefined (reading 'key')`, culprit `Void.renderText (slate-react)`. 17 users impacted, recurring steadily across releases 1.21.1 and 1.22.0.

## What I observed
Every event in this group has the identical stack:
```
react-dom ... 
slate-react.js (Void.render)
slate-react.js (Void.renderText)
```
Looking at the `slate-react` fork's source (`bengotow/slate#0.45.1-react`), `Void.renderText` does:
```js
this.renderText = function () {
  var child = node.getFirstText();
  return React.createElement(Text, { ..., key: child.key, node: child, ... });
};
```
If a void node (image/emoji/template-variable — anything marked `isVoid: true` in `app/src/components/composer-editor/conversion.tsx`) has **zero child nodes**, `getFirstText()` returns `undefined` and `child.key` throws exactly this error.

## Root cause
`convertFromHTML()` in `app/src/components/composer-editor/conversion.tsx` converts a draft/message's raw HTML (used for the composer body, including quoted/forwarded content) into a Slate JSON tree and calls `Value.fromJSON(json)` directly — bypassing the schema-aware editor, so Slate's own "void nodes need a text child" normalization never runs. The code already had a manual workaround for this, but only for **block** elements:
```js
if (node.object === 'block' && node.nodes.length === 0) { /* add empty text child */ }
```
Two deserialize rules produce void **inline** nodes that fall through this gap:
- `inline-attachment-plugins.tsx`: ``'&lt;img src="cid:..."&gt;'`` (common in signatures/forwards) deserializes to `{ object: 'inline', type: 'image', nodes: [] }`.
- `emoji-plugins.tsx` / `template-plugins.tsx`: deserialize to `{ object: 'inline', ... }` with no `nodes` key at all.

The pre-existing guard `if (!('nodes' in node)) return;` also meant the second case (no `nodes` key) skipped the fix function entirely, before it ever reached the empty-children check.

So: reply to or forward an email containing an inline `cid:` image (or open a draft with an emoji/template-variable inline that lost its text child), and the composer renders a void inline node with no text descendant → crash.

## Fix
In `optimizeTextNodesForNormalization`:
- Bail out based on `node.object === 'text'` instead of the presence of a `nodes` key, and default a missing `nodes` array to `[]` — so inline nodes that omit `nodes` entirely are treated the same as ones with `nodes: []`.
- Extend the "ensure an empty text child" fix to `inline` elements as well as `block` elements.

Verified locally that both shapes (`nodes: []` and `nodes` omitted) end up with the required empty text child after normalization.


---
_Generated by [Claude Code](https://claude.ai/code/session_01X6SmHUz1Z7yEqSBqGBb5pG)_