### PR TITLE
fix(linux): send org.freedesktop.DBus.Hello before emitting the LauncherEntry badge signal

### DIFF
--- a/app/spec/linux-launcher-entry-spec.ts
+++ b/app/spec/linux-launcher-entry-spec.ts
@@ -1,5 +1,6 @@
 import {
   marshalMessage,
+  marshalHello,
   sanitizeCount,
   emitLauncherEntryBadge,
   _resetLauncherBusForSpec,
@@ -105,5 +106,47 @@ describe('emitLauncherEntryBadge', () => {
     expect(() => emitLauncherEntryBadge(0)).not.toThrow();
     if (saved !== undefined) process.env.DBUS_SESSION_BUS_ADDRESS = saved;
     else delete process.env.DBUS_SESSION_BUS_ADDRESS;
+  });
+});
+
+describe('marshalHello', () => {
+  // The D-Bus spec requires a client to obtain a unique connection name via
+  // org.freedesktop.DBus.Hello before sending any other message; a client that
+  // skips it is disconnected from the bus.
+  // https://dbus.freedesktop.org/doc/dbus-specification.html#bus-messages-hello
+
+  it('writes a valid fixed header (little-endian METHOD_CALL, v1) with the serial', () => {
+    const buf = marshalHello(3);
+    expect(buf[0]).toBe(0x6c); // 'l' - little-endian
+    expect(buf[1]).toBe(1); // message type METHOD_CALL
+    expect(buf[2]).toBe(0); // flags
+    expect(buf[3]).toBe(1); // protocol version
+    expect(buf.readUInt32LE(4)).toBe(0); // body length - Hello takes no arguments
+    expect(buf.readUInt32LE(8)).toBe(3); // serial
+  });
+
+  // Golden fixture: Hello takes no arguments, so its bytes are fully
+  // deterministic. Byte-for-byte comparison is what actually catches a
+  // marshalling regression (alignment, padding, or a wrong field-array length).
+  const HELLO_SERIAL_1_HEX =
+    '6c01000100000000010000006d00000001016f00150000002f6f72672f667265' +
+    '656465736b746f702f4442757300000002017300140000006f72672e66726565' +
+    '6465736b746f702e4442757300000000030173000500000048656c6c6f000000' +
+    '06017300140000006f72672e667265656465736b746f702e4442757300000000';
+
+  it('marshals byte-for-byte correctly', () => {
+    expect(marshalHello(1).toString('hex')).toBe(HELLO_SERIAL_1_HEX);
+  });
+
+  it('declares a header-field array length that spans exactly the fields', () => {
+    const buf = marshalHello(1);
+    // fields start at 16 (after the 4-byte length at 12, already 8-aligned);
+    // the declared length must exclude the trailing pad-to-8 only.
+    expect(buf.readUInt32LE(12)).toBe(109);
+    expect(buf.length).toBe(128);
+  });
+
+  it('pads the message to an 8-byte boundary', () => {
+    expect(marshalHello(1).length % 8).toBe(0);
   });
 });

--- a/app/src/browser/linux-launcher-entry.ts
+++ b/app/src/browser/linux-launcher-entry.ts
@@ -167,6 +167,65 @@ export function marshalMessage(
   return buf.subarray(0, o);
 }
 
