### PR TITLE
Improve Contact.fromString parsing and Account.meUsingAlias fallback

### DIFF
--- a/app/spec/models/account-spec.ts
+++ b/app/spec/models/account-spec.ts
@@ -189,6 +189,48 @@ describe('Account', function () {
     });
   });
 
+  describe('meUsingAlias()', function () {
+    const accountWithAliases = (aliases: string[]) =>
+      new Account({
+        id: TEST_ACCOUNT_ID,
+        name: TEST_ACCOUNT_NAME,
+        emailAddress: TEST_ACCOUNT_EMAIL,
+        aliases,
+      });
+
+    it('returns me() when the alias is empty', function () {
+      const contact = accountWithAliases([]).meUsingAlias('');
+      expect(contact.email).toBe(TEST_ACCOUNT_EMAIL);
+      expect(contact.name).toBe(TEST_ACCOUNT_NAME);
+    });
+
+    it('parses a well formed alias', function () {
+      const contact = accountWithAliases([]).meUsingAlias('Ben Alt <alt@example.com>');
+      expect(contact.name).toBe('Ben Alt');
+      expect(contact.email).toBe('alt@example.com');
+      expect(contact.accountId).toBe(TEST_ACCOUNT_ID);
+    });
+
+    it('does not throw when the alias contains the email address twice', function () {
+      const contact = accountWithAliases([]).meUsingAlias('alt@example.com <alt@example.com>');
+      expect(contact.name).toBe('alt@example.com');
+      expect(contact.email).toBe('alt@example.com');
+    });
+
+    it('falls back to the account address when the alias has no email address', function () {
+      const contact = accountWithAliases([]).meUsingAlias('Just A Name');
+      expect(contact.email).toBe(TEST_ACCOUNT_EMAIL);
+      expect(contact.name).toBe('Just A Name');
+      expect(contact.accountId).toBe(TEST_ACCOUNT_ID);
+    });
+
+    it('falls back to the account name when the alias is only whitespace', function () {
+      const contact = accountWithAliases([]).meUsingAlias('   ');
+      expect(contact.email).toBe(TEST_ACCOUNT_EMAIL);
+      expect(contact.name).toBe(TEST_ACCOUNT_NAME);
+    });
+  });
+
   describe('defaultMe()', function () {
     it('returns me() when no defaultAlias is set', function () {
       const account = new Account({

--- a/app/spec/models/contact-spec.ts
+++ b/app/spec/models/contact-spec.ts
@@ -146,6 +146,56 @@ describe('Contact', function () {
     expect(c1.displayName({ compact: true })).toBe('You');
   });
 
+  describe('fromString', function () {
+    it('parses a name and an email address', function () {
+      const c1 = Contact.fromString('Ben Gotow <ben@mailspring.com>');
+      expect(c1.name).toBe('Ben Gotow');
+      expect(c1.email).toBe('ben@mailspring.com');
+    });
+
+    it('parses a bare email address', function () {
+      const c1 = Contact.fromString('ben@mailspring.com');
+      expect(c1.name).toBe('');
+      expect(c1.email).toBe('ben@mailspring.com');
+    });
+
+    it('assigns the accountId and a deterministic id', function () {
+      const c1 = Contact.fromString('Ben <ben@mailspring.com>', { accountId: 'a1' });
+      expect(c1.accountId).toBe('a1');
+      expect(c1.id).toBe('local-a1-ben@mailspring.com');
+    });
+
+    it('prefers the address in angle brackets when the string contains several', function () {
+      const c1 = Contact.fromString('ben@mailspring.com <ben@mailspring.com>');
+      expect(c1.name).toBe('ben@mailspring.com');
+      expect(c1.email).toBe('ben@mailspring.com');
+
+      const c2 = Contact.fromString('Ben (old: ben@old.com) <ben@mailspring.com>');
+      expect(c2.name).toBe('Ben (old: ben@old.com)');
+      expect(c2.email).toBe('ben@mailspring.com');
+    });
+
+    it('uses the last address when several appear without angle brackets', function () {
+      const c1 = Contact.fromString('ben@old.com ben@mailspring.com');
+      expect(c1.name).toBe('ben@old.com');
+      expect(c1.email).toBe('ben@mailspring.com');
+    });
+
+    it('does not throw when the string contains no email address', function () {
+      const c1 = Contact.fromString('Ben Gotow');
+      expect(c1.name).toBe('Ben Gotow');
+      expect(c1.email).toBe('');
+
+      const c2 = Contact.fromString('Ben Gotow <>');
+      expect(c2.name).toBe('Ben Gotow <>');
+      expect(c2.email).toBe('');
+
+      const c3 = Contact.fromString('');
+      expect(c3.name).toBe('');
+      expect(c3.email).toBe('');
+    });
+  });
+
   describe('isMe', function () {
     it('returns true if the contact name matches the account email address', function () {
       let c1 = new Contact({ email: this.account.emailAddress });

--- a/app/src/flux/models/account.ts
+++ b/app/src/flux/models/account.ts
@@ -164,9 +164,20 @@ export class Account extends ModelWithMetadata {
     if (!alias) {
       return this.me();
     }
-    return Contact.fromString(alias, {
+    const contact = Contact.fromString(alias, {
       accountId: this.id,
     });
+
+    // Aliases are user-provided and may not contain an email address at all
+    // (eg: legacy or hand-edited data.) Treat the alias as a display name over
+    // the account's own address - which is what the preferences UI saves for
+    // the same input - rather than returning a contact that can't send mail.
+    if (!contact.email) {
+      contact.email = this.emailAddress;
+      contact.name = contact.name || this.name;
+      contact.id = `local-${this.id}-${this.emailAddress}`;
+    }
+    return contact;
   }
 
   defaultMe() {

--- a/app/src/flux/models/contact.ts
+++ b/app/src/flux/models/contact.ts
@@ -448,7 +448,7 @@ export class Contact extends Model {
       // used to give them random strings, let's try for something consistent
       id: `local-${accountId}-${email}`,
       accountId: accountId,
-      name: name.trim(),
+      name: name,
       email: email,
     });
   }

--- a/app/src/flux/models/contact.ts
+++ b/app/src/flux/models/contact.ts
@@ -412,18 +412,37 @@ export class Contact extends Model {
     return Contact.sortOrderAttribute().descending();
   };
 
-  static fromString(string, { accountId }: { accountId?: string } = {}) {
+  // Public: Parses a string like `Ben Gotow <ben@foundry376.com>` into a {Contact}.
+  //
+  // Note: This is called with user-provided values - account aliases in particular -
+  // which are often malformed. `ben@foundry376.com <ben@foundry376.com>` (the email
+  // used as the display name) and strings with no email address at all are both
+  // common. Parsing must never throw: a single bad alias is read by
+  // AccountStore.aliases(), and would otherwise take down every view that calls
+  // Contact#isMe, including the thread list.
+  //
+  // If no email address is present, the returned contact has an empty `email` and
+  // the entire string as its `name`.
+  static fromString(string: string, { accountId }: { accountId?: string } = {}) {
     const emailRegex = RegExpUtils.emailRegex();
-    const match = emailRegex.exec(string);
-    if (emailRegex.exec(string)) {
-      throw new Error(
-        'Error while calling Contact.fromString: string contains more than one email'
-      );
+    const matches: RegExpExecArray[] = [];
+    let match: RegExpExecArray = null;
+    while ((match = emailRegex.exec(string)) !== null) {
+      matches.push(match);
     }
-    const email = match[0];
-    let name = string.substr(0, match.index - 1);
+
+    // When the string contains more than one address, prefer the last one wrapped in
+    // angle brackets (`"a@b.com" <a@b.com>`), and otherwise the last one found, since
+    // the address trails the display name in the `Name <email>` format.
+    const bracketed = matches.filter(
+      (m) => string[m.index - 1] === '<' && string[m.index + m[0].length] === '>'
+    );
+    const chosen = bracketed[bracketed.length - 1] || matches[matches.length - 1];
+
+    const email = chosen ? chosen[0] : '';
+    let name = (chosen ? string.slice(0, chosen.index) : string).trim();
     if (name.endsWith('<') || name.endsWith('(')) {
-      name = name.substr(0, name.length - 1);
+      name = name.slice(0, name.length - 1).trim();
     }
     return new Contact({
       // used to give them random strings, let's try for something consistent


### PR DESCRIPTION
## Summary

Improves the robustness of contact string parsing to handle malformed user input (particularly account aliases) without throwing errors. Updates `Contact.fromString()` to gracefully handle multiple email addresses and missing emails, and adds fallback logic to `Account.meUsingAlias()` to ensure a valid email address is always present.

## Key Changes

- **Contact.fromString() parsing improvements**:
  - Changed from throwing an error when multiple emails are found to intelligently selecting the best match
  - Prefers email addresses wrapped in angle brackets (e.g., `Name <email@example.com>`)
  - Falls back to the last email found when no bracketed address exists
  - Gracefully handles strings with no email address by returning empty email and using the entire string as the name
  - Added comprehensive JSDoc explaining the parsing strategy and why it must never throw

- **Account.meUsingAlias() fallback logic**:
  - Added validation to check if parsed alias contains an email address
  - Falls back to the account's own email address if the alias has no email
  - Preserves the alias as a display name while using the account's email for sending
  - Ensures the contact always has a valid email address for mail operations

- **Test coverage**:
  - Added 6 new test cases for `Contact.fromString()` covering edge cases: well-formed input, bare emails, multiple addresses, missing emails, and empty strings
  - Added 5 new test cases for `Account.meUsingAlias()` covering empty aliases, well-formed aliases, duplicate emails, missing emails, and whitespace-only input

## Implementation Details

The parsing logic now collects all email matches in the string and applies selection heuristics:
1. Filter for emails wrapped in angle brackets
2. Use the last bracketed match if available
3. Otherwise use the last match found (since display name typically precedes email)
4. Extract the display name as everything before the chosen email, trimmed and cleaned of trailing delimiters

This approach handles common malformed alias patterns like `ben@mailspring.com <ben@mailspring.com>` (email as display name) without throwing, which is critical since a single bad alias would otherwise crash views that call `Contact#isMe()`.

https://claude.ai/code/session_013T1jsQixghcikuw6s3PiUy