### PR TITLE
Fix TaskQueue crash: Rx.Observable.fromQuery is not a function

### DIFF
--- a/app/src/flux/stores/task-queue.ts
+++ b/app/src/flux/stores/task-queue.ts
@@ -4,6 +4,17 @@ import { Rx } from 'mailspring-exports';
 import { Task } from '../tasks/task';
 import DatabaseStore from './database-store';
 
+// TaskQueue is constructed as a module-level side effect below (`export default
+// new TaskQueue()`), and its constructor calls `Rx.Observable.fromQuery`, which
+// only exists once `mailspring-observables` has run and patched it onto Rx.
+// That normally happens because app-env.ts requires 'mailspring-observables'
+// before 'mailspring-exports', but nothing enforces that ordering when this
+// module is required directly or transitively before that point (this exact
+// scenario has caused "Rx.Observable.fromQuery is not a function" crashes in
+// production). Importing it here guarantees the patch is applied before we
+// construct the singleton below, regardless of require order elsewhere.
+import 'mailspring-observables';
+
 /*
 Public: The TaskQueue is a Flux-compatible Store that manages a queue of {Task}
 objects. Each {Task} represents an individual API action, like sending a draft


### PR DESCRIPTION
## Summary

Fixes [MAILSPRING-CLIENT-33](https://foundry-376-llc.sentry.io/issues/MAILSPRING-CLIENT-33) — `Error: mailspring_exports_1.Rx.Observable.fromQuery is not a function`, thrown from `new TaskQueue()`. 17 users impacted, all on Windows, spanning multiple releases (first seen 2026-05-08, still recurring as of 2026-07-27).

## What I observed

`app/src/flux/stores/task-queue.ts` instantiates its store as a module-level side effect:

```ts
export default new TaskQueue();
```

`TaskQueue`'s constructor immediately calls `Rx.Observable.fromQuery(...)`. That method doesn't exist on `rx-lite`'s `Rx.Observable` out of the box — it's monkey-patched on at runtime by `app/src/global/mailspring-observables.ts`, which mutates the shared `Rx.Observable` object as a side effect of being required.

`app/src/app-env.ts` requires the two modules in a specific, deliberate order:

```ts
// We extend observables with our own methods. This happens on
// require of mailspring-observables
require('mailspring-observables');
require('mailspring-exports');
```

That comment shows the ordering hazard was already known and worked around — but it's enforced entirely by convention in `app-env.ts`. `task-queue.ts` itself has no static import relationship to `mailspring-observables.ts`, so nothing guarantees it can't be reached (directly or transitively) before that ordering plays out. Whenever that happens, `Rx.Observable.fromQuery` is still `undefined` when `TaskQueue`'s constructor runs, and it throws exactly the reported error. This matches the crash precisely: the stack trace shows the exception unwinding through `Module._compile`/`Module.load` while `task-queue.js` is being required, i.e. during construction of the module-level singleton.

I traced the static import graph from `mailspring-observables.ts` and confirmed it does *not* import `task-queue.ts` (so this isn't a classic require-cycle deadlock) — the bug is the missing dependency edge, not a bad one.

## Fix

Make `task-queue.ts` self-sufficient instead of relying on load-order convention: import `mailspring-observables` directly at the top of the file. This guarantees the `Rx.Observable.fromQuery` patch is applied before the singleton is constructed, regardless of what else requires `task-queue.ts` first (or how build/packaging on a given platform happens to order things). The import is a no-op if the module is already loaded, since Node caches modules by path, so this doesn't change behavior for the normal path — it just removes the implicit ordering dependency for the abnormal one.

## Test plan

- [x] `npx tsc -p app/tsconfig.json --noEmit` — no new errors
- [ ] Manual verification in the running app (couldn't launch the full Electron app in this environment)


---
_Generated by [Claude Code](https://claude.ai/code/session_01SfxLnUKBhbEXnhkLeeuRA9)_