### PR TITLE
Fix pasted text colors and Windows line spacing

### DIFF
--- a/app/spec/components/composer-editor/conversion-spec.tsx
+++ b/app/spec/components/composer-editor/conversion-spec.tsx
@@ -15,8 +15,34 @@ describe('Composer HTML conversion', () => {
       '<ol><li><span style="color: rgb(236, 236, 241)">Visible text</span></li></ol>'
     );
 
-    expect(convertToHTML(value)).not.toContain('color');
+    expect(convertToHTML(value)).not.toContain('rgb(236, 236, 241)');
     expect(convertToPlainText(value)).toContain('Visible text');
+  });
+
+  it('drops a near-white source text color without discarding the source font family', () => {
+    const value = convertFromHTML(
+      '<span style="color: rgb(240, 239, 236)">' +
+        '<font style="font-family: Example-Sans, system-ui, sans-serif">Visible text</font>' +
+        '</span>'
+    );
+    const html = convertToHTML(value);
+
+    expect(html).not.toContain('rgb(240, 239, 236)');
+    expect(html).toContain('Example-Sans');
+    expect(convertToPlainText(value)).toContain('Visible text');
+  });
+
+  it('drops near-black source text colors', () => {
+    const value = convertFromHTML('<span style="color: #1f1f1f">Dark text</span>');
+
+    expect(convertToHTML(value)).not.toContain('rgb(31, 31, 31)');
+    expect(convertToPlainText(value)).toContain('Dark text');
+  });
+
+  it('preserves a neutral color just outside the near-black threshold', () => {
+    const value = convertFromHTML('<span style="color: #222222">Dark text</span>');
+
+    expect(convertToHTML(value)).toContain('rgb(34, 34, 34)');
   });
 
   it('preserves intentional non-neutral text colors', () => {
@@ -25,12 +51,20 @@ describe('Composer HTML conversion', () => {
     expect(convertToHTML(value)).toContain('rgb(200, 20, 20)');
   });
 
-  it('preserves newlines represented by white-space: pre-wrap', () => {
+  it('classifies rgba source colors from their RGB channels, ignoring alpha', () => {
     const value = convertFromHTML(
-      '<div style="white-space: pre-wrap">First line\nSecond line</div>'
+      '<span style="color: rgba(255, 255, 255, 0.5)">Faded text</span>'
     );
 
-    expect(convertToPlainText(value)).toBe('First line\nSecond line');
+    expect(convertToHTML(value)).not.toContain('rgba(255, 255, 255, 0.5)');
+    expect(convertToPlainText(value)).toContain('Faded text');
+  });
+
+  it('drops transparent source text colors rather than sending invisible text', () => {
+    const value = convertFromHTML('<span style="color: transparent">Hidden text</span>');
+
+    expect(convertToHTML(value)).not.toContain('rgba(0, 0, 0, 0)');
+    expect(convertToPlainText(value)).toContain('Hidden text');
   });
 
   it('normalizes Windows line endings before plain-text paste', () => {

--- a/app/spec/components/composer-editor/conversion-spec.tsx
+++ b/app/spec/components/composer-editor/conversion-spec.tsx
@@ -1,8 +1,13 @@
+import { Value } from 'slate';
 import {
   convertFromHTML,
   convertToHTML,
   convertToPlainText,
 } from '../../../src/components/composer-editor/conversion';
+import {
+  ComposerEditor,
+  normalizePlainTextForPaste,
+} from '../../../src/components/composer-editor/composer-editor';
 
 describe('Composer HTML conversion', () => {
   it('drops near-white source text colors that would be unreadable on a light email background', () => {
@@ -26,5 +31,38 @@ describe('Composer HTML conversion', () => {
     );
 
     expect(convertToPlainText(value)).toBe('First line\nSecond line');
+  });
+
+  it('normalizes Windows line endings before plain-text paste', () => {
+    expect(normalizePlainTextForPaste('First\r\n\r\nSecond')).toBe('First\n\nSecond');
+  });
+
+  it('does not serialize blank lines pasted from Windows as non-breaking-space blocks', () => {
+    const initialValue = convertFromHTML('<div>Existing</div>');
+    const insertFragment = jasmine.createSpy('insertFragment');
+    const preventDefault = jasmine.createSpy('preventDefault');
+    const next = jasmine.createSpy('next');
+    const editor = {
+      value: initialValue,
+      isVoid: () => false,
+      insertFragment,
+    } as any;
+    const event = {
+      clipboardData: {
+        types: ['text/plain'],
+        items: [],
+        getData: (type: string) => (type === 'text/plain' ? 'First\r\n\r\nSecond' : ''),
+      },
+      preventDefault,
+    } as any;
+    const component = new ComposerEditor({ onFileReceived: null } as any);
+
+    component.onPaste(event, editor, next);
+
+    const pasted = Value.create({ document: insertFragment.calls[0].args[0] });
+    expect(convertToPlainText(pasted)).toBe('First\n\nSecond');
+    expect(convertToHTML(pasted)).not.toContain('&nbsp;');
+    expect(preventDefault).toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
   });
 });

--- a/app/spec/components/composer-editor/conversion-spec.tsx
+++ b/app/spec/components/composer-editor/conversion-spec.tsx
@@ -1,0 +1,30 @@
+import {
+  convertFromHTML,
+  convertToHTML,
+  convertToPlainText,
+} from '../../../src/components/composer-editor/conversion';
+
+describe('Composer HTML conversion', () => {
+  it('drops near-white source text colors that would be unreadable on a light email background', () => {
+    const value = convertFromHTML(
+      '<ol><li><span style="color: rgb(236, 236, 241)">Visible text</span></li></ol>'
+    );
+
+    expect(convertToHTML(value)).not.toContain('color');
+    expect(convertToPlainText(value)).toContain('Visible text');
+  });
+
+  it('preserves intentional non-neutral text colors', () => {
+    const value = convertFromHTML('<span style="color: rgb(200, 20, 20)">Red text</span>');
+
+    expect(convertToHTML(value)).toContain('rgb(200, 20, 20)');
+  });
+
+  it('preserves newlines represented by white-space: pre-wrap', () => {
+    const value = convertFromHTML(
+      '<div style="white-space: pre-wrap">First line\nSecond line</div>'
+    );
+
+    expect(convertToPlainText(value)).toBe('First line\nSecond line');
+  });
+});

--- a/app/src/components/composer-editor/base-mark-plugins.tsx
+++ b/app/src/components/composer-editor/base-mark-plugins.tsx
@@ -65,9 +65,10 @@ function isNeutralDefaultColor(color: string) {
 
   // Near-black and near-white colors are commonly the source page's default text
   // color. Preserving them when pasting from a page using the opposite color scheme
-  // can make the sent email unreadable (for example white ChatGPT text on Gmail's
-  // white message background). Mailspring does not preserve source backgrounds, so
-  // these colors cannot be safely treated as intentional formatting.
+  // can make the sent email unreadable (for example near-white text copied from a
+  // dark-themed web app, landing on a light message background). Mailspring does not
+  // preserve source backgrounds, so these colors cannot be safely treated as
+  // intentional formatting.
   return isNeutral && (lightest <= 32 || darkest >= 223);
 }
 

--- a/app/src/components/composer-editor/base-mark-plugins.tsx
+++ b/app/src/components/composer-editor/base-mark-plugins.tsx
@@ -37,11 +37,44 @@ const PT_TO_SIZE = [0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 3, 4, 4, 5, 5, 5, 5, 5, 
 
 let plugins = null;
 
+function isNeutralDefaultColor(color: string) {
+  const normalized = color.toLowerCase().replace(/\s/g, '');
+
+  if (['black', 'white', 'transparent'].includes(normalized)) return true;
+
+  const shortHex = normalized.match(/^#([0-9a-f])([0-9a-f])([0-9a-f])$/i);
+  const longHex = normalized.match(/^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i);
+  const rgb = normalized.match(
+    /^rgba?\((\d+(?:\.\d+)?),(\d+(?:\.\d+)?),(\d+(?:\.\d+)?)(?:,[^)]+)?\)$/i
+  );
+
+  let channels: number[] = null;
+  if (shortHex) {
+    channels = shortHex.slice(1).map((channel) => parseInt(channel + channel, 16));
+  } else if (longHex) {
+    channels = longHex.slice(1).map((channel) => parseInt(channel, 16));
+  } else if (rgb) {
+    channels = rgb.slice(1, 4).map(Number);
+  }
+
+  if (!channels) return false;
+
+  const darkest = Math.min(...channels);
+  const lightest = Math.max(...channels);
+  const isNeutral = lightest - darkest <= 12;
+
+  // Near-black and near-white colors are commonly the source page's default text
+  // color. Preserving them when pasting from a page using the opposite color scheme
+  // can make the sent email unreadable (for example white ChatGPT text on Gmail's
+  // white message background). Mailspring does not preserve source backgrounds, so
+  // these colors cannot be safely treated as intentional formatting.
+  return isNeutral && (lightest <= 32 || darkest >= 223);
+}
+
 function isMeaningfulColor(color: string, el: HTMLElement) {
   if (!color) return false;
 
-  const meaningless = ['black', 'rgb(0,0,0)', 'rgba(0,0,0,1)', '#000', '#000000'];
-  if (meaningless.includes(color.replace(/ /g, ''))) return false;
+  if (isNeutralDefaultColor(color)) return false;
 
   const isOwnHTML = (el.style.fontFamily || '').includes('Nylas-Pro');
   if (isOwnHTML && color === AppEnv.themes.getEmailTextColor()) return false;

--- a/app/src/components/composer-editor/composer-editor.tsx
+++ b/app/src/components/composer-editor/composer-editor.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom';
 import * as Immutable from 'immutable';
 import { Editor, Value, Operation, Range, Block, Text, Point } from 'slate';
 import { Editor as SlateEditorComponent, EditorProps, Plugin } from 'slate-react';
+import Plain from 'slate-plain-serializer';
 import { clipboard as ElectronClipboard } from 'electron';
 import { InlineStyleTransformer, SanitizeTransformer } from 'mailspring-exports';
 import os from 'os';
@@ -69,6 +70,10 @@ function isSelectionBroken(value: Value, operations: Immutable.List<Operation>):
 const AEditor = SlateEditorComponent as any as React.ComponentType<
   EditorProps & { ref: any; propsForPlugins: any }
 >;
+
+export function normalizePlainTextForPaste(text: string) {
+  return text.replace(/\r\n?/g, '\n');
+}
 
 interface ComposerEditorProps {
   value: Value;
@@ -300,7 +305,29 @@ export class ComposerEditor extends React.Component<ComposerEditorProps, Compose
       }
     }
 
-    // fall back to Slate's default behavior
+    // Slate's plain-text paste handler splits on `\n` without first normalizing Windows
+    // CRLF line endings. This leaves a stray `\r` in every block; a blank line becomes a
+    // block containing only `\r`, which our HTML serializer later emits as `&nbsp;`.
+    // Handle plain text here so the editor model, composer preview, and sent HTML all
+    // represent blank lines the same way.
+    const text = event.clipboardData.getData('text/plain');
+    if (text) {
+      const { document, selection, startBlock } = editor.value;
+      // Slate's runtime Editor includes isVoid, but the version's public TypeScript
+      // declaration omits it.
+      if (!startBlock || (editor as any).isVoid(startBlock)) return next();
+
+      const fragment = Plain.deserialize(normalizePlainTextForPaste(text), {
+        defaultBlock: startBlock as any,
+        defaultMarks: document.getInsertMarksAtRange(selection as any) as any,
+      }).document;
+
+      editor.insertFragment(fragment);
+      event.preventDefault();
+      return;
+    }
+
+    // Fall back to Slate for clipboard types we do not handle.
     return next();
   };
 

--- a/app/src/components/composer-editor/conversion.tsx
+++ b/app/src/components/composer-editor/conversion.tsx
@@ -85,41 +85,6 @@ function parseHtml(html: string) {
   const parsed = new DOMParser().parseFromString(html, 'text/html');
   const tree = parsed.body;
 
-  // Some web apps render copied plain text with CSS `white-space` rather than
-  // actual <br> elements. Convert those significant newlines before the general
-  // whitespace cleanup below, which intentionally collapses ordinary HTML
-  // whitespace. This is common when copying responses from AI chat applications.
-  const textWalker = document.createTreeWalker(tree, NodeFilter.SHOW_TEXT);
-  const newlineTextNodes: Text[] = [];
-  while (textWalker.nextNode()) {
-    const text = textWalker.currentNode as Text;
-    if (!/[\r\n]/.test(text.data)) continue;
-
-    let el = text.parentElement;
-    let whiteSpace = '';
-    while (el && el !== tree) {
-      if (el.style.whiteSpace) {
-        whiteSpace = el.style.whiteSpace;
-        break;
-      }
-      el = el.parentElement;
-    }
-
-    if (['pre', 'pre-line', 'pre-wrap', 'break-spaces'].includes(whiteSpace)) {
-      newlineTextNodes.push(text);
-    }
-  }
-
-  newlineTextNodes.forEach((text) => {
-    const lines = text.data.replace(/\r\n?/g, '\n').split('\n');
-    const fragment = document.createDocumentFragment();
-    lines.forEach((line, idx) => {
-      if (idx > 0) fragment.appendChild(document.createElement('br'));
-      fragment.appendChild(document.createTextNode(line));
-    });
-    text.parentNode.replaceChild(fragment, text);
-  });
-
   // whitespace /between/ HTML nodes really confuses the parser because
   // it doesn't know these `text` elements are meaningless. Strip them all.
   const collapse = require('collapse-whitespace');

--- a/app/src/components/composer-editor/conversion.tsx
+++ b/app/src/components/composer-editor/conversion.tsx
@@ -85,6 +85,41 @@ function parseHtml(html: string) {
   const parsed = new DOMParser().parseFromString(html, 'text/html');
   const tree = parsed.body;
 
+  // Some web apps render copied plain text with CSS `white-space` rather than
+  // actual <br> elements. Convert those significant newlines before the general
+  // whitespace cleanup below, which intentionally collapses ordinary HTML
+  // whitespace. This is common when copying responses from AI chat applications.
+  const textWalker = document.createTreeWalker(tree, NodeFilter.SHOW_TEXT);
+  const newlineTextNodes: Text[] = [];
+  while (textWalker.nextNode()) {
+    const text = textWalker.currentNode as Text;
+    if (!/[\r\n]/.test(text.data)) continue;
+
+    let el = text.parentElement;
+    let whiteSpace = '';
+    while (el && el !== tree) {
+      if (el.style.whiteSpace) {
+        whiteSpace = el.style.whiteSpace;
+        break;
+      }
+      el = el.parentElement;
+    }
+
+    if (['pre', 'pre-line', 'pre-wrap', 'break-spaces'].includes(whiteSpace)) {
+      newlineTextNodes.push(text);
+    }
+  }
+
+  newlineTextNodes.forEach((text) => {
+    const lines = text.data.replace(/\r\n?/g, '\n').split('\n');
+    const fragment = document.createDocumentFragment();
+    lines.forEach((line, idx) => {
+      if (idx > 0) fragment.appendChild(document.createElement('br'));
+      fragment.appendChild(document.createTextNode(line));
+    });
+    text.parentNode.replaceChild(fragment, text);
+  });
+
   // whitespace /between/ HTML nodes really confuses the parser because
   // it doesn't know these `text` elements are meaningless. Strip them all.
   const collapse = require('collapse-whitespace');


### PR DESCRIPTION
## Summary

- normalize Windows CRLF line endings before Slate deserializes plain-text paste data
- discard neutral near-black and near-white source-page text colors while preserving intentional non-neutral colors
- add regression coverage for both cases

## Problem

Mailspring's plain and rich paste paths can fail in opposite ways.

For plain paste on Windows, Slate's plain-text serializer splits input on `\n` without first normalizing CRLF. This leaves a trailing `\r` in each block. A blank line becomes a block containing only `\r`, and Mailspring's existing HTML serialization workaround converts that block to `&nbsp;`. The composer can visually compress this structure, while receiving clients render the placeholder blocks at full height, producing recipient-side spacing that does not match the composition view.

For rich paste, source pages using a dark color scheme can put their default near-white text color on the clipboard. Mailspring preserves that foreground color but not the page background, so the sent message can become unreadable in a light mail client. The inverse can happen when near-black defaults cross into a dark presentation.

## Implementation

Plain paste is handled explicitly at the composer ingress: CRLF and lone CR are normalized to LF, then the existing Slate plain serializer is used with the current block and marks. This keeps blank lines as genuinely empty Slate blocks instead of `\r` blocks.

Color filtering treats a color as an inherited page default only when it is nearly neutral, meaning its lightest and darkest RGB channels differ by no more than 12, and it also sits at or below roughly `#202020` or at or above roughly `#dfdfdf`. Named `black`, `white`, and `transparent` are included. Saturated colors and mid-range greys are left alone, so `#333` and `#ddd` both survive.

This is an intentional readability policy rather than a reliable distinction between inherited and deliberate colors. Mailspring has no background-color mark and block deserialization keeps only `className`, so a copied dark background never survives conversion. Preserving a near-white foreground therefore already produces unreadable output on a light message background, and dropping it restores readable inherited text.

Two behavior changes are worth calling out, and both are covered by specs:

- Alpha is deliberately ignored, so `rgba` values are classified from their RGB channels alone.
- `transparent` was previously preserved and is now dropped, which makes invisible pasted text visible rather than sending it hidden.

## Validation

- `npx tsc -p app/tsconfig.json --noEmit`
- targeted ESLint checks for the changed composer and spec files
- manual end-to-end validation on Windows with Mailspring 1.23.0 using rich paste, `Ctrl+Shift+V`, and Paste and Match Style
- decoded the outgoing multipart message before the change and confirmed both failures in the HTML Mailspring actually sent: CR-derived `&nbsp;` placeholder blocks from the plain and match-style sections, and a repeated near-white source text color in the rich-paste section
- decoded the outgoing message after the change and confirmed newly composed sections had consistent paragraph structure and no CR-derived `&nbsp;` placeholder blocks, while `&nbsp;` elements inside quoted history from the earlier message were left untouched

The post-change message was not a controlled comparison of the same clipboard payload, so the color behavior is pinned by the regression specs rather than by that sample. The specs cover both thresholds, a value just outside the near-black threshold, alpha, `transparent`, and that dropping a neutral foreground leaves the source font family intact.

No message bodies or account data are included in the tests or this PR.

## Removed from this branch

An earlier revision also converted literal newlines beneath `white-space: pre-wrap` into `<br>` elements. That change lived in the shared `parseHtml`, so it ran for every `convertFromHTML` call, including draft loading, templates and ordinary quoted blocks, rather than only pasted clipboard HTML. Ordinary `blockquote` and `.gmail_quote` content are normal Slate blocks, so an edited draft could be reserialized with newly inserted `<br>` elements well outside any paste.

I also have no reproducible clipboard payload that demonstrates the newline failure it was meant to fix. It has been removed rather than rescoped. If a payload turns up, it should get its own PR, applied to pasted rich HTML only, after `InlineStyleTransformer.runSync()` and immediately before `convertFromHTML()`, with its own tests.
