### PR TITLE
Fix composer crash from unset Slate selection point (MAILSPRING-CLIENT-1E)

### DIFF
--- a/app/src/components/composer-editor/composer-editor.tsx
+++ b/app/src/components/composer-editor/composer-editor.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import * as Immutable from 'immutable';
-import { Editor, Value, Operation, Range, Block, Text } from 'slate';
+import { Editor, Value, Operation, Range, Block, Text, Point } from 'slate';
 import { Editor as SlateEditorComponent, EditorProps, Plugin } from 'slate-react';
 import { clipboard as ElectronClipboard } from 'electron';
 import { InlineStyleTransformer, SanitizeTransformer } from 'mailspring-exports';
@@ -38,6 +38,20 @@ function getDocumentBrokenReason(value: Value): string | null {
   }
 
   return null;
+}
+
+// Returns true if the value's selection anchor or focus point has become "unset"
+// (key === null). This happens when a plugin calls `editor.removeNodeByKey` on the
+// exact node the selection anchor/focus was pointing into — eg. removing a template
+// variable, toggling quoted text, or removing an attachment/uneditable block — without
+// explicitly moving the selection somewhere else afterwards. Slate's own point
+// normalization intentionally leaves a fully-unset point alone rather than guessing a
+// replacement, so if we don't repair it here, the very next keystroke crashes deep
+// inside Slate's `deleteExpandedAtRange` (`Point.moveTo` calling `.equals` on a null
+// path) with "Cannot read properties of null (reading 'equals')" (MAILSPRING-CLIENT-1E).
+function isSelectionBroken(value: Value): boolean {
+  const { anchor, focus } = value.selection;
+  return anchor.key == null || focus.key == null;
 }
 
 const AEditor = SlateEditorComponent as any as React.ComponentType<
@@ -301,6 +315,22 @@ export class ComposerEditor extends React.Component<ComposerEditorProps, Compose
       this.props.onChange({
         operations: change.operations.push(op),
         value: op.apply(change.value),
+      });
+      return;
+    }
+
+    // Same idea as above, but for a broken selection rather than a broken document:
+    // move the dangling anchor/focus back to the start of the document so the next
+    // keystroke doesn't crash inside Slate.
+    if (isSelectionBroken(change.value)) {
+      console.warn(
+        `ComposerEditor: selection has an unset anchor or focus, moving to the start of the document to recover.`
+      );
+      const firstText = change.value.document.getFirstText();
+      const point = Point.create({ key: firstText.key, offset: 0 });
+      this.props.onChange({
+        operations: change.operations,
+        value: change.value.setSelection({ anchor: point, focus: point }),
       });
       return;
     }

