### PR TITLE
Do not hardcode Mailspring.desktop

### DIFF
--- a/app/src/browser/linux-launcher-entry.ts
+++ b/app/src/browser/linux-launcher-entry.ts
@@ -16,10 +16,11 @@
  * Wire format reference: https://dbus.freedesktop.org/doc/dbus-specification.html
  */
 import * as net from 'net';
+import pkg from '../utils/package';
 
-export const APP_URI = 'application://Mailspring.desktop';
+export const APP_URI = `application://${pkg.desktopName}`;
 
-const OBJECT_PATH = '/com/canonical/unity/launcherentry/mailspring';
+const OBJECT_PATH = `/com/canonical/unity/launcherentry/${pkg.name.replace(/\./g, '/')}`;
 const IFACE = 'com.canonical.Unity.LauncherEntry';
 const MEMBER = 'Update';
 const BODY_SIG = 'sa{sv}';


### PR DESCRIPTION
Like #2748.

[This spec](https://github.com/Foundry376/Mailspring/blob/30ff42ccffd0db091db7d956b60630b88f5499be/app/spec/linux-launcher-entry-spec.ts#L60-L73) is now probably false when run in flatpak, i am not sure if this is a problem:
```ts
  it('is byte-identical to the reference dbus-next output', () => {
    // Golden capture of the on-the-wire bytes dbus-next produces for
    // Update('application://Mailspring.desktop', {count: Int64(5), count-visible: true})
    // with serial 1. Guards the hand-rolled marshaller against regressions.
    const expected =
      '6c04000164000000010000008400000001016f002d0000002f636f6d2f63616e6f6e6963616c2f' +
      '756e6974792f6c61756e63686572656e7472792f6d61696c737072696e670000000201730021000000' +
      '636f6d2e63616e6f6e6963616c2e556e6974792e4c61756e63686572456e747279000000000000000301' +
      '7300060000005570646174650000080167000673617b73767d0000000000200000006170706c69636174' +
      '696f6e3a2f2f4d61696c737072696e672e6465736b746f7000000000340000000000000005000000636f' +
      '756e740001780000000005000000000000000d000000636f756e742d76697369626c65000162000000000' +
      '1000000';
    expect(marshalMessage(1, APP_URI, 5, true).toString('hex')).toBe(expected);
  });
```