### PR TITLE
Capture caller stack for uncaught shell.openExternal rejections

### DIFF
--- a/app/src/browser/application.ts
+++ b/app/src/browser/application.ts
@@ -1,5 +1,6 @@
 /* eslint global-require: "off" */
 
+import '../safe-shell';
 import { BrowserWindow, Menu, app, ipcMain, dialog, nativeImage, shell } from 'electron';
 
 import fs from 'fs';

--- a/app/src/safe-shell.ts
+++ b/app/src/safe-shell.ts
@@ -1,0 +1,44 @@
+import { shell } from 'electron';
+
+// `shell.openExternal` rejects with an OS-level error (eg. "Failed to open:
+// No application is associated with the specified file..." / MK_E_UNAVAILABLE
+// on Windows) when there's no application registered to handle the URL. That
+// error has a message but no JS stack (it's constructed in native code), so
+// when a caller doesn't add its own `.catch`, it surfaces as an unhandled
+// promise rejection that Sentry reports with no stacktrace and no way to
+// tell which of our many `shell.openExternal` call sites, or what URL, was
+// involved (see MAILSPRING-CLIENT-6E).
+//
+// We capture the caller's stack synchronously (before the async native call
+// runs) and attach it to the error if it doesn't already have one, then
+// re-throw so existing `.catch` handlers keep working exactly as before —
+// this only makes the error more informative, it doesn't change control flow.
+const originalOpenExternal = shell.openExternal.bind(shell);
+shell.openExternal = (url: string, options?: Electron.OpenExternalOptions) => {
+  const callSite: { stack?: string } = {};
+  Error.captureStackTrace(callSite, shell.openExternal);
+
+  return originalOpenExternal(url, options).catch((err: Error) => {
+    if (!err.stack) {
+      const frames = (callSite.stack || '').split('\n').slice(1).join('\n');
+      err.stack = `${err.name || 'Error'}: ${err.message}\n${frames}`;
+    }
+    console.error(`shell.openExternal could not open "${url}":`, err);
+    throw err;
+  });
+};
+
+// `shell.openPath` resolves (rather than rejects) with a string containing
+// the error message when it fails, so it can't produce an unhandled
+// rejection. Callers that don't check the resolved value (most of them)
+// currently fail completely silently; log it so failures are at least
+// visible in the console/log file.
+const originalOpenPath = shell.openPath.bind(shell);
+shell.openPath = (path: string) => {
+  return originalOpenPath(path).then((result) => {
+    if (result) {
+      console.error(`shell.openPath could not open "${path}": ${result}`);
+    }
+    return result;
+  });
+};

--- a/app/src/safe-shell.ts
+++ b/app/src/safe-shell.ts
@@ -20,10 +20,17 @@ shell.openExternal = (url: string, options?: Electron.OpenExternalOptions) => {
 
   return originalOpenExternal(url, options).catch((err: Error) => {
     if (!err.stack) {
-      const frames = (callSite.stack || '').split('\n').slice(1).join('\n');
-      err.stack = `${err.name || 'Error'}: ${err.message}\n${frames}`;
+      try {
+        const frames = (callSite.stack || '').split('\n').slice(1).join('\n');
+        err.stack = `${err.name || 'Error'}: ${err.message}\n${frames}`;
+      } catch {
+        // err.stack isn't writable on this particular error; leave it as-is
+        // rather than let this diagnostic path mask the original rejection.
+      }
     }
-    console.error(`shell.openExternal could not open "${url}":`, err);
+    // Re-throw unchanged: existing `.catch` handlers (eg. the link-open
+    // error dialog) already report this; the global unhandled-rejection
+    // handler logs/reports anything nobody else catches, now with a stack.
     throw err;
   });
 };

--- a/app/src/secondary-window-bootstrap.ts
+++ b/app/src/secondary-window-bootstrap.ts
@@ -14,6 +14,7 @@
 //
 // Extend the standard promise class a bit
 import './promise-extensions';
+import './safe-shell';
 
 import AppEnvClass from './app-env';
 window.AppEnv = new AppEnvClass();

