### PR TITLE
Add subject line support to email templates

### DIFF
--- a/app/internal_packages/composer-templates/README.md
+++ b/app/internal_packages/composer-templates/README.md
@@ -6,6 +6,19 @@ email again! Templates live in the templates folder inside the Mailspring config
 Each template is an HTML file - the name of the file is the name of the template,
 and it's contents are the default message body.
 
+A template can also carry a subject line, which is stored in a `<meta>` tag at the
+very top of the file:
+
+```html
+<meta name="subject" content="Following up on our call"/>
+<div>Hey there!</div>
+```
+
+When you insert the template, the subject is filled into your draft. Templates
+without the meta tag leave the draft's subject alone, and the subject of a reply
+is never overwritten. If your draft already has a subject, Mailspring asks before
+replacing it.
+
 If you include HTML &lt;code&gt; tags in your template, you can create
 regions that you can jump between and fill easily.
 Give &lt;code&gt; tags the `var` class to mark them as template regions. Add

--- a/app/internal_packages/composer-templates/README.md
+++ b/app/internal_packages/composer-templates/README.md
@@ -17,7 +17,8 @@ very top of the file:
 When you insert the template, the subject is filled into your draft. Templates
 without the meta tag leave the draft's subject alone, and the subject of a reply or
 a forward is never overwritten. If your draft already has a subject, Mailspring
-asks before replacing it.
+asks before replacing it. The same rule applies in reverse: saving a reply or a
+forward with "Save Draft as Template" keeps the body but not the subject.
 
 If you include HTML &lt;code&gt; tags in your template, you can create
 regions that you can jump between and fill easily.