+/**
+ * Marshal the org.freedesktop.DBus.Hello METHOD_CALL.
+ *
+ * REQUIRED by the D-Bus spec: a client MUST send Hello and receive a unique
+ * connection name before it may send any other message; the bus disconnects
+ * clients that skip it. dbus-next performed this inside sessionBus(), so the
+ * requirement became invisible once that dependency was removed.
+ *
+ * Same layout as marshalMessage but type=METHOD_CALL, empty body, plus a
+ * DESTINATION header field (id 6) addressed to the bus itself.
+ */
+export function marshalHello(serial: number): Buffer {
+  const buf = Buffer.alloc(256);
+  let o = 0;
+
+  buf[o++] = 0x6c; // 'l' = little-endian
+  buf[o++] = 1; // METHOD_CALL
+  buf[o++] = 0; // flags
+  buf[o++] = 1; // protocol version
+  buf.writeUInt32LE(0, o); // body length = 0
+  o += 4;
+  buf.writeUInt32LE(serial, o);
+  o += 4;
+
+  const writeStr = (str: string) => {
+    o += pad(o, 4);
+    const b = Buffer.from(str, 'utf8');
+    buf.writeUInt32LE(b.length, o);
+    o += 4;
+    b.copy(buf, o);
+    o += b.length;
+    buf[o++] = 0;
+  };
+
+  const writeField = (id: number, typeSig: string, writeValue: () => void) => {
+    o += pad(o, 8);
+    buf[o++] = id;
+    buf[o++] = 1;
+    buf[o++] = typeSig.charCodeAt(0);
+    buf[o++] = 0;
+    writeValue();
+  };
+
+  const arrLenOff = o;
+  o += 4;
+  o += pad(o, 8);
+  const arrStart = o;
+
+  writeField(1, 'o', () => writeStr('/org/freedesktop/DBus')); // PATH
+  writeField(2, 's', () => writeStr('org.freedesktop.DBus')); // INTERFACE
+  writeField(3, 's', () => writeStr('Hello')); // MEMBER
+  writeField(6, 's', () => writeStr('org.freedesktop.DBus')); // DESTINATION
+
+  buf.writeUInt32LE(o - arrStart, arrLenOff);
+  o += pad(o, 8);
+
+  return buf.subarray(0, o);
+}
+
 // ---------------------------------------------------------------------------
 // Connection management
 // ---------------------------------------------------------------------------
@@ -244,6 +303,9 @@ function sendRaw(msg: Buffer): void {
     for (const line of lines) {
       if (line.startsWith('OK')) {
         socket.write('BEGIN\r\n');
+        // REQUIRED: obtain a unique connection name before any other
+        // message, or the bus disconnects us and the signal is lost.
+        socket.write(marshalHello(++_serial));
         conn.ready = true;
         for (const pending of conn.pending) socket.write(pending);
         conn.pending = [];


### PR DESCRIPTION
Follow-up to #2756.

After that merged, the badge stopped updating on my machine. The cause is that the new dependency-free D-Bus client never sends `org.freedesktop.DBus.Hello`.

The EXTERNAL auth handshake is correct (`AUTH` -> `OK` -> `BEGIN`), but per the [D-Bus specification](https://dbus.freedesktop.org/doc/dbus-specification.html#bus-messages-hello):

> Before an application is able to send messages to other applications it must send the `org.freedesktop.DBus.Hello` message to the message bus to obtain a unique name. If an application without a unique name tries to send a message to another application, or a message to the message bus itself that isn't the `org.freedesktop.DBus.Hello` message, it will be disconnected from the bus.

`dbus-next` performed this inside `sessionBus()`, so the requirement became invisible once that dependency was removed. The marshalled signal bytes are byte-identical as intended; only the connection setup was incomplete. Nothing surfaced in the logs because the emit is fire-and-forget.

### The fix

Adds `marshalHello()` (METHOD_CALL, empty body, DESTINATION header field id 6), mirroring the structure of `marshalMessage()`, sent immediately after `BEGIN` and before any queued signal.

Hello is pipelined without awaiting its `METHOD_RETURN`, which is safe because the bus processes a connection's messages in order, so the unique name is assigned before the following signal is dispatched.

### Tests

Hello takes no arguments, so its 128 bytes are fully deterministic. The specs follow the existing golden-fixture style and compare byte-for-byte, which is what actually catches an alignment, padding or field-array-length regression.

### Verification

Fedora 44, KDE Plasma 6.7 (Wayland). With the badge cleared to a blank baseline, it tracked live from 8 to 9 on a new email and back down to 4 as messages were read. Without the Hello call it never updated at all.

As a control, emitting the same signal with `gdbus` (which performs the Hello handshake) updated the badge correctly, confirming the receiver side was fine.
