### PR TITLE
Add option to count unread messages across all accounts

### DIFF
--- a/app/spec/stores/badge-store-spec.ts
+++ b/app/spec/stores/badge-store-spec.ts
@@ -1,6 +1,9 @@
 import BadgeStore from '../../src/flux/stores/badge-store';
+import FocusedPerspectiveStore from '../../src/flux/stores/focused-perspective-store';
+import { AccountStore } from '../../src/flux/stores/account-store';
+import CategoryStore from '../../src/flux/stores/category-store';
 
-describe('BadgeStore', () =>
+describe('BadgeStore', function () {
   describe('_setBadgeForCount', () =>
     it('should set the badge correctly', function () {
       spyOn(BadgeStore, '_setBadge');
@@ -16,4 +19,49 @@ describe('BadgeStore', () =>
       (BadgeStore as any)._unread = 1000;
       BadgeStore._setBadgeForCount();
       expect(BadgeStore._setBadge).toHaveBeenCalledWith('999+');
-    })));
+    }));
+
+  describe('_updateCounts', function () {
+    let originalUnread: number;
+    let originalTotal: number;
+
+    beforeEach(function () {
+      // BadgeStore is a singleton shared across the whole spec run, and other
+      // suites (system-tray) read its counts, so snapshot and restore them.
+      originalUnread = (BadgeStore as any)._unread;
+      originalTotal = (BadgeStore as any)._total;
+
+      // Force the counts to a value the store cannot compute, so the
+      // "counts unchanged" early return never hides a call.
+      (BadgeStore as any)._unread = -1;
+      (BadgeStore as any)._total = -1;
+      spyOn(BadgeStore, '_setBadge');
+      spyOn(FocusedPerspectiveStore, 'current').andReturn({ accountIds: ['a'] } as any);
+      spyOn(AccountStore, 'accountIds').andReturn(['a', 'b']);
+      spyOn(CategoryStore, 'getCategoriesWithRoles').andReturn([]);
+    });
+
+    afterEach(function () {
+      (BadgeStore as any)._unread = originalUnread;
+      (BadgeStore as any)._total = originalTotal;
+    });
+
+    const setAllAccountsPref = (value: boolean) => {
+      spyOn(AppEnv.config, 'get').andCallFake((keyPath: string) =>
+        keyPath === 'core.notifications.countBadgeAllAccounts' ? value : undefined
+      );
+    };
+
+    it('counts only the focused perspective accounts by default', function () {
+      setAllAccountsPref(false);
+      (BadgeStore as any)._updateCounts();
+      expect(CategoryStore.getCategoriesWithRoles).toHaveBeenCalledWith(['a'], 'inbox');
+    });
+
+    it('counts every account when countBadgeAllAccounts is enabled', function () {
+      setAllAccountsPref(true);
+      (BadgeStore as any)._updateCounts();
+      expect(CategoryStore.getCategoriesWithRoles).toHaveBeenCalledWith(['a', 'b'], 'inbox');
+    });
+  });
+});

--- a/app/src/config-schema.ts
+++ b/app/src/config-schema.ts
@@ -371,6 +371,13 @@ export default {
             ],
             title: localized('Show badge on the app icon'),
           },
+          countBadgeAllAccounts: {
+            type: 'boolean',
+            default: false,
+            title: localized(
+              'Count unread messages in all accounts, not just the selected folder'
+            ),
+          },
         },
       },
     },

--- a/app/src/flux/stores/badge-store.ts
+++ b/app/src/flux/stores/badge-store.ts
@@ -1,6 +1,7 @@
 /* eslint global-require:0 */
 import MailspringStore from 'mailspring-store';
 import FocusedPerspectiveStore from './focused-perspective-store';
+import { AccountStore } from './account-store';
 import ThreadCountsStore from './thread-counts-store';
 import CategoryStore from './category-store';
 
@@ -13,6 +14,9 @@ class BadgeStore extends MailspringStore {
 
     this.listenTo(FocusedPerspectiveStore, this._updateCounts);
     this.listenTo(ThreadCountsStore, this._updateCounts);
+    this.listenTo(AccountStore, this._updateCounts);
+
+    AppEnv.config.onDidChange('core.notifications.countBadgeAllAccounts', this._updateCounts);
 
     AppEnv.config.onDidChange('core.notifications.countBadge', ({ newValue }) => {
       if (newValue !== 'hide') {
@@ -38,7 +42,9 @@ class BadgeStore extends MailspringStore {
     let unread = 0;
     let total = 0;
 
-    const accountIds = FocusedPerspectiveStore.current().accountIds;
+    const accountIds = AppEnv.config.get('core.notifications.countBadgeAllAccounts')
+      ? AccountStore.accountIds()
+      : FocusedPerspectiveStore.current().accountIds;
     for (const cat of CategoryStore.getCategoriesWithRoles(accountIds, 'inbox')) {
       unread += ThreadCountsStore.unreadCountForCategoryId(cat.id);
       total += ThreadCountsStore.totalCountForCategoryId(cat.id);


### PR DESCRIPTION
The taskbar/dock badge derives its count from the accounts in the currently focused perspective. With several accounts configured, selecting a single account's inbox makes the badge show only that account's unread mail, so it can read lower than the unified inbox, and drop to nothing while other accounts still have unread messages.

That behaviour is reasonable (the badge mirrors what you are looking at), so this does not change it. It adds an opt-in preference instead:

`core.notifications.countBadgeAllAccounts` (boolean, default `false`)

- `false` (default): unchanged, the count follows the focused perspective.
- `true`: every configured account is counted, regardless of the focused perspective.

The setting composes with the existing `countBadge` preference rather than replacing it: `countBadge` decides what is shown (hide / unread / total), the new key decides whose mail is counted.

### Implementation notes

- `BadgeStore` also listens to `AccountStore` now, so adding or removing an account updates the badge when the option is on. `FocusedPerspectiveStore` is not guaranteed to fire for that.
- The config observer mirrors the existing `core.notifications.countBadge` pattern, so toggling the checkbox updates the badge without a restart.
- No UI file changes: `ConfigSchemaItem` renders the `notifications` schema block, so the checkbox appears in Preferences under General.

### Tests

`app/spec/stores/badge-store-spec.ts` gains coverage asserting which account ids reach `CategoryStore.getCategoriesWithRoles`, which is the actual branch:

- option off, focused perspective accounts only
- option on, all accounts

The new specs snapshot and restore `BadgeStore`'s counts, since it is a singleton other suites read.

Verified on Fedora KDE with the full spec suite green, and manually with several accounts: with the option off the badge behaves exactly as before, and with it on the badge holds the all-accounts total while viewing a single account.