### PR TITLE
Defense-in-depth fix for EPIPE crash in Sentry error reporter (MAILSPRING-CLIENT-2N)

### DIFF
--- a/app/src/error-logger-extensions/sentry-error-reporter.js
+++ b/app/src/error-logger-extensions/sentry-error-reporter.js
@@ -19,6 +19,22 @@ function makeEventId() {
   return crypto.randomBytes(16).toString('hex');
 }
 
+// console.log can itself throw (eg. EPIPE writing to a closed stdout/stderr
+// pipe on Linux, when the terminal or launcher that started Mailspring has
+// exited). These calls run inside network callbacks rather than the
+// top-level uncaughtException handler, so a stray throw here escapes as an
+// unrelated "write EPIPE" crash reported from this file (Sentry:
+// MAILSPRING-CLIENT-2N) instead of whatever actually went wrong. main.js
+// already swallows EPIPE at the stream level, but never let a logging call
+// in here fail regardless.
+function safeLog(message) {
+  try {
+    console.log(message);
+  } catch (e) {
+    // ignore
+  }
+}
+
 // Filenames Sentry should not classify as "in_app": Node internals,
 // chrome-extension URLs, anonymous/eval pseudo-files, and anything that
 // isn't an absolute path. Mirrors what raven-node did in utils.js.
@@ -114,7 +130,7 @@ function sendEnvelope(event, release) {
     },
   });
   req.on('error', e => {
-    console.log(`Sentry: ${e.message}`);
+    safeLog(`Sentry: ${e.message}`);
   });
   req.on('response', res => {
     // Drain the response so the socket can be released back to the agent
@@ -122,7 +138,7 @@ function sendEnvelope(event, release) {
     res.on('data', () => {});
     res.on('end', () => {
       if (res.statusCode < 200 || res.statusCode >= 300) {
-        console.log(`Sentry: ${res.statusCode} - ${res.statusMessage}`);
+        safeLog(`Sentry: ${res.statusCode} - ${res.statusMessage}`);
       }
     });
   });
@@ -193,7 +209,7 @@ module.exports = class SentryErrorReporter {
     try {
       sendEnvelope(event, release);
     } catch (e) {
-      console.log(`Sentry: ${e.message}`);
+      safeLog(`Sentry: ${e.message}`);
     }
   }
 };

--- a/app/src/error-logger-extensions/sentry-error-reporter.js
+++ b/app/src/error-logger-extensions/sentry-error-reporter.js
@@ -166,7 +166,7 @@ module.exports = class SentryErrorReporter {
           }
         });
       } catch (err) {
-        console.error(err);
+        safeLog(err);
       }
     }
   }


### PR DESCRIPTION
## Summary

Fixes/addresses [MAILSPRING-CLIENT-2N](https://foundry-376-llc.sentry.io/issues/MAILSPRING-CLIENT-2N) — `Error: write EPIPE`, culprit `ClientRequest.<anonymous>(src/error-logger-extensions/sentry-error-reporter)`.

### What I observed

The stack trace for this issue shows the crash happening *inside* a `console.log()` call in `sentry-error-reporter.js`'s `req.on('error', ...)` handler:

```
app:///src/error-logger-extensions/sentry-error-reporter.js:117:13 (ClientRequest.<anonymous>)
    console.log(`Sentry: ${e.message}`);
    at console.log (node:internal/console/constructor:416:26)
    ...
    at Socket._write (node:net:1037:8)
```

This is the same underlying bug as [MAILSPRING-CLIENT-1V](https://foundry-376-llc.sentry.io/issues/MAILSPRING-CLIENT-1V), fixed in `d4b1b17` (#2769): on Linux, writes to `process.stdout`/`process.stderr` can throw `EPIPE` synchronously when the reader end of the pipe has gone away (e.g. the terminal/launcher that started Mailspring exited). Here that happens while trying to *log* the original network error, turning an unrelated network hiccup into an app-crashing exception that gets reported back to Sentry as `write EPIPE` — with the log statement itself as the culprit instead of whatever actually failed.

I confirmed `d4b1b17` (the process-wide `process.stdout`/`stderr` "swallow EPIPE" guard added in `main.js`) is already merged and shipped in the current `1.23.0` build. Every event recorded against this issue is tagged with an older release (`1.21.0-561a81a3`, `1.21.1-ae68e881`, `1.22.0-b29ea0e6`) that predates that commit — so going forward, users on current builds should no longer hit this via the global guard alone.

### The fix

As defense-in-depth (matching the pattern already used in `error-logger.js`'s `reportError`, which wraps its `console.error` call in a try/catch), I wrapped the three `console.log` call sites in `sentry-error-reporter.js` in a small `safeLog()` helper that swallows any throw. This closes the gap for this specific file without relying solely on the global stream-level guard in `main.js` — so a logging call failing here can never escape as its own crash again, regardless of process ordering or any future changes to the stream guard.

## Test plan

- [x] `node --check app/src/error-logger-extensions/sentry-error-reporter.js` — syntax valid
- [x] Confirmed `d4b1b17` (the related EPIPE fix) is an ancestor of the current `1.23.0` release commit
- [ ] No existing spec coverage for this file; change is a minimal, mechanical try/catch wrap around existing logging calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_015pxSCk6PcaUq5PG9BVrKG1)_