--- a/app/src/components/composer-editor/composer-editor.tsx
+++ b/app/src/components/composer-editor/composer-editor.tsx
@@ -44,14 +44,26 @@ function getDocumentBrokenReason(value: Value): string | null {
 // (key === null). This happens when a plugin calls `editor.removeNodeByKey` on the
 // exact node the selection anchor/focus was pointing into — eg. removing a template
 // variable, toggling quoted text, or removing an attachment/uneditable block — without
-// explicitly moving the selection somewhere else afterwards. Slate's own point
-// normalization intentionally leaves a fully-unset point alone rather than guessing a
-// replacement, so if we don't repair it here, the very next keystroke crashes deep
-// inside Slate's `deleteExpandedAtRange` (`Point.moveTo` calling `.equals` on a null
-// path) with "Cannot read properties of null (reading 'equals')" (MAILSPRING-CLIENT-1E).
-function isSelectionBroken(value: Value): boolean {
+// explicitly moving the selection somewhere else afterwards. Slate's `Value#removeNode`
+// unsets any point in the removed subtree that has no previous/next text to fall back
+// on, and Slate's point normalization then intentionally leaves that unset point alone
+// rather than guessing a replacement. If we don't repair it here, the very next
+// keystroke crashes deep inside Slate's `deleteExpandedAtRange` (`Point.moveTo` calling
+// `.equals` on a null path) with "Cannot read properties of null (reading 'equals')"
+// (MAILSPRING-CLIENT-1E).
+//
+// NOTE: a fully-unset-but-focused selection isn't unique to this bug — slate-react's
+// own `AfterPlugin.onFocus` intentionally calls `editor.deselect().focus()` on every
+// mouse-down focus (to stop a stale selection from blocking the upcoming native
+// `selectionchange`), which produces the exact same unset shape. That transient state
+// is harmless and self-corrects once the native selection lands, so we must not treat
+// every unset selection as broken — only recover when `operations` shows a `remove_node`
+// actually ran, since that's the only operation whose point clean-up (`Value#removeNode`)
+// can leave a point permanently unset instead of re-anchoring it.
+function isSelectionBroken(value: Value, operations: Immutable.List<Operation>): boolean {
   const { anchor, focus } = value.selection;
-  return anchor.key == null || focus.key == null;
+  const isUnset = anchor.key == null || focus.key == null;
+  return isUnset && operations.some((op) => op.type === 'remove_node');
 }
 
 const AEditor = SlateEditorComponent as any as React.ComponentType<
@@ -297,14 +309,16 @@ export class ComposerEditor extends React.Component<ComposerEditorProps, Compose
     // (like spellcheck and the context menu).
     if (!this._mounted) return;
 
-    // If the incoming value is broken, apply the recovery operation directly to
-    // change.value before forwarding to the parent. This emits a single onChange with
-    // the already-corrected value rather than emitting the broken value and then a
-    // second onChange from a deferred microtask (which is what would happen if we called
-    // editor.insertNodeByPath here). The parent therefore never sees the broken state,
-    // and the insert_node operation is included in the operations list so the parent
-    // knows the document changed and doesn't skip saving.
-    const reason = getDocumentBrokenReason(change.value);
+    // If the incoming value is broken, apply recovery operations directly to `value`
+    // before forwarding to the parent. This emits a single onChange with the already-
+    // corrected value rather than emitting the broken value and then a second onChange
+    // from a deferred microtask (which is what would happen if we called editor commands
+    // here). The parent therefore never sees the broken state, and any recovery operation
+    // that changes the document is included in the operations list so the parent knows
+    // the document changed and doesn't skip saving.
+    let { operations, value } = change;
+
+    const reason = getDocumentBrokenReason(value);
     if (reason) {
       console.warn(`ComposerEditor: ${reason}, inserting empty paragraph to recover.`);
       const op = require('slate').Operation.create({
@@ -312,26 +326,28 @@ export class ComposerEditor extends React.Component<ComposerEditorProps, Compose
         path: Immutable.List([0]),
         node: Block.create({ type: 'div', nodes: Immutable.List([Text.create('')]) }),
       });
-      this.props.onChange({
-        operations: change.operations.push(op),
-        value: op.apply(change.value),
-      });
-      return;
+      operations = operations.push(op);
+      value = op.apply(value);
     }
 
-    // Same idea as above, but for a broken selection rather than a broken document:
-    // move the dangling anchor/focus back to the start of the document so the next
-    // keystroke doesn't crash inside Slate.
-    if (isSelectionBroken(change.value)) {
+    // Same idea as above, but for a broken selection rather than a broken document: move
+    // the dangling anchor/focus back to the start of the document so the next keystroke
+    // doesn't crash inside Slate. This check must run on `value` (which may have just been
+    // repaired above), not the original `change.value` — removing the last text-carrying
+    // node from the document unsets the selection *and* triggers the document-broken repair
+    // in the same change, and inserting the recovery paragraph does not re-anchor a
+    // previously-unset selection point, so the selection would still be broken afterwards.
+    if (isSelectionBroken(value, change.operations)) {
       console.warn(
         `ComposerEditor: selection has an unset anchor or focus, moving to the start of the document to recover.`
       );
-      const firstText = change.value.document.getFirstText();
+      const firstText = value.document.getFirstText();
       const point = Point.create({ key: firstText.key, offset: 0 });
-      this.props.onChange({
-        operations: change.operations,
-        value: change.value.setSelection({ anchor: point, focus: point }),
-      });
+      value = value.setSelection({ anchor: point, focus: point });
+    }
+
+    if (value !== change.value) {
+      this.props.onChange({ operations, value });
       return;
     }
 


### PR DESCRIPTION
## Summary

Fixes [MAILSPRING-CLIENT-1E](https://foundry-376-llc.sentry.io/issues/MAILSPRING-CLIENT-1E) — `Error: Cannot read properties of null (reading 'equals')` at `Point.moveTo (slate/lib/slate)`. This is the highest-impact unassigned issue in the 1.21.1 Sentry view: **71 users impacted, 1,175 occurrences**, ongoing since May and still firing as of today.

## Root cause

Several composer plugins (template variables, quoted-text removal, attachment/uneditable-block removal, and the draft body "hotwire" that runs on template/signature insertion) call `editor.removeNodeByKey()` directly on a live, focused Slate editor. In some cases this leaves the current selection's `anchor` or `focus` point referencing a node that no longer resolves.

I traced this precisely against the exact vendored Slate fork this app uses (`slate@0.45.1`, pinned via `github:bengotow/slate#cd6f40e8`, downloaded and diffed locally):

- `Point.normalize()` (`slate.js`) intentionally leaves a **fully-unset** point (`key: null, path: null`) alone rather than guessing a replacement — by design, since it has no reference to work from.
- The next time the user types a character, `insertTextAtRange` → `deleteExpandedAtRange` runs:
  ```js
  if (document.hasDescendant(start.key)) {
    range = range.moveToStart();
  } else {
    range = range.moveTo(end.key, 0).normalize(document); // end.key is null here
  }
  ```
- `Range.moveTo(path, offset)` calls `Point.moveTo(path, offset)` for each point, and when `path` is `null` (neither a string nor a number), it falls into:
  ```js
  key = path.equals(this.path) ? this.key : null; // path is null -> crash
  ```
  This is the exact `"Cannot read properties of null (reading 'equals')"` from the Sentry report, matching the reported stack frames (`Point.moveTo` → `Selection.updatePoints` → `Selection.moveTo` → `deleteExpandedAtRange` → `insertTextAtRange` → `Editor.command`) line for line.

I reproduced this class of crash locally against the real vendored Slate package by constructing a half-unset selection and calling `editor.insertTextAtRange(...)`/`editor.insertText(...)` on it — both throw null-reference errors from the same underlying defect, and confirmed the fix below neutralizes it.

## Fix

`composer-editor.tsx` already has a self-healing check in its `onChange` handler that detects a "broken" document (no text nodes, or all text hidden inside quoted/uneditable content) and repairs it before forwarding the change to the parent, so the broken state is never observed by the rest of the app.

This PR adds a sibling check, `isSelectionBroken`, that detects when the selection's anchor or focus point has become unset (`key == null`), and repairs it by moving the selection to the start of the document — before the broken state can reach the next keystroke and crash deep inside Slate.

This is a general, proactive fix rather than patching each individual plugin call site, since any of several plugins (present and future) that call `removeNodeByKey` on a live editor could produce the same broken state.

## Test plan

- [x] `tsc --noEmit` passes
- [x] `eslint` passes on the changed file
- [x] Reproduced the crash directly against the project's actual vendored `slate` package (downloaded from npm, confirmed byte-identical to the installed fork around the relevant functions) by constructing a half-unset selection and calling `insertTextAtRange`/`insertText` on it — confirmed it throws a null-reference error from the same code path, and confirmed the repair logic added here produces a valid selection that no longer crashes.
- [ ] Manual verification in the running app (not performed in this environment)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MBmAFB6CdJxBasN9sF82jv)_