### PR TITLE
Add a details url to the latest release and instruct claude to do so for future ones

### DIFF
--- a/.claude/commands/changelog.md
+++ b/.claude/commands/changelog.md
@@ -31,11 +31,13 @@ Build a changelog entry for a new Mailspring release by analyzing git history.
    - `app/package.json` — the `"version"` field.
    - `app/package-lock.json` — the two top-of-file `"version"` fields (the root `"version"` on line ~3 and the `packages[""]."version"` on line ~9). Both must match.
 
-7. **Add a release line** to the top of the `<releases>` list in `app/build/resources/linux/mailspring.appdata.xml.in`, without reformatting the rest of the file:
+7. **Add a release entry** to the top of the `<releases>` list in `app/build/resources/linux/mailspring.appdata.xml.in`, without reformatting the rest of the file:
    ```xml
-   <release version="1.X.Y" date="YYYY-MM-DD" />
+   <release version="1.X.Y" date="YYYY-MM-DD">
+     <url type="details">https://github.com/Foundry376/Mailspring/releases/tag/1.X.Y</url>
+   </release>
    ```
-   Note the date here is ISO format (`YYYY-MM-DD`), unlike the `M/D/YYYY` format used in the changelog heading.
+   Note the date here is ISO format (`YYYY-MM-DD`), unlike the `M/D/YYYY` format used in the changelog heading. In both the the version string and the URL, 1.X.Y is a placeholder for the new version number.
 
 ## Changelog Format
 

--- a/app/build/resources/linux/mailspring.appdata.xml.in
+++ b/app/build/resources/linux/mailspring.appdata.xml.in
@@ -52,7 +52,9 @@
   <content_rating type="oars-1.1" />
 
   <releases>
-    <release version="1.23.0" date="2026-07-19" />
+    <release version="1.23.0" date="2026-07-19">
+      <url type="details">https://github.com/Foundry376/Mailspring/releases/tag/1.23.0</url>
+    </release>
     <release version="1.22.0" date="2026-06-13" />
     <release version="1.21.1" date="2026-05-19" />
     <release version="1.21.0" date="2026-05-05" />


### PR DESCRIPTION
Pretty much what the title says. Will fix the "No changelog provided" in [flathub](https://flathub.org/en/apps/com.getmailspring.Mailspring) and other stores. 