--- a/app/src/window-bootstrap.ts
+++ b/app/src/window-bootstrap.ts
@@ -3,6 +3,7 @@
 
 // Extend the standard promise class a bit
 import './promise-extensions';
+import './safe-shell';
 
 import AppEnvClass from './app-env';
 window.AppEnv = new AppEnvClass();


### PR DESCRIPTION
## Summary

Fixes [MAILSPRING-CLIENT-6E](https://foundry-376-llc.sentry.io/issues/MAILSPRING-CLIENT-6E) — `Error: Failed to open: No se ha encontrado la aplicación (0x800401F5)`, affecting 3 users, unassigned, no stacktrace, no culprit.

### What I observed

- The event has a `message` but **no stacktrace at all**, and Sentry's own "culprit" detection came up empty.
- `0x800401F5` is `MK_E_UNAVAILABLE`, and "Failed to open: ..." matches Electron/Windows's `shell.openExternal` rejection format when there's no application registered to handle a URL (eg. no default browser configured on a broken Windows install).
- Our codebase has **~20 call sites** across `app/src` and `app/internal_packages` that call `shell.openExternal(...)` without a `.catch()`. When one of these rejects, it becomes an unhandled promise rejection, which our top-level handlers (`app/src/browser/main.js`'s `process.on('unhandledRejection', ...)` for the main process, and `app/src/app-env.ts`'s `window.addEventListener('unhandledrejection', ...)` for renderers) forward straight to Sentry via `errorLogger.reportError`.
- The rejection reason from Electron's native binding has a `message` but no JS `.stack` (it's constructed in native code). `app/src/error-logger.js`'s existing "wrap error to capture a stack" logic only kicks in when **both** `message` and `stack` are missing (`if (!hasMessage && !hasStack)`), so an error with a message but no stack — exactly this case — passes straight through unmodified. Combined with `app/src/error-logger-extensions/sentry-error-reporter.js` omitting `stacktrace` entirely when there are no parseable frames, the resulting Sentry event has no way to identify which of the ~20 call sites (or what URL) is actually failing.

Because of this, there's no single specific call site to point at as "the" bug — the actual defect is structural: any of these ~20 places can produce an unactionable report the same way.

### The fix

Added `app/src/safe-shell.ts`, which wraps `shell.openExternal`:
- Synchronously captures the **calling code's** stack (via `Error.captureStackTrace`) before the async native call runs.
- In the `.catch`, if the rejected error has no `.stack`, attaches the captured caller stack to it — so Sentry will show the exact file/line that triggered the failure next time.
- Re-throws the (now enriched) error, so existing `.catch` handlers — eg. the "Failed to Open Link" dialog in `window-event-handler.ts` and the "Failed to Open Settings" dialog in `default-client-helper.ts` — keep working exactly as before. This is purely additive; it doesn't swallow or change any existing behavior.
- Also wraps `shell.openPath`, which resolves (rather than rejects) with an error string on failure, so it can never produce an unhandled rejection — but currently fails completely silently everywhere it's called. Now logs the failure so it's at least visible in the log file.

Wired in via the earliest bootstrap point for both the main process (`app/src/browser/application.ts`, first import) and every renderer window (`app/src/window-bootstrap.ts` and `app/src/secondary-window-bootstrap.ts`), so it covers all ~20 existing call sites (and any future ones) without having to touch each one individually.

Verified with `tsc --noEmit`, `eslint`, and a standalone Node script simulating the real shape (native error with no stack) to confirm the synthesized stack correctly identifies the real caller and that existing `.catch`-based dialogs are unaffected.

## Test plan

- [x] `tsc --noEmit` passes for the touched files
- [x] `eslint` passes for the touched files
- [x] Manually simulated a stack-less native rejection through the wrapper to confirm the synthesized stack points at the real caller and existing `.catch` handlers still fire unchanged
- [ ] Next time this error occurs in production, the Sentry event should include a stacktrace pointing at the actual `shell.openExternal` call site


---
_Generated by [Claude Code](https://claude.ai/code/session_018rC3joWjKjkVhvzy1TtCNm)_