--- a/app/internal_packages/composer-templates/README.md
+++ b/app/internal_packages/composer-templates/README.md
@@ -15,9 +15,9 @@ very top of the file:
 ```
 
 When you insert the template, the subject is filled into your draft. Templates
-without the meta tag leave the draft's subject alone, and the subject of a reply
-is never overwritten. If your draft already has a subject, Mailspring asks before
-replacing it.
+without the meta tag leave the draft's subject alone, and the subject of a reply or
+a forward is never overwritten. If your draft already has a subject, Mailspring
+asks before replacing it.
 
 If you include HTML &lt;code&gt; tags in your template, you can create
 regions that you can jump between and fill easily.

--- a/app/internal_packages/composer-templates/assets/Bienvenue dans Modèles.html
+++ b/app/internal_packages/composer-templates/assets/Bienvenue dans Modèles.html
@@ -1,3 +1,4 @@
+<meta name="subject" content="Bienvenue dans Modèles !"/>
 <div>Salut, <span data-tvar="Prénom" class="template-variable undefined" title="first_name">Prénom</span>!</div>
 <div><br/></div>
 <div>Les modèles sont des emails pré-écrits avec des
@@ -12,6 +13,8 @@ réponse rapide. Voici comment ça marche:
 <li>Sélectionnez le texte que vous souhaitez modifier à chaque fois que vous envoyez l'email (comme le nom du destinataire
 ou l'entreprise dans laquelle il travaille) et cliquez sur l'icône <strong>Tag</strong> dans la barre d'outils ci-dessus pour
 transformer le texte en variable taguée.</li>
+<li>Remplissez le champ <strong>Objet</strong> pour donner une ligne d'objet au modèle. (Celui-ci en a
+une : c'est pourquoi l'objet de ce brouillon a été rempli pour vous !)</li>
 </ol>
 <div><br/></div>
 <strong>Utiliser le modèle:</strong>

--- a/app/internal_packages/composer-templates/assets/Welcome to Templates.html
+++ b/app/internal_packages/composer-templates/assets/Welcome to Templates.html
@@ -1,3 +1,4 @@
+<meta name="subject" content="Welcome to Templates!"/>
 <div>Hey, <span data-tvar="first_name" class="template-variable undefined" title="first_name">First Name</span>!</div>
 <div><br/></div>
 <div>Templates are pre-written emails with
@@ -12,6 +13,8 @@ reply quickly. Here's how it works:
 <li>Select text that you'd like to change each time you send the email (like the recipient's name
 or the company they work at) and click the <strong>Tag</strong> icon in the toolbar above to
 turn the text into a tagged variable.</li>
+<li>Fill in the <strong>Subject</strong> field to give the template a subject line. (This one has
+one - that's why the subject of this draft was filled in for you!)</li>
 </ol>
 <div><br/></div>
 <strong>Use the Template:</strong>

--- a/app/internal_packages/composer-templates/lib/preferences-templates.tsx
+++ b/app/internal_packages/composer-templates/lib/preferences-templates.tsx
@@ -5,23 +5,20 @@ import { Flexbox, EditableList, ComposerEditor, ComposerSupport } from 'mailspri
 import { Actions, localized, localizedReactFragment } from 'mailspring-exports';
 import { Value } from 'slate';
 
-import TemplateStore from './template-store';
+import TemplateStore, { TemplateItem } from './template-store';
+import { parseTemplate, stringifyTemplate } from './template-file';
 
-interface ITemplate {
-  path: string;
-  name: string;
-}
 const {
   Conversion: { convertFromHTML, convertToHTML },
 } = ComposerSupport;
 
 interface TemplateEditorProps {
-  template: ITemplate;
+  template: TemplateItem;
   onEditTitle: (title: string) => void;
 }
 class TemplateEditor extends React.Component<
   TemplateEditorProps,
-  { readOnly: boolean; editorState: Value }
+  { readOnly: boolean; editorState: Value; subject: string }
 > {
   _composer: ComposerEditor;
 
@@ -29,14 +26,16 @@ class TemplateEditor extends React.Component<
     super(props);
 
     if (this.props.template) {
-      const inHTML = fs.readFileSync(props.template.path).toString();
+      const { subject, body } = parseTemplate(fs.readFileSync(props.template.path).toString());
       this.state = {
-        editorState: convertFromHTML(inHTML),
+        editorState: convertFromHTML(body),
+        subject,
         readOnly: false,
       };
     } else {
       this.state = {
         editorState: convertFromHTML(''),
+        subject: '',
         readOnly: true,
       };
     }
@@ -44,9 +43,16 @@ class TemplateEditor extends React.Component<
 
   _onSave = () => {
     if (!this.state.readOnly) {
-      const outHTML = convertToHTML(this.state.editorState);
+      const outHTML = stringifyTemplate({
+        subject: this.state.subject,
+        body: convertToHTML(this.state.editorState),
+      });
       fs.writeFileSync(this.props.template.path, outHTML);
     }
+  };
+
+  _onSubjectChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    this.setState({ subject: e.target.value });
   };
 
   _onFocusEditor = (e: React.MouseEvent<HTMLDivElement>) => {
@@ -57,23 +63,38 @@ class TemplateEditor extends React.Component<
 
   render() {
     const { onEditTitle, template } = this.props;
-    const { readOnly, editorState } = this.state;
+    const { readOnly, editorState, subject } = this.state;
 
     return (
       <div className={`template-wrap ${readOnly && 'empty'}`}>
-        <div className="section">
-          <label htmlFor="template-title" className="sr-only">
-            {localized('Template Name')}
-          </label>
-          <input
-            type="text"
-            id="template-title"
-            placeholder={localized('Name')}
-            style={{ maxWidth: 400 }}
-            disabled={readOnly}
-            defaultValue={template ? template.name : ''}
-            onBlur={(e) => onEditTitle(e.target.value)}
-          />
+        <div className="section fields">
+          <div className="field name">
+            <label htmlFor="template-title" className="sr-only">
+              {localized('Template Name')}
+            </label>
+            <input
+              type="text"
+              id="template-title"
+              placeholder={localized('Name')}
+              disabled={readOnly}
+              defaultValue={template ? template.name : ''}
+              onBlur={(e) => onEditTitle(e.target.value)}
+            />
+          </div>
+          <div className="field subject">
+            <label htmlFor="template-subject" className="sr-only">
+              {localized('Subject')}
+            </label>
+            <input
+              type="text"
+              id="template-subject"
+              placeholder={localized('Subject (optional)')}
+              disabled={readOnly}
+              value={subject}
+              onChange={this._onSubjectChange}
+              onBlur={this._onSave}
+            />
+          </div>
         </div>
         <div className="section editor" onClick={this._onFocusEditor}>
           <ComposerEditor
@@ -86,6 +107,9 @@ class TemplateEditor extends React.Component<
           />
         </div>
         <div className="section note">
+          {localized(
+            'The subject is filled into your draft when you use the template. Leave it blank to keep the subject you already have.'
+          )}{' '}
           {localizedReactFragment(
             'Changes are saved automatically. View the %@ for tips and tricks.',
             <a href="https://community.getmailspring.com/t/reply-faster-with-email-templates/167">
@@ -100,7 +124,7 @@ class TemplateEditor extends React.Component<
 
 export default class PreferencesTemplates extends React.Component<
   Record<string, unknown>,
-  { selected: ITemplate; templates: ITemplate[] }
+  { selected: TemplateItem; templates: TemplateItem[] }
 > {
   static displayName = 'PreferencesTemplates';
 
@@ -156,7 +180,7 @@ export default class PreferencesTemplates extends React.Component<
     Actions.renameTemplate(this.state.selected.name, newName);
   };
 
-  _onSelect = (item: ITemplate) => {
+  _onSelect = (item: TemplateItem) => {
     this.setState({ selected: item });
   };
 

--- a/app/internal_packages/composer-templates/lib/template-file.ts
+++ b/app/internal_packages/composer-templates/lib/template-file.ts
@@ -1,0 +1,64 @@
+// Templates are stored as plain HTML files in the templates folder so they stay
+// easy to read, edit and share. To keep a template a single self-contained file,
+// the subject line is stored in a <meta> tag at the top of the document instead
+// of in a sidecar file:
+//
+//   <meta name="subject" content="Following up on our call"/>
+//   <div>Hey {{first_name}}, ...</div>
+//
+// Templates written before subject support existed simply have no meta tag and
+// parse to an empty subject.
+const SUBJECT_META_REGEX =
+  /^\s*<meta\s+name=["']?subject["']?\s+content=(?:"([^"]*)"|'([^']*)')\s*\/?>[^\S\n]*\n?/i;
+
+export interface ParsedTemplate {
+  subject: string;
+  body: string;
+}
+
+function escapeAttributeValue(value: string) {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function unescapeAttributeValue(value: string) {
+  return value
+    .replace(/&quot;/g, '"')
+    .replace(/&#0?39;/g, "'")
+    .replace(/&apos;/g, "'")
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&amp;/g, '&');
+}
+
+/**
+ * Split the contents of a template file into its subject line and message body.
+ * Files without a subject meta tag return an empty subject and untouched body.
+ */
+export function parseTemplate(contents: string): ParsedTemplate {
+  const match = SUBJECT_META_REGEX.exec(contents || '');
+  if (!match) {
+    return { subject: '', body: contents || '' };
+  }
+  const rawSubject = match[1] !== undefined ? match[1] : match[2];
+  return {
+    subject: unescapeAttributeValue(rawSubject).trim(),
+    body: (contents || '').substr(match[0].length),
+  };
+}
+
+/**
+ * Serialize a subject and body back into the contents of a template file. The
+ * meta tag is omitted entirely when the template has no subject, so templates
+ * you never give a subject to look exactly like they always have.
+ */
+export function stringifyTemplate({ subject, body }: ParsedTemplate): string {
+  const cleanSubject = (subject || '').trim();
+  if (!cleanSubject) {
+    return body || '';
+  }
+  return `<meta name="subject" content="${escapeAttributeValue(cleanSubject)}"/>\n${body || ''}`;
+}

--- a/app/internal_packages/composer-templates/lib/template-picker.tsx
+++ b/app/internal_packages/composer-templates/lib/template-picker.tsx
@@ -33,10 +33,12 @@ class TemplatePopover extends React.Component<{ headerMessageId: string }> {
       return templates;
     }
 
+    // Match both lines shown in each item the same way, so typing a word from
+    // the middle of a name finds it just like a word from the middle of a subject.
     const query = searchValue.toLowerCase();
     return templates.filter((t) => {
       return (
-        t.name.toLowerCase().indexOf(query) === 0 || (t.subject || '').toLowerCase().includes(query)
+        t.name.toLowerCase().includes(query) || (t.subject || '').toLowerCase().includes(query)
       );
     });
   }

--- a/app/internal_packages/composer-templates/lib/template-picker.tsx
+++ b/app/internal_packages/composer-templates/lib/template-picker.tsx
@@ -33,8 +33,11 @@ class TemplatePopover extends React.Component<{ headerMessageId: string }> {
       return templates;
     }
 
+    const query = searchValue.toLowerCase();
     return templates.filter((t) => {
-      return t.name.toLowerCase().indexOf(searchValue.toLowerCase()) === 0;
+      return (
+        t.name.toLowerCase().indexOf(query) === 0 || (t.subject || '').toLowerCase().includes(query)
+      );
     });
   }
 
@@ -89,7 +92,12 @@ class TemplatePopover extends React.Component<{ headerMessageId: string }> {
         footerComponents={footerComponents}
         items={filteredTemplates}
         itemKey={(item) => item.id}
-        itemContent={(item) => item.name}
+        itemContent={(item) => (
+          <div className="template">
+            <div className="name">{item.name}</div>
+            {item.subject ? <div className="subject">{item.subject}</div> : null}
+          </div>
+        )}
         onSelect={this._onChooseTemplate}
       />
     );

--- a/app/internal_packages/composer-templates/lib/template-store.ts
+++ b/app/internal_packages/composer-templates/lib/template-store.ts
@@ -172,10 +172,14 @@ class TemplateStore extends MailspringStore {
     }
 
     // The draft's subject becomes both the template's name and its subject line,
-    // so using the template later fills the subject back in.
+    // so using the template later fills the subject back in. Not for a reply or
+    // a forward though - a "Re:" / "Fwd:" subject belongs to the thread the draft
+    // came from, and it's the one thing we'd refuse to apply on the way back out.
+    const isThreadSubject = !!draft.replyToHeaderMessageId || !!draft.forwardedHeaderMessageId;
+
     this.saveNewTemplate(
       draftName,
-      { subject: draftSubject, body: draftContents },
+      { subject: isThreadSubject ? '' : draftSubject, body: draftContents },
       this._onShowTemplates
     );
   }

--- a/app/internal_packages/composer-templates/lib/template-store.ts
+++ b/app/internal_packages/composer-templates/lib/template-store.ts
@@ -12,18 +12,21 @@ import MailspringStore from 'mailspring-store';
 import path from 'path';
 import fs from 'fs';
 
+import { parseTemplate, stringifyTemplate, ParsedTemplate } from './template-file';
+
 // Support accented characters in template names
 // https://regex101.com/r/nD3eY8/1
 const INVALID_TEMPLATE_NAME_REGEX = /[^a-zA-Z\u00C0-\u017F0-9_\- ]+/g;
 
-interface TemplateItem {
+export interface TemplateItem {
   id: string;
   name: string;
   path: string;
+  subject: string;
 }
 
 class TemplateStore extends MailspringStore {
-  private _items = [];
+  private _items: TemplateItem[] = [];
   private _templatesDir = path.join(AppEnv.getConfigDirPath(), 'templates');
   private _watcher = null;
 
@@ -82,57 +85,76 @@ class TemplateStore extends MailspringStore {
     return this._items;
   }
 
-  _populate() {
-    fs.readdir(this._templatesDir, (err, filenames) => {
-      if (err) {
-        AppEnv.showErrorDialog({
-          title: localized('Cannot scan templates directory'),
-          message: localized(
-            'Mailspring was unable to read the contents of your templates directory (%@). You may want to delete this folder or ensure filesystem permissions are set correctly.',
-            this._templatesDir
-          ),
-        });
-        return;
-      }
-      this._items = [];
-      for (let i = 0, filename; i < filenames.length; i++) {
-        filename = filenames[i];
-        if (filename[0] === '.') {
-          continue;
-        }
-        const displayname = path.basename(filename, path.extname(filename));
-        this._items.push({
-          id: filename,
-          name: displayname,
-          path: path.join(this._templatesDir, filename),
-        });
-      }
-      this.trigger(this);
-    });
+  async _populate() {
+    let filenames = [];
+    try {
+      filenames = await fs.promises.readdir(this._templatesDir);
+    } catch (err) {
+      AppEnv.showErrorDialog({
+        title: localized('Cannot scan templates directory'),
+        message: localized(
+          'Mailspring was unable to read the contents of your templates directory (%@). You may want to delete this folder or ensure filesystem permissions are set correctly.',
+          this._templatesDir
+        ),
+      });
+      return;
+    }
+
+    // Read each template so we know its subject line - they're small HTML files
+    // and we want to show / search subjects alongside template names.
+    this._items = await Promise.all(
+      filenames
+        .filter((filename) => filename[0] !== '.')
+        .map(async (filename) => {
+          const templatePath = path.join(this._templatesDir, filename);
+          let subject = '';
+          try {
+            subject = parseTemplate(await fs.promises.readFile(templatePath, 'utf8')).subject;
+          } catch (err) {
+            // an unreadable file or a subdirectory - list it without a subject
+          }
+          return {
+            id: filename,
+            name: path.basename(filename, path.extname(filename)),
+            path: templatePath,
+            subject,
+          };
+        })
+    );
+    this.trigger(this);
   }
 
   _onCreateTemplate({
     headerMessageId,
     name,
     contents,
-  }: { headerMessageId?: string; name?: string; contents?: string } = {}) {
+    subject,
+  }: {
+    headerMessageId?: string;
+    name?: string;
+    contents?: string;
+    subject?: string;
+  } = {}) {
     if (headerMessageId) {
       this._onCreateTemplateFromDraft(headerMessageId);
       return;
     }
     if (!name || name.length === 0) {
       this._displayError(localized('You must provide a name for your template.'));
+      return;
     }
     if (!contents || contents.length === 0) {
       this._displayError(localized('You must provide contents for your template.'));
+      return;
     }
-    this.saveNewTemplate(name, contents, this._onShowTemplates);
+    this.saveNewTemplate(name, { subject: subject || '', body: contents }, this._onShowTemplates);
   }
 
   async _onCreateTemplateFromDraft(headerMessageId: string) {
     const session = await DraftStore.sessionForClientId(headerMessageId);
     const draft = session.draft();
-    const draftName = draft.subject.replace(INVALID_TEMPLATE_NAME_REGEX, '');
+    const draftSubject = (draft.subject || '').trim();
+    const draftName = draftSubject.replace(INVALID_TEMPLATE_NAME_REGEX, '');
 
     let draftContents = QuotedHTMLTransformer.removeQuotedHTML(draft.body);
     const sigIndex = draftContents.search(RegExpUtils.mailspringSignatureRegex());
@@ -140,13 +162,22 @@ class TemplateStore extends MailspringStore {
 
     if (!draftName || draftName.length === 0) {
       this._displayError(localized('Give your draft a subject to name your template.'));
+      return;
     }
     if (!draftContents || draftContents.length === 0) {
       this._displayError(
         localized('To create a template you need to fill the body of the current draft.')
       );
+      return;
     }
-    this.saveNewTemplate(draftName, draftContents, this._onShowTemplates);
+
+    // The draft's subject becomes both the template's name and its subject line,
+    // so using the template later fills the subject back in.
+    this.saveNewTemplate(
+      draftName,
+      { subject: draftSubject, body: draftContents },
+      this._onShowTemplates
+    );
   }
 
   _onShowTemplates() {
@@ -170,7 +201,11 @@ class TemplateStore extends MailspringStore {
     );
   }
 
-  saveNewTemplate(name: string, contents: string, callback: (template: TemplateItem) => void) {
+  saveNewTemplate(
+    name: string,
+    template: ParsedTemplate,
+    callback: (template: TemplateItem) => void
+  ) {
     if (!name || name.length === 0) {
       this._displayError(localized('You must provide a template name.'));
       return;
@@ -192,17 +227,21 @@ class TemplateStore extends MailspringStore {
       resolvedName = `${name} ${number}`;
       number += 1;
     }
-    this.saveTemplate(resolvedName, contents, callback);
+    this.saveTemplate(resolvedName, template, callback);
     this.trigger(this);
   }
 
-  saveTemplate(name: string, contents: string, callback: (template: TemplateItem) => void) {
+  saveTemplate(
+    name: string,
+    { subject, body }: ParsedTemplate,
+    callback: (template: TemplateItem) => void
+  ) {
     const filename = `${name}.html`;
     const templatePath = path.join(this._templatesDir, filename);
     let template = this._items.find((t) => t.name === name);
 
     this.unwatch();
-    fs.writeFile(templatePath, contents, (err) => {
+    fs.writeFile(templatePath, stringifyTemplate({ subject, body }), (err) => {
       this.watch();
       if (err) {
         this._displayError(err.message);
@@ -212,8 +251,11 @@ class TemplateStore extends MailspringStore {
           id: filename,
           name: name,
           path: templatePath,
+          subject: (subject || '').trim(),
         };
         this._items.unshift(template);
+      } else {
+        template.subject = (subject || '').trim();
       }
       if (callback) {
         callback(template);
@@ -275,22 +317,45 @@ class TemplateStore extends MailspringStore {
     headerMessageId,
   }: { templateId?: string; headerMessageId?: string } = {}) {
     const template = this._items.find((t) => t.id === templateId);
-    const templateBody = fs.readFileSync(template.path).toString();
+    const { subject: templateSubject, body: templateBody } = parseTemplate(
+      fs.readFileSync(template.path).toString()
+    );
     const session = await DraftStore.sessionForClientId(headerMessageId);
+    const draft = session.draft();
+
+    // Never touch the subject of a reply - it's tied to the thread the user is
+    // replying to (and the composer doesn't even show the field.)
+    const canApplySubject = !!templateSubject && !draft.replyToHeaderMessageId;
+    const draftSubject = (draft.subject || '').trim();
+
+    const bodyWouldBeReplaced = !draft.pristine && !draft.hasEmptyBody();
+    const subjectWouldBeReplaced =
+      canApplySubject && draftSubject.length > 0 && draftSubject !== templateSubject;
 
     let proceed = true;
-    if (!session.draft().pristine && !session.draft().hasEmptyBody()) {
-      proceed = this._displayDialog(
-        localized('Replace draft contents?'),
-        localized(
+    if (bodyWouldBeReplaced || subjectWouldBeReplaced) {
+      let message;
+      if (bodyWouldBeReplaced && subjectWouldBeReplaced) {
+        message = localized(
+          'It looks like your draft already has a subject and some content. Loading this template will overwrite the subject line and all draft contents.'
+        );
+      } else if (subjectWouldBeReplaced) {
+        message = localized(
+          'It looks like your draft already has a subject. Loading this template will replace it.'
+        );
+      } else {
+        message = localized(
           'It looks like your draft already has some content. Loading this template will overwrite all draft contents.'
-        ),
-        [localized('Replace contents'), localized('Cancel')]
-      );
+        );
+      }
+      proceed = this._displayDialog(localized('Replace draft contents?'), message, [
+        localized('Replace contents'),
+        localized('Cancel'),
+      ]);
     }
 
     if (proceed) {
-      const current = session.draft().body;
+      const current = draft.body;
       let insertion = current.length;
       for (const s of [
         '<signature',
@@ -302,7 +367,13 @@ class TemplateStore extends MailspringStore {
           insertion = Math.min(insertion, i);
         }
       }
-      session.changes.add({ body: `${templateBody}${current.substr(insertion)}` });
+      const changes: { body: string; subject?: string } = {
+        body: `${templateBody}${current.substr(insertion)}`,
+      };
+      if (canApplySubject) {
+        changes.subject = templateSubject;
+      }
+      session.changes.add(changes);
     }
   }
 

--- a/app/internal_packages/composer-templates/lib/template-store.ts
+++ b/app/internal_packages/composer-templates/lib/template-store.ts
@@ -323,9 +323,11 @@ class TemplateStore extends MailspringStore {
     const session = await DraftStore.sessionForClientId(headerMessageId);
     const draft = session.draft();
 
-    // Never touch the subject of a reply - it's tied to the thread the user is
-    // replying to (and the composer doesn't even show the field.)
-    const canApplySubject = !!templateSubject && !draft.replyToHeaderMessageId;
+    // Never touch the subject of a reply or a forward - the "Re:" / "Fwd:" prefix
+    // and the original subject tie the message to the thread it came from. (The
+    // composer doesn't even show the subject field when you're replying.)
+    const canApplySubject =
+      !!templateSubject && !draft.replyToHeaderMessageId && !draft.forwardedHeaderMessageId;
     const draftSubject = (draft.subject || '').trim();
 
     const bodyWouldBeReplaced = !draft.pristine && !draft.hasEmptyBody();

--- a/app/internal_packages/composer-templates/lib/template-store.ts
+++ b/app/internal_packages/composer-templates/lib/template-store.ts
@@ -340,24 +340,13 @@ class TemplateStore extends MailspringStore {
 
     let proceed = true;
     if (bodyWouldBeReplaced || subjectWouldBeReplaced) {
-      let message;
-      if (bodyWouldBeReplaced && subjectWouldBeReplaced) {
-        message = localized(
-          'It looks like your draft already has a subject and some content. Loading this template will overwrite the subject line and all draft contents.'
-        );
-      } else if (subjectWouldBeReplaced) {
-        message = localized(
-          'It looks like your draft already has a subject. Loading this template will replace it.'
-        );
-      } else {
-        message = localized(
+      proceed = this._displayDialog(
+        localized('Replace draft contents?'),
+        localized(
           'It looks like your draft already has some content. Loading this template will overwrite all draft contents.'
-        );
-      }
-      proceed = this._displayDialog(localized('Replace draft contents?'), message, [
-        localized('Replace contents'),
-        localized('Cancel'),
-      ]);
+        ),
+        [localized('Replace contents'), localized('Cancel')]
+      );
     }
 
     if (proceed) {

--- a/app/internal_packages/composer-templates/specs/template-file-spec.ts
+++ b/app/internal_packages/composer-templates/specs/template-file-spec.ts
@@ -1,0 +1,67 @@
+import { parseTemplate, stringifyTemplate } from '../lib/template-file';
+
+describe('template-file', function templateFile() {
+  describe('parseTemplate', () => {
+    it('returns an empty subject for templates without a meta tag', () => {
+      const body = '<div>Hello world</div>';
+      expect(parseTemplate(body)).toEqual({ subject: '', body });
+    });
+
+    it('returns an empty subject and body for empty contents', () => {
+      expect(parseTemplate('')).toEqual({ subject: '', body: '' });
+      expect(parseTemplate(undefined)).toEqual({ subject: '', body: '' });
+    });
+
+    it('extracts the subject and strips the meta tag from the body', () => {
+      const { subject, body } = parseTemplate(
+        '<meta name="subject" content="Following up"/>\n<div>Hello world</div>'
+      );
+      expect(subject).toBe('Following up');
+      expect(body).toBe('<div>Hello world</div>');
+    });
+
+    it('accepts single quotes, no quotes around the name and no self-closing slash', () => {
+      const { subject, body } = parseTemplate(
+        "<meta name=subject content='Following up'><div>Hello</div>"
+      );
+      expect(subject).toBe('Following up');
+      expect(body).toBe('<div>Hello</div>');
+    });
+
+    it('unescapes entities in the subject', () => {
+      const { subject } = parseTemplate(
+        '<meta name="subject" content="Ben &amp; Jerry&#39;s &quot;best&quot; &lt;flavors&gt;"/>'
+      );
+      expect(subject).toBe('Ben & Jerry\'s "best" <flavors>');
+    });
+
+    it('does not treat a meta tag in the middle of the body as the subject', () => {
+      const body = '<div>Hi</div><meta name="subject" content="Nope"/>';
+      expect(parseTemplate(body)).toEqual({ subject: '', body });
+    });
+  });
+
+  describe('stringifyTemplate', () => {
+    it('writes the body unchanged when there is no subject', () => {
+      expect(stringifyTemplate({ subject: '', body: '<div>Hi</div>' })).toBe('<div>Hi</div>');
+      expect(stringifyTemplate({ subject: '   ', body: '<div>Hi</div>' })).toBe('<div>Hi</div>');
+    });
+
+    it('prepends a meta tag when there is a subject', () => {
+      expect(stringifyTemplate({ subject: 'Following up', body: '<div>Hi</div>' })).toBe(
+        '<meta name="subject" content="Following up"/>\n<div>Hi</div>'
+      );
+    });
+
+    it('escapes entities in the subject', () => {
+      expect(stringifyTemplate({ subject: 'Ben & Jerry\'s "best"', body: '' })).toBe(
+        '<meta name="subject" content="Ben &amp; Jerry\'s &quot;best&quot;"/>\n'
+      );
+    });
+
+    it('round-trips subjects containing markup and quotes', () => {
+      const template = { subject: 'A <b>bold</b> & "quoted" subject', body: '<div>Hi</div>' };
+      expect(parseTemplate(stringifyTemplate(template))).toEqual(template);
+    });
+  });
+});

--- a/app/internal_packages/composer-templates/specs/template-store-spec.ts
+++ b/app/internal_packages/composer-templates/specs/template-store-spec.ts
@@ -90,4 +90,45 @@ describe('TemplateStore', function templateStore() {
       expect(changes.body).toBe('<div>Hey!</div><signature>Ben</signature>');
     });
   });
+
+  describe('creating a template from a draft', () => {
+    const createFromDraft = async (draftProps) => {
+      const draft = new Message({
+        draft: true,
+        subject: '',
+        body: '<div>Hey there!</div>',
+        ...draftProps,
+      });
+      spyOn(DraftStore, 'sessionForClientId').andReturn(Promise.resolve({ draft: () => draft }));
+      spyOn(TemplateStore as any, 'saveNewTemplate');
+      await (TemplateStore as any)._onCreateTemplateFromDraft('draft-1');
+      const spy = (TemplateStore as any).saveNewTemplate;
+      return spy.calls.length
+        ? { name: spy.mostRecentCall.args[0], ...spy.mostRecentCall.args[1] }
+        : null;
+    };
+
+    it("keeps the draft's subject as the template subject", async () => {
+      const saved = await createFromDraft({ subject: 'Following up on our call' });
+      expect(saved.name).toBe('Following up on our call');
+      expect(saved.subject).toBe('Following up on our call');
+    });
+
+    it('does not carry over the subject of a reply', async () => {
+      const saved = await createFromDraft({
+        subject: 'Re: Lunch tomorrow',
+        replyToHeaderMessageId: 'other-message',
+      });
+      expect(saved.name).toBe('Re Lunch tomorrow');
+      expect(saved.subject).toBe('');
+    });
+
+    it('does not carry over the subject of a forward', async () => {
+      const saved = await createFromDraft({
+        subject: 'Fwd: Q3 numbers',
+        forwardedHeaderMessageId: 'other-message',
+      });
+      expect(saved.subject).toBe('');
+    });
+  });
 });

--- a/app/internal_packages/composer-templates/specs/template-store-spec.ts
+++ b/app/internal_packages/composer-templates/specs/template-store-spec.ts
@@ -55,6 +55,15 @@ describe('TemplateStore', function templateStore() {
       expect((TemplateStore as any)._displayDialog).not.toHaveBeenCalled();
     });
 
+    it('never replaces the subject of a forward', async () => {
+      const changes = await insert({
+        subject: 'Fwd: Lunch tomorrow',
+        forwardedHeaderMessageId: 'other-message',
+      });
+      expect(changes.subject).toBe(undefined);
+      expect((TemplateStore as any)._displayDialog).not.toHaveBeenCalled();
+    });
+
     it('asks before replacing a subject the draft already has', async () => {
       const changes = await insert({ subject: 'Lunch tomorrow' });
       expect((TemplateStore as any)._displayDialog).toHaveBeenCalled();

--- a/app/internal_packages/composer-templates/specs/template-store-spec.ts
+++ b/app/internal_packages/composer-templates/specs/template-store-spec.ts
@@ -1,0 +1,84 @@
+import fs from 'fs';
+import { DraftStore, Message } from 'mailspring-exports';
+import TemplateStore from '../lib/template-store';
+
+const TEMPLATE = {
+  id: 'Follow Up.html',
+  name: 'Follow Up',
+  path: '/tmp/templates/Follow Up.html',
+  subject: 'Following up on our call',
+};
+
+const TEMPLATE_FILE = `<meta name="subject" content="Following up on our call"/>\n<div>Hey!</div>`;
+
+describe('TemplateStore', function templateStore() {
+  describe('inserting a template into a draft', () => {
+    let session = null;
+    let draft = null;
+
+    const insert = async (draftProps, fileContents = TEMPLATE_FILE) => {
+      draft = new Message({ draft: true, pristine: true, subject: '', body: '', ...draftProps });
+      session = { draft: () => draft, changes: { add: jasmine.createSpy('add') } };
+      spyOn(fs, 'readFileSync').andReturn(fileContents);
+      spyOn(DraftStore, 'sessionForClientId').andReturn(Promise.resolve(session));
+      await (TemplateStore as any)._onInsertTemplateId({
+        templateId: TEMPLATE.id,
+        headerMessageId: 'draft-1',
+      });
+      return session.changes.add.calls.length ? session.changes.add.mostRecentCall.args[0] : null;
+    };
+
+    beforeEach(() => {
+      (TemplateStore as any)._items = [TEMPLATE];
+      spyOn(TemplateStore as any, '_displayDialog').andReturn(true);
+    });
+
+    it("fills in the draft's subject and body when the draft has no subject", async () => {
+      const changes = await insert({});
+      expect(changes.subject).toBe('Following up on our call');
+      expect(changes.body).toBe('<div>Hey!</div>');
+      expect((TemplateStore as any)._displayDialog).not.toHaveBeenCalled();
+    });
+
+    it('leaves the subject alone when the template does not have one', async () => {
+      const changes = await insert({}, '<div>Hey!</div>');
+      expect(changes.subject).toBe(undefined);
+      expect(changes.body).toBe('<div>Hey!</div>');
+    });
+
+    it('never replaces the subject of a reply', async () => {
+      const changes = await insert({
+        subject: 'Re: Lunch tomorrow',
+        replyToHeaderMessageId: 'other-message',
+      });
+      expect(changes.subject).toBe(undefined);
+      expect((TemplateStore as any)._displayDialog).not.toHaveBeenCalled();
+    });
+
+    it('asks before replacing a subject the draft already has', async () => {
+      const changes = await insert({ subject: 'Lunch tomorrow' });
+      expect((TemplateStore as any)._displayDialog).toHaveBeenCalled();
+      expect(changes.subject).toBe('Following up on our call');
+    });
+
+    it('does not ask when the draft subject already matches the template', async () => {
+      const changes = await insert({ subject: 'Following up on our call' });
+      expect((TemplateStore as any)._displayDialog).not.toHaveBeenCalled();
+      expect(changes.subject).toBe('Following up on our call');
+    });
+
+    it('makes no changes when the user cancels the replacement', async () => {
+      (TemplateStore as any)._displayDialog.andReturn(false);
+      const changes = await insert({ subject: 'Lunch tomorrow' });
+      expect(changes).toBe(null);
+    });
+
+    it('inserts the body above the signature and quoted text', async () => {
+      const changes = await insert({
+        body: '<div>draft</div><signature>Ben</signature>',
+        pristine: false,
+      });
+      expect(changes.body).toBe('<div>Hey!</div><signature>Ben</signature>');
+    });
+  });
+});

--- a/app/internal_packages/composer-templates/styles/message-templates.less
+++ b/app/internal_packages/composer-templates/styles/message-templates.less
@@ -5,12 +5,26 @@
 
 .template-picker {
   .content-container {
-    height: 150px;
-    width: 210px;
+    height: 190px;
+    width: 260px;
     overflow-y: scroll;
   }
   .footer-container {
     border-top: 1px solid @border-color-secondary;
+  }
+  .template {
+    .name {
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    .subject {
+      font-size: @font-size-small;
+      opacity: 0.65;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
   }
 }
 
@@ -82,6 +96,23 @@
 
     .section {
       margin-bottom: 10px;
+      &.fields {
+        display: flex;
+
+        .field {
+          display: flex;
+          &.name {
+            flex: 0 1 240px;
+            margin-right: 6px;
+          }
+          &.subject {
+            flex: 1 1 auto;
+          }
+          input {
+            width: 100%;
+          }
+        }
+      }
       &.editor {
         display: flex;
         flex: 1;

--- a/docs/creating-composer-plugins.md
+++ b/docs/creating-composer-plugins.md
@@ -919,8 +919,8 @@ The templates plugin is the most complete example. It uses all three plugin syst
 
 **Template insertion flow**:
 1. User clicks template picker button → `Actions.insertTemplateId()`
-2. `TemplateStore` reads template HTML from disk
-3. Template HTML is inserted via `session.changes.add({ body: templateHTML + existingContent })`
+2. `TemplateStore` reads template HTML from disk and splits off the optional subject line, which is stored in a `<meta name="subject">` tag at the top of the file (see `template-file.ts`)
+3. Template HTML is inserted via `session.changes.add({ body: templateHTML + existingContent, subject })` — the subject is only included when the template has one and the draft is not a reply
 4. The body setter converts HTML to Slate value, finding `<span data-tvar>` elements and creating `templatevar` inline nodes via the deserialization rules
 5. `TemplateStatusBar` detects the variables and shows the "Press tab" hint
 

--- a/docs/creating-composer-plugins.md
+++ b/docs/creating-composer-plugins.md
@@ -920,7 +920,7 @@ The templates plugin is the most complete example. It uses all three plugin syst
 **Template insertion flow**:
 1. User clicks template picker button → `Actions.insertTemplateId()`
 2. `TemplateStore` reads template HTML from disk and splits off the optional subject line, which is stored in a `<meta name="subject">` tag at the top of the file (see `template-file.ts`)
-3. Template HTML is inserted via `session.changes.add({ body: templateHTML + existingContent, subject })` — the subject is only included when the template has one and the draft is not a reply
+3. Template HTML is inserted via `session.changes.add({ body: templateHTML + existingContent, subject })` — the subject is only included when the template has one and the draft is not a reply or forward
 4. The body setter converts HTML to Slate value, finding `<span data-tvar>` elements and creating `templatevar` inline nodes via the deserialization rules
 5. `TemplateStatusBar` detects the variables and shows the "Press tab" hint
 

--- a/playwright/tests/preferences-data.spec.ts
+++ b/playwright/tests/preferences-data.spec.ts
@@ -127,6 +127,31 @@ test('creating a template persists it as an HTML file and renaming updates the f
   await expect(renamedItem).toBeVisible({ timeout: 3_000 });
 });
 
+test("a template's subject line is saved into the template file", async () => {
+  const templatesContainer = mainWindow.locator('.preferences-templates-container');
+  await expect(templatesContainer).toBeVisible({ timeout: 3_000 });
+
+  // The template renamed above is still selected - give it a subject line.
+  const subjectInput = templatesContainer.locator('#template-subject');
+  await expect(subjectInput).toBeVisible({ timeout: 3_000 });
+  await subjectInput.fill('Following up on our call');
+
+  // The editor saves on blur.
+  await subjectInput.press('Tab');
+
+  const templatePath = path.join(configDir, 'templates', 'My Test Template.html');
+  const deadline = Date.now() + 5_000;
+  let contents = '';
+  while (Date.now() < deadline) {
+    contents = fs.readFileSync(templatePath, 'utf-8');
+    if (contents.includes('name="subject"')) {
+      break;
+    }
+    await mainWindow.waitForTimeout(300);
+  }
+  expect(contents).toContain('<meta name="subject" content="Following up on our call"/>');
+});
+
 // --- Mail Rules ---
 
 test('creating a mail rule persists it to localStorage', async () => {


### PR DESCRIPTION
## Summary

Templates only covered the message body, so anyone reusing one had to retype the subject line every time — the most repetitive part of sending the same email over and over. A template can now carry a subject line, which is filled into your draft when you insert the template.

A template file with a subject looks like this:

```html
<meta name="subject" content="Following up on our call"/>
<div>Hey there!</div>
```

## Key Changes

- **New `template-file.ts` module**: parses and serializes template files with subject metadata
  - `parseTemplate()` pulls the subject out of the leading meta tag and returns it separately from the body
  - `stringifyTemplate()` writes subject and body back out, omitting the meta tag entirely when there is no subject
  - Handles HTML entity escaping/unescaping in subject lines
  - Backward compatible: templates without the meta tag parse to an empty subject and behave exactly as before

- **Enhanced `TemplateItem` interface**: added a `subject` field

- **Updated template storage and retrieval**:
  - `_populate()` reads each template file to pick up its subject (async/await refactor)
  - `saveNewTemplate()` and `saveTemplate()` take `ParsedTemplate` objects with subject and body

- **One rule for thread-bound subjects, applied in both directions.** A `Re:` / `Fwd:` subject belongs to the thread the draft came from, so it is never carried into a template and never applied out of one. Both paths test `!draft.replyToHeaderMessageId && !draft.forwardedHeaderMessageId`:
  - Inserting a template applies its subject only when the template has one and the draft is neither a reply nor a forward
  - "Save Draft as Template" saves the draft's subject only under the same condition — the subject still names the template either way

- **Subject application in `_onInsertTemplateId()`**:
  - Filled in silently when the draft has no subject yet
  - Asks before replacing a subject the user already typed, and doesn't ask when it already matches, reusing the existing "Replace draft contents?" dialog copy

- **UI in preferences**:
  - Template editor has a Subject field beside the Name field, optional, saved on blur

- **Template picker**:
  - Two-line items showing each template's subject under its name, dimmed to distinguish it
  - Search matches names and subjects the same way (substring on both)
  - Popup widened to fit the second line

- **Test coverage**:
  - `template-file-spec.ts`: parsing/serialization across meta tag formats, entity escaping, and round-tripping
  - `template-store-spec.ts`: the insert decision matrix (empty subject, no template subject, reply, forward, confirm, cancel, body insertion above signature/quoted text) and the create-from-draft rules
  - A Playwright regression test that a subject typed in preferences persists to the template file

- **Documentation**: README and `docs/creating-composer-plugins.md` updated; the bundled English and French welcome templates now carry subjects to demo the feature

## Implementation Details

- The subject meta tag goes at the very start of the template HTML, so a template stays a single hand-editable file rather than needing a sidecar
- Entity escaping keeps quotes and markup in a subject from breaking the attribute
- Template files remain plain HTML, so they're still easy to share and edit by hand
- Async file operations use `fs.promises`

https://claude.ai/code/session_01S6tHJb3ZDFgeE5YQHC5xTo