### PR TITLE
Swallow EROFS/EIO/ENOSPC/EBADF alongside EPIPE in stdout/stderr error handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Bug Fixes:
 - Fixed cancellation of `GetManyRFC2822Task` (folder export). (#118) Thanks @Kevin-Hamilton!
 - Fixed handling of XDG paths. (#2761) Thanks @LinusDierheimer!
 - On Linux, fixed an EPIPE crash loop in the uncaughtException handler. (#2769)
+- On Linux, fixed an EROFS/EIO/ENOSPC/EBADF crash loop in the uncaughtException handler that the EPIPE fix didn't cover. (#2789)
 - On Linux, send `org.freedesktop.DBus.Hello` before emitting the badge signal. (#2778) Thanks @WebDevBar!
 - Stopped startup after a fatal `config.json` load failure. (#2764)
 - Guarded `nativeTheme` remote object access in `SystemTrayIconStore`. (#2753)

--- a/app/src/browser/main.js
+++ b/app/src/browser/main.js
@@ -6,17 +6,22 @@ const util = require('util');
 const fs = require('fs');
 
 // On Linux, writes to process.stdout/stderr use a synchronous fast path when
-// the fd is a pipe. If the reader end of that pipe has gone away (eg. the
-// terminal or launcher that started Mailspring has exited), the write fails
-// with EPIPE and — because there's no 'error' listener on the stream — Node
-// throws it synchronously instead of emitting it. When this happens inside
-// our `uncaughtException` handler (which itself logs via console.error), the
-// thrown EPIPE re-enters the same handler, producing an infinite crash loop.
-// Swallowing EPIPE here lets writes to a dead stdout/stderr silently no-op.
+// the fd is a pipe or a plain file. If the destination goes away or becomes
+// unwritable — the reader end of a pipe exits (EPIPE), or the fd is backed by
+// a filesystem that's read-only or gone (EROFS, seen eg. under snap when a
+// revision's squashfs mount is swapped out from under a running process, or
+// EIO/ENOSPC/EBADF for similar reasons) — the write throws synchronously
+// instead of emitting an event, because there's no 'error' listener on the
+// stream. When this happens inside our `uncaughtException` handler (which
+// itself logs via console.error), the thrown error re-enters the same
+// handler, producing a crash loop. None of these codes are actionable by the
+// app, so swallow them all here and let writes to a dead stdout/stderr
+// silently no-op.
+const IGNORABLE_STREAM_ERROR_CODES = new Set(['EPIPE', 'EROFS', 'EIO', 'ENOSPC', 'EBADF']);
 for (const stream of [process.stdout, process.stderr]) {
   if (stream) {
     stream.on('error', error => {
-      if (error && error.code === 'EPIPE') {
+      if (error && IGNORABLE_STREAM_ERROR_CODES.has(error.code)) {
         return;
       }
       throw error;


### PR DESCRIPTION
## What I observed

Reviewing unresolved Sentry issues on release `1.21.1-ae68e881` (sorted by impacted users), I found [MAILSPRING-CLIENT-3R](https://foundry-376-llc.sentry.io/issues/MAILSPRING-CLIENT-3R) — unassigned, "Error: EROFS: read-only file system, write", 2 users / ~1500 occurrences at the time of triage.

Its culprit (`ErrorLogger.reportError`) and stack trace (`console.error` → `Writable.write` → `SyncWriteStream._write` → `writeSync`) are identical to the already-assigned [MAILSPRING-CLIENT-1V](https://foundry-376-llc.sentry.io/issues/MAILSPRING-CLIENT-1V) — same title, same code path, 28 users / 30,000+ occurrences, and **still recurring as of today** (last event minutes before I started this investigation).

MAILSPRING-CLIENT-1V was the issue referenced in commit d4b1b17 (#2769), "Fix EPIPE crash loop in uncaughtException handler on Linux". That fix added a `stream.on('error', ...)` handler in `app/src/browser/main.js` that swallows `EPIPE` but explicitly re-throws every other error code:

```js
stream.on('error', error => {
  if (error && error.code === 'EPIPE') {
    return;
  }
  throw error;
});
```

The mismatch: the Sentry issue that motivated that fix has always been titled **EROFS**, not EPIPE. `EROFS` is not in the swallow list, so it's re-thrown by that same handler, re-entering the `uncaughtException` handler → `ErrorLogger.reportError` → another failing `console.error` write, which is exactly the crash loop the original fix was meant to eliminate — just for a different errno. That's why 1V kept generating events for 16 days after the "fix" shipped, and why 3R (same bug, different Sentry fingerprint) is still open and unassigned.

Both issues share the same underlying trigger: on some Linux installs (e.g. snap, where a squashfs mount can go read-only or be swapped out from under a running process), writes to `process.stdout`/`process.stderr` start failing with codes other than EPIPE. Since Mailspring's main process logs frequently, every log write on such a system throws, gets caught by `uncaughtException`, gets reported to Sentry, and repeats.

## The fix

`app/src/browser/main.js`: broaden the ignorable error-code set on the stdout/stderr `'error'` listener from just `EPIPE` to the full family of "the log destination is unusable" errno codes: `EPIPE`, `EROFS`, `EIO`, `ENOSPC`, `EBADF`. None of these are actionable by the app — there's nothing useful to do with a broken debug-log destination other than let the write silently no-op, which is exactly what the original EPIPE-only fix intended, just under-scoped.

This directly fixes MAILSPRING-CLIENT-3R (linked via commit message) and should also stop the still-active recurrence of MAILSPRING-CLIENT-1V, which shares the identical root cause and stack trace.

## Test plan
- [x] `node --check app/src/browser/main.js` — syntax valid
- [x] Verified via `git log`/`git show` that the pre-existing EPIPE fix (d4b1b17) explicitly re-throws non-EPIPE codes, confirming this is the gap
- [ ] Would benefit from manual verification on a Linux box where stdout is redirected to a read-only-mounted file, but this isn't easily reproducible in this environment

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_014AqZ9RDDUV88f9S9Zw99r8

---
_Generated by [Claude Code](https://claude.ai/code/session_014AqZ9RDDUV88f9S9Zw99r8)_