### PR TITLE
Fix calendar deletion, block edits on read-only calendars and past events

### DIFF
--- a/app/internal_packages/main-calendar/lib/core/agenda-view.tsx
+++ b/app/internal_packages/main-calendar/lib/core/agenda-view.tsx
@@ -153,7 +153,7 @@ export class AgendaView extends React.Component<MailspringCalendarViewProps, Age
     Actions.openPopover(
       <CalendarEventPopover
         event={event}
-        isCalendarReadOnly={this.props.readOnlyCalendarIds.has(event.calendarId)}
+        isCalendarReadOnly={this.props.isCalendarReadOnly(event.calendarId)}
       />,
       {
         originRect: eventEl.getBoundingClientRect(),

--- a/app/internal_packages/main-calendar/lib/core/agenda-view.tsx
+++ b/app/internal_packages/main-calendar/lib/core/agenda-view.tsx
@@ -150,12 +150,18 @@ export class AgendaView extends React.Component<MailspringCalendarViewProps, Age
    */
   _onAgendaEventDoubleClick = (e: React.MouseEvent, event: EventOccurrence) => {
     const eventEl = e.currentTarget as HTMLElement;
-    Actions.openPopover(<CalendarEventPopover event={event} />, {
-      originRect: eventEl.getBoundingClientRect(),
-      direction: 'right',
-      fallbackDirection: 'left',
-      closeOnAppBlur: false,
-    });
+    Actions.openPopover(
+      <CalendarEventPopover
+        event={event}
+        isCalendarReadOnly={this.props.readOnlyCalendarIds.has(event.calendarId)}
+      />,
+      {
+        originRect: eventEl.getBoundingClientRect(),
+        direction: 'right',
+        fallbackDirection: 'left',
+        closeOnAppBlur: false,
+      }
+    );
   };
 
   _renderEvent(event: EventOccurrence, dayKey: string) {

--- a/app/internal_packages/main-calendar/lib/core/calendar-drag-utils.ts
+++ b/app/internal_packages/main-calendar/lib/core/calendar-drag-utils.ts
@@ -319,34 +319,33 @@ export function updateDragState(
 }
 
 /**
- * Check whether an event's end time has already passed.
- * @param endUnix Event end time, in Unix seconds
+ * Check if a timestamp is in the past
+ * @param timestamp Unix timestamp to check
+ * @returns True if the timestamp has passed
  */
-export function hasEnded(endUnix: number): boolean {
-  return endUnix * 1000 < Date.now();
+export function isPastDate(timestamp: number): boolean {
+  return timestamp * 1000 < Date.now();
 }
 
 /**
- * Check if an event can be dragged (not read-only, not cancelled, etc.)
+ * Check if an event's time can be changed by drag, resize, or keyboard
  * @param event The event occurrence
  * @param isCalendarReadOnly Whether the calendar containing this event is read-only
- * @returns True if event can be dragged
+ * @returns True if the event can be moved
  */
-export function canDragEvent(event: EventOccurrence, isCalendarReadOnly = false): boolean {
-  // Don't allow dragging events in read-only calendars
+export function canMoveEvent(event: EventOccurrence, isCalendarReadOnly = false): boolean {
+  // Don't allow moving events in read-only calendars
   if (isCalendarReadOnly) {
     return false;
   }
 
-  // Don't allow dragging cancelled events
+  // Don't allow moving cancelled events
   if (event.isCancelled) {
     return false;
   }
 
-  // Don't allow dragging events that have already ended. An in-progress event is
-  // still draggable — only its end time being in the past locks it. Deliberate
-  // edits through the popover are still allowed.
-  if (hasEnded(event.end)) {
+  // An in-progress event can still be moved — only a past end time locks it
+  if (isPastDate(event.end)) {
     return false;
   }
 

--- a/app/internal_packages/main-calendar/lib/core/calendar-drag-utils.ts
+++ b/app/internal_packages/main-calendar/lib/core/calendar-drag-utils.ts
@@ -319,6 +319,14 @@ export function updateDragState(
 }
 
 /**
+ * Check whether an event's end time has already passed.
+ * @param endUnix Event end time, in Unix seconds
+ */
+export function hasEnded(endUnix: number): boolean {
+  return endUnix * 1000 < Date.now();
+}
+
+/**
  * Check if an event can be dragged (not read-only, not cancelled, etc.)
  * @param event The event occurrence
  * @param isCalendarReadOnly Whether the calendar containing this event is read-only
@@ -332,6 +340,13 @@ export function canDragEvent(event: EventOccurrence, isCalendarReadOnly = false)
 
   // Don't allow dragging cancelled events
   if (event.isCancelled) {
+    return false;
+  }
+
+  // Don't allow dragging events that have already ended. An in-progress event is
+  // still draggable — only its end time being in the past locks it. Deliberate
+  // edits through the popover are still allowed.
+  if (hasEnded(event.end)) {
     return false;
   }
 

--- a/app/internal_packages/main-calendar/lib/core/calendar-event-popover.tsx
+++ b/app/internal_packages/main-calendar/lib/core/calendar-event-popover.tsx
@@ -82,7 +82,7 @@ interface CalendarEventPopoverProps {
   accounts?: Account[];
   /** Disabled calendar IDs (required when isNewEvent is true) */
   disabledCalendars?: string[];
-  /** When true, the event's calendar is read-only and the popover never enters edit mode */
+  /** Whether the calendar containing this event is read-only */
   isCalendarReadOnly?: boolean;
 }
 
@@ -209,13 +209,6 @@ export class CalendarEventPopover extends React.Component<
   }
 
   saveEdits = async (): Promise<void> => {
-    // Safety check: render() never shows the edit UI for a read-only calendar, but the
-    // save path is the one that actually queues a task, so it enforces this too.
-    if (this.props.isCalendarReadOnly) {
-      console.warn('Cannot save changes to an event in a read-only calendar');
-      return;
-    }
-
     if (this.props.isNewEvent) {
       await this._createNewEvent();
       return;
@@ -589,11 +582,9 @@ export class CalendarEventPopover extends React.Component<
   }
 }
 
-class CalendarEventPopoverUnenditable extends React.Component<{
-  event: EventOccurrence;
-  onEdit: () => void;
-  isCalendarReadOnly?: boolean;
-}> {
+class CalendarEventPopoverUnenditable extends React.Component<
+  CalendarEventPopoverProps & { onEdit: () => void }
+> {
   descriptionRef = React.createRef<HTMLDivElement>();
 
   renderTime() {

--- a/app/internal_packages/main-calendar/lib/core/calendar-event-popover.tsx
+++ b/app/internal_packages/main-calendar/lib/core/calendar-event-popover.tsx
@@ -82,6 +82,8 @@ interface CalendarEventPopoverProps {
   accounts?: Account[];
   /** Disabled calendar IDs (required when isNewEvent is true) */
   disabledCalendars?: string[];
+  /** When true, the event's calendar is read-only and the popover never enters edit mode */
+  isCalendarReadOnly?: boolean;
 }
 
 interface CalendarEventPopoverState {
@@ -207,6 +209,13 @@ export class CalendarEventPopover extends React.Component<
   }
 
   saveEdits = async (): Promise<void> => {
+    // Safety check: render() never shows the edit UI for a read-only calendar, but the
+    // save path is the one that actually queues a task, so it enforces this too.
+    if (this.props.isCalendarReadOnly) {
+      console.warn('Cannot save changes to an event in a read-only calendar');
+      return;
+    }
+
     if (this.props.isNewEvent) {
       await this._createNewEvent();
       return;
@@ -573,7 +582,7 @@ export class CalendarEventPopover extends React.Component<
   };
 
   render() {
-    if (this.state.editing || this.props.isNewEvent) {
+    if (!this.props.isCalendarReadOnly && (this.state.editing || this.props.isNewEvent)) {
       return this.renderEditable();
     }
     return <CalendarEventPopoverUnenditable {...this.props} onEdit={this.onEdit} />;
@@ -583,6 +592,7 @@ export class CalendarEventPopover extends React.Component<
 class CalendarEventPopoverUnenditable extends React.Component<{
   event: EventOccurrence;
   onEdit: () => void;
+  isCalendarReadOnly?: boolean;
 }> {
   descriptionRef = React.createRef<HTMLDivElement>();
 
@@ -617,7 +627,7 @@ class CalendarEventPopoverUnenditable extends React.Component<{
   }
 
   render() {
-    const { event, onEdit } = this.props;
+    const { event, onEdit, isCalendarReadOnly } = this.props;
     const { title, description, location, attendees } = event;
 
     const notes = extractNotesFromDescription(description);
@@ -626,13 +636,15 @@ class CalendarEventPopoverUnenditable extends React.Component<{
       <div className="calendar-event-popover" tabIndex={0}>
         <div className="title-wrapper">
           <div className="title">{title}</div>
-          <RetinaImg
-            className="edit-icon"
-            name="edit-icon.png"
-            title="Edit Item"
-            mode={RetinaImg.Mode.ContentIsMask}
-            onClick={onEdit}
-          />
+          {!isCalendarReadOnly && (
+            <RetinaImg
+              className="edit-icon"
+              name="edit-icon.png"
+              title="Edit Item"
+              mode={RetinaImg.Mode.ContentIsMask}
+              onClick={onEdit}
+            />
+          )}
         </div>
         {location && (
           <div className="location">

--- a/app/internal_packages/main-calendar/lib/core/calendar-event.tsx
+++ b/app/internal_packages/main-calendar/lib/core/calendar-event.tsx
@@ -5,7 +5,7 @@ import { EventOccurrence } from './calendar-data-source';
 import { calcEventColors, extractMeetingDomain, formatEventTimeRange } from './calendar-helpers';
 import { RecurringIcon } from './calendar-icons';
 import { HitZone, ViewDirection } from './calendar-drag-types';
-import { detectHitZone, canDragEvent, formatDragPreviewTime } from './calendar-drag-utils';
+import { detectHitZone, canMoveEvent, formatDragPreviewTime } from './calendar-drag-utils';
 
 interface CalendarEventProps {
   event: EventOccurrence;
@@ -162,7 +162,7 @@ export class CalendarEvent extends React.Component<CalendarEventProps, CalendarE
       return false;
     }
     return (
-      canDragEvent(this.props.event, this.props.isCalendarReadOnly) && !!this.props.onDragStart
+      canMoveEvent(this.props.event, this.props.isCalendarReadOnly) && !!this.props.onDragStart
     );
   }
 

--- a/app/internal_packages/main-calendar/lib/core/calendar-helpers.tsx
+++ b/app/internal_packages/main-calendar/lib/core/calendar-helpers.tsx
@@ -325,6 +325,15 @@ export function showNoEditableCalendarsError(): void {
 }
 
 /**
+ * Show an error dialog when the user tries to change events on a read-only calendar.
+ */
+export function showReadOnlyCalendarError(): void {
+  AppEnv.showErrorDialog(
+    localized("This calendar is read-only, so its events can't be changed or deleted.")
+  );
+}
+
+/**
  * Options for creating a new calendar event.
  */
 export interface CreateCalendarEventOptions {

--- a/app/internal_packages/main-calendar/lib/core/mailspring-calendar.tsx
+++ b/app/internal_packages/main-calendar/lib/core/mailspring-calendar.tsx
@@ -97,6 +97,9 @@ export interface MailspringCalendarViewProps extends EventRendererProps {
 
   /** Set of calendar IDs that are read-only (events in these calendars cannot be dragged) */
   readOnlyCalendarIds: Set<string>;
+
+  /** Fail-closed read-only check; prefer this over readOnlyCalendarIds for write decisions */
+  isCalendarReadOnly: (calendarId: string) => boolean;
 }
 
 /*
@@ -206,9 +209,9 @@ export class MailspringCalendar extends React.Component<
    * Fails closed until the calendar subscription first emits, since events render
    * from an independent subscription and can paint before calendars resolve.
    */
-  _isCalendarReadOnly(calendarId: string): boolean {
+  _isCalendarReadOnly = (calendarId: string): boolean => {
     return !this.state.calendarsLoaded || this.state.readOnlyCalendarIds.has(calendarId);
-  }
+  };
 
   onChangeView = (view: CalendarView) => {
     // Clear any active drag state when changing views
@@ -851,6 +854,7 @@ export class MailspringCalendar extends React.Component<
         dragState={this.state.dragState}
         onEventDragStart={this._onEventDragStart}
         readOnlyCalendarIds={this.state.readOnlyCalendarIds}
+        isCalendarReadOnly={this._isCalendarReadOnly}
       />
     );
   }

--- a/app/internal_packages/main-calendar/lib/core/mailspring-calendar.tsx
+++ b/app/internal_packages/main-calendar/lib/core/mailspring-calendar.tsx
@@ -168,7 +168,7 @@ export class MailspringCalendar extends React.Component<
 
   componentWillUnmount() {
     // The component is unmounting, dispose subscriptions
-    this._disposable.dispose();
+    this._disposable?.dispose();
     this._themeDisposable?.dispose();
     if (this._unlisten) {
       this._unlisten();
@@ -379,23 +379,29 @@ export class MailspringCalendar extends React.Component<
       return;
     }
 
-    // Partition before prompting so the dialog describes what will actually happen
-    const deletable = this.state.selectedEvents.filter(
-      (o) => !this._isCalendarReadOnly(o.calendarId)
-    );
+    // Partition before prompting so the dialog can disclose a partial delete
+    const selected = this.state.selectedEvents;
+    const deletable = selected.filter((o) => !this._isCalendarReadOnly(o.calendarId));
     if (deletable.length === 0) {
       showReadOnlyCalendarError();
       return;
     }
+    const skipped = selected.length - deletable.length;
 
     // Show initial confirmation dialog
     const response = require('@electron/remote').dialog.showMessageBoxSync({
       type: 'warning',
       buttons: [localized('Delete'), localized('Cancel')],
       message: localized('Delete or decline these events?'),
-      detail: localized(
-        `Are you sure you want to delete or decline invitations for the selected event(s)?`
-      ),
+      detail: skipped
+        ? localized(
+            "%1$@ of the %2$@ selected events will be deleted. The rest are on read-only calendars and can't be changed.",
+            deletable.length,
+            selected.length
+          )
+        : localized(
+            `Are you sure you want to delete or decline invitations for the selected event(s)?`
+          ),
     });
 
     if (response !== 0) {

--- a/app/internal_packages/main-calendar/lib/core/mailspring-calendar.tsx
+++ b/app/internal_packages/main-calendar/lib/core/mailspring-calendar.tsx
@@ -8,7 +8,7 @@ import {
   Account,
   Actions,
   localized,
-  DestroyModelTask,
+  DestroyEventTask,
   Event,
   SyncbackEventTask,
   ICSEventHelpers,
@@ -482,13 +482,7 @@ export class MailspringCalendar extends React.Component<
    * Delete an entire event (or series)
    */
   async _deleteEntireEvent(event: Event) {
-    const task = new DestroyModelTask({
-      modelId: event.id,
-      modelName: event.constructor.name,
-      endpoint: '/events',
-      accountId: event.accountId,
-    });
-    Actions.queueTask(task);
+    Actions.queueTask(DestroyEventTask.forRemoving({ events: [event] }));
   }
 
   /**

--- a/app/internal_packages/main-calendar/lib/core/mailspring-calendar.tsx
+++ b/app/internal_packages/main-calendar/lib/core/mailspring-calendar.tsx
@@ -49,6 +49,7 @@ import {
   updateDragState,
   parseEventIdFromOccurrence,
   snapAllDayTimes,
+  hasEnded,
 } from './calendar-drag-utils';
 import { showRecurringEventDialog } from './recurring-event-dialog';
 import { modifyEventWithRecurringSupport, EventTimeChangeOptions } from './recurring-event-actions';
@@ -590,6 +591,11 @@ export class MailspringCalendar extends React.Component<
       return;
     }
 
+    // Past events can't be moved or resized with the keyboard, matching drag behavior
+    if (hasEnded(occurrence.end)) {
+      return;
+    }
+
     // Calculate time delta based on view and direction
     // Day/Week view: up/down changes time, left/right changes day
     // Month view: left/right changes day
@@ -709,6 +715,14 @@ export class MailspringCalendar extends React.Component<
       const calendar = this.state.calendars.find((c) => c.id === event.calendarId);
       if (!calendar || calendar.readOnly) {
         console.warn('Cannot modify event in read-only calendar');
+        return;
+      }
+
+      // Safety check: the event must not already have ended. Tested against the
+      // event's original end, not the drop target, so dragging a future event back
+      // into a past slot is still allowed.
+      if (hasEnded(dragState.originalEnd)) {
+        console.warn('Cannot modify an event that has already ended');
         return;
       }
 

--- a/app/internal_packages/main-calendar/lib/core/mailspring-calendar.tsx
+++ b/app/internal_packages/main-calendar/lib/core/mailspring-calendar.tsx
@@ -33,6 +33,7 @@ import {
   getColorCacheVersion,
   getEditableCalendars,
   showNoEditableCalendarsError,
+  showReadOnlyCalendarError,
   invalidateThemeTextColorCache,
 } from './calendar-helpers';
 import { Disposable } from 'rx-core';
@@ -49,7 +50,7 @@ import {
   updateDragState,
   parseEventIdFromOccurrence,
   snapAllDayTimes,
-  hasEnded,
+  canMoveEvent,
 } from './calendar-drag-utils';
 import { showRecurringEventDialog } from './recurring-event-dialog';
 import { modifyEventWithRecurringSupport, EventTimeChangeOptions } from './recurring-event-actions';
@@ -200,6 +201,15 @@ export class MailspringCalendar extends React.Component<
     );
   }
 
+  /**
+   * Single source of truth for whether an event's calendar may be written to.
+   * Fails closed until the calendar subscription first emits, since events render
+   * from an independent subscription and can paint before calendars resolve.
+   */
+  _isCalendarReadOnly(calendarId: string): boolean {
+    return !this.state.calendarsLoaded || this.state.readOnlyCalendarIds.has(calendarId);
+  }
+
   onChangeView = (view: CalendarView) => {
     // Clear any active drag state when changing views
     this.setState({ view, dragState: null });
@@ -230,7 +240,7 @@ export class MailspringCalendar extends React.Component<
     Actions.openPopover(
       <CalendarEventPopover
         event={eventModel}
-        isCalendarReadOnly={this.state.readOnlyCalendarIds.has(eventModel.calendarId)}
+        isCalendarReadOnly={this._isCalendarReadOnly(eventModel.calendarId)}
       />,
       {
         originRect: eventEl.getBoundingClientRect(),
@@ -366,6 +376,15 @@ export class MailspringCalendar extends React.Component<
       return;
     }
 
+    // Partition before prompting so the dialog describes what will actually happen
+    const deletable = this.state.selectedEvents.filter(
+      (o) => !this._isCalendarReadOnly(o.calendarId)
+    );
+    if (deletable.length === 0) {
+      showReadOnlyCalendarError();
+      return;
+    }
+
     // Show initial confirmation dialog
     const response = require('@electron/remote').dialog.showMessageBoxSync({
       type: 'warning',
@@ -380,8 +399,7 @@ export class MailspringCalendar extends React.Component<
       return; // User cancelled
     }
 
-    // Process each selected event
-    for (const occurrence of this.state.selectedEvents) {
+    for (const occurrence of deletable) {
       await this._deleteEvent(occurrence);
     }
   };
@@ -390,11 +408,6 @@ export class MailspringCalendar extends React.Component<
    * Delete a single event occurrence, handling recurring events appropriately
    */
   async _deleteEvent(occurrence: EventOccurrence) {
-    if (this.state.readOnlyCalendarIds.has(occurrence.calendarId)) {
-      console.warn('Cannot delete an event in a read-only calendar');
-      return;
-    }
-
     try {
       // Parse the event ID from the occurrence ID (handles recurring instance IDs)
       const eventId = parseEventIdFromOccurrence(occurrence.id);
@@ -586,13 +599,7 @@ export class MailspringCalendar extends React.Component<
 
     const occurrence = this.state.selectedEvents[0];
 
-    // Check if event is in a read-only calendar
-    if (this.state.readOnlyCalendarIds.has(occurrence.calendarId)) {
-      return;
-    }
-
-    // Past events can't be moved or resized with the keyboard, matching drag behavior
-    if (hasEnded(occurrence.end)) {
+    if (!canMoveEvent(occurrence, this._isCalendarReadOnly(occurrence.calendarId))) {
       return;
     }
 
@@ -709,20 +716,8 @@ export class MailspringCalendar extends React.Component<
         return;
       }
 
-      // Check if calendar is read-only (safety check). Treat an unknown calendar as
-      // read-only — `state.calendars` is populated asynchronously, and defaulting to
-      // writable would let a drag through before the subscription first fires.
-      const calendar = this.state.calendars.find((c) => c.id === event.calendarId);
-      if (!calendar || calendar.readOnly) {
+      if (this._isCalendarReadOnly(event.calendarId)) {
         console.warn('Cannot modify event in read-only calendar');
-        return;
-      }
-
-      // Safety check: the event must not already have ended. Tested against the
-      // event's original end, not the drop target, so dragging a future event back
-      // into a past slot is still allowed.
-      if (hasEnded(dragState.originalEnd)) {
-        console.warn('Cannot modify an event that has already ended');
         return;
       }
 

--- a/app/internal_packages/main-calendar/lib/core/mailspring-calendar.tsx
+++ b/app/internal_packages/main-calendar/lib/core/mailspring-calendar.tsx
@@ -226,12 +226,18 @@ export class MailspringCalendar extends React.Component<
     const direction = isDayView ? 'down' : 'right';
     const fallbackDirection = isDayView ? 'up' : 'left';
 
-    Actions.openPopover(<CalendarEventPopover event={eventModel} />, {
-      originRect: eventEl.getBoundingClientRect(),
-      direction,
-      fallbackDirection,
-      closeOnAppBlur: false,
-    });
+    Actions.openPopover(
+      <CalendarEventPopover
+        event={eventModel}
+        isCalendarReadOnly={this.state.readOnlyCalendarIds.has(eventModel.calendarId)}
+      />,
+      {
+        originRect: eventEl.getBoundingClientRect(),
+        direction,
+        fallbackDirection,
+        closeOnAppBlur: false,
+      }
+    );
   }
 
   _onEventClick = (e: React.MouseEvent, event: EventOccurrence) => {
@@ -383,6 +389,11 @@ export class MailspringCalendar extends React.Component<
    * Delete a single event occurrence, handling recurring events appropriately
    */
   async _deleteEvent(occurrence: EventOccurrence) {
+    if (this.state.readOnlyCalendarIds.has(occurrence.calendarId)) {
+      console.warn('Cannot delete an event in a read-only calendar');
+      return;
+    }
+
     try {
       // Parse the event ID from the occurrence ID (handles recurring instance IDs)
       const eventId = parseEventIdFromOccurrence(occurrence.id);
@@ -692,9 +703,11 @@ export class MailspringCalendar extends React.Component<
         return;
       }
 
-      // Check if calendar is read-only (safety check)
+      // Check if calendar is read-only (safety check). Treat an unknown calendar as
+      // read-only — `state.calendars` is populated asynchronously, and defaulting to
+      // writable would let a drag through before the subscription first fires.
       const calendar = this.state.calendars.find((c) => c.id === event.calendarId);
-      if (calendar?.readOnly) {
+      if (!calendar || calendar.readOnly) {
         console.warn('Cannot modify event in read-only calendar');
         return;
       }

--- a/app/internal_packages/main-calendar/lib/core/month-view-event.tsx
+++ b/app/internal_packages/main-calendar/lib/core/month-view-event.tsx
@@ -5,7 +5,7 @@ import { EventOccurrence } from './calendar-data-source';
 import { calcEventColors } from './calendar-helpers';
 import { RecurringIcon } from './calendar-icons';
 import { HitZone } from './calendar-drag-types';
-import { detectHitZone, canDragEvent, formatDragPreviewTime } from './calendar-drag-utils';
+import { detectHitZone, canMoveEvent, formatDragPreviewTime } from './calendar-drag-utils';
 
 interface MonthViewEventProps {
   event: EventOccurrence;
@@ -83,7 +83,7 @@ export class MonthViewEvent extends React.Component<MonthViewEventProps, MonthVi
       return false;
     }
     return (
-      canDragEvent(this.props.event, this.props.isCalendarReadOnly) && !!this.props.onDragStart
+      canMoveEvent(this.props.event, this.props.isCalendarReadOnly) && !!this.props.onDragStart
     );
   }
 

--- a/app/spec/calendar-drag-utils-spec.ts
+++ b/app/spec/calendar-drag-utils-spec.ts
@@ -1,8 +1,8 @@
 // Import the functions under test directly from the source file.
 // We use a relative path because the plugin is not registered in mailspring-exports.
 import {
-  hasEnded,
-  canDragEvent,
+  isPastDate,
+  canMoveEvent,
 } from '../internal_packages/main-calendar/lib/core/calendar-drag-utils';
 import { EventOccurrence } from '../internal_packages/main-calendar/lib/core/calendar-data-source';
 
@@ -27,42 +27,42 @@ function makeOccurrence(overrides: Partial<EventOccurrence> = {}): EventOccurren
     organizer: null,
     attendees: [],
     ...overrides,
-  } as EventOccurrence;
+  };
 }
 
-describe('hasEnded', function () {
-  it('returns true for an end time in the past', function () {
-    expect(hasEnded(Date.now() / 1000 - HOUR)).toBe(true);
+describe('isPastDate', function () {
+  it('returns true for a timestamp in the past', function () {
+    expect(isPastDate(Date.now() / 1000 - HOUR)).toBe(true);
   });
 
-  it('returns false for an end time in the future', function () {
-    expect(hasEnded(Date.now() / 1000 + HOUR)).toBe(false);
+  it('returns false for a timestamp in the future', function () {
+    expect(isPastDate(Date.now() / 1000 + HOUR)).toBe(false);
   });
 });
 
-describe('canDragEvent', function () {
-  it('allows dragging an upcoming event', function () {
-    expect(canDragEvent(makeOccurrence())).toBe(true);
+describe('canMoveEvent', function () {
+  it('allows moving an upcoming event', function () {
+    expect(canMoveEvent(makeOccurrence())).toBe(true);
   });
 
-  it('blocks dragging an event that has already ended', function () {
+  it('blocks moving an event that has already ended', function () {
     const nowUnix = Date.now() / 1000;
     const past = makeOccurrence({ start: nowUnix - 2 * HOUR, end: nowUnix - HOUR });
-    expect(canDragEvent(past)).toBe(false);
+    expect(canMoveEvent(past)).toBe(false);
   });
 
-  it('allows dragging an in-progress event, since only the end time being past locks it', function () {
+  it('allows moving an in-progress event, since only the end time being past locks it', function () {
     const nowUnix = Date.now() / 1000;
     const inProgress = makeOccurrence({ start: nowUnix - HOUR, end: nowUnix + HOUR });
-    expect(canDragEvent(inProgress)).toBe(true);
+    expect(canMoveEvent(inProgress)).toBe(true);
   });
 
-  it('blocks dragging an event in a read-only calendar', function () {
-    expect(canDragEvent(makeOccurrence(), true)).toBe(false);
+  it('blocks moving an event in a read-only calendar', function () {
+    expect(canMoveEvent(makeOccurrence(), true)).toBe(false);
   });
 
-  it('blocks dragging a cancelled event', function () {
-    expect(canDragEvent(makeOccurrence({ isCancelled: true }))).toBe(false);
+  it('blocks moving a cancelled event', function () {
+    expect(canMoveEvent(makeOccurrence({ isCancelled: true }))).toBe(false);
   });
 
   it('blocks an all-day event only once its day is over', function () {
@@ -73,15 +73,15 @@ describe('canDragEvent', function () {
     const today = makeOccurrence({
       isAllDay: true,
       start: todayStartUnix,
-      end: todayStartUnix + 24 * HOUR - 1,
+      end: todayStartUnix + 24 * HOUR,
     });
-    expect(canDragEvent(today)).toBe(true);
+    expect(canMoveEvent(today)).toBe(true);
 
     const yesterday = makeOccurrence({
       isAllDay: true,
       start: todayStartUnix - 24 * HOUR,
       end: todayStartUnix - 1,
     });
-    expect(canDragEvent(yesterday)).toBe(false);
+    expect(canMoveEvent(yesterday)).toBe(false);
   });
 });

--- a/app/spec/calendar-drag-utils-spec.ts
+++ b/app/spec/calendar-drag-utils-spec.ts
@@ -1,0 +1,87 @@
+// Import the functions under test directly from the source file.
+// We use a relative path because the plugin is not registered in mailspring-exports.
+import {
+  hasEnded,
+  canDragEvent,
+} from '../internal_packages/main-calendar/lib/core/calendar-drag-utils';
+import { EventOccurrence } from '../internal_packages/main-calendar/lib/core/calendar-data-source';
+
+const HOUR = 60 * 60;
+
+function makeOccurrence(overrides: Partial<EventOccurrence> = {}): EventOccurrence {
+  const nowUnix = Date.now() / 1000;
+  return {
+    id: 'event-1-e0',
+    accountId: 'acct-1',
+    calendarId: 'cal-1',
+    title: 'Standup',
+    location: '',
+    description: '',
+    start: nowUnix + HOUR,
+    end: nowUnix + 2 * HOUR,
+    isAllDay: false,
+    isCancelled: false,
+    isPending: false,
+    isException: false,
+    isRecurring: false,
+    organizer: null,
+    attendees: [],
+    ...overrides,
+  } as EventOccurrence;
+}
+
+describe('hasEnded', function () {
+  it('returns true for an end time in the past', function () {
+    expect(hasEnded(Date.now() / 1000 - HOUR)).toBe(true);
+  });
+
+  it('returns false for an end time in the future', function () {
+    expect(hasEnded(Date.now() / 1000 + HOUR)).toBe(false);
+  });
+});
+
+describe('canDragEvent', function () {
+  it('allows dragging an upcoming event', function () {
+    expect(canDragEvent(makeOccurrence())).toBe(true);
+  });
+
+  it('blocks dragging an event that has already ended', function () {
+    const nowUnix = Date.now() / 1000;
+    const past = makeOccurrence({ start: nowUnix - 2 * HOUR, end: nowUnix - HOUR });
+    expect(canDragEvent(past)).toBe(false);
+  });
+
+  it('allows dragging an in-progress event, since only the end time being past locks it', function () {
+    const nowUnix = Date.now() / 1000;
+    const inProgress = makeOccurrence({ start: nowUnix - HOUR, end: nowUnix + HOUR });
+    expect(canDragEvent(inProgress)).toBe(true);
+  });
+
+  it('blocks dragging an event in a read-only calendar', function () {
+    expect(canDragEvent(makeOccurrence(), true)).toBe(false);
+  });
+
+  it('blocks dragging a cancelled event', function () {
+    expect(canDragEvent(makeOccurrence({ isCancelled: true }))).toBe(false);
+  });
+
+  it('blocks an all-day event only once its day is over', function () {
+    const startOfToday = new Date();
+    startOfToday.setHours(0, 0, 0, 0);
+    const todayStartUnix = startOfToday.getTime() / 1000;
+
+    const today = makeOccurrence({
+      isAllDay: true,
+      start: todayStartUnix,
+      end: todayStartUnix + 24 * HOUR - 1,
+    });
+    expect(canDragEvent(today)).toBe(true);
+
+    const yesterday = makeOccurrence({
+      isAllDay: true,
+      start: todayStartUnix - 24 * HOUR,
+      end: todayStartUnix - 1,
+    });
+    expect(canDragEvent(yesterday)).toBe(false);
+  });
+});

--- a/app/src/global/mailspring-exports.d.ts
+++ b/app/src/global/mailspring-exports.d.ts
@@ -71,6 +71,7 @@ export * from '../flux/tasks/change-labels-task';
 export * from '../flux/tasks/change-folder-task';
 export * from '../flux/tasks/change-unread-task';
 export * from '../flux/tasks/destroy-model-task';
+export * from '../flux/tasks/destroy-event-task';
 export * from '../flux/tasks/syncback-draft-task';
 export * from '../flux/tasks/change-starred-task';
 export * from '../flux/tasks/syncback-event-task';


### PR DESCRIPTION
## Summary

Four gaps in how the calendar handles changing and deleting events:

- **The event popover ignored read-only calendars entirely** — Edit → change time → Save persisted. Agenda view has no drag gating either, so nothing there stopped it.
- **Delete had no read-only check**, and its confirm dialog ran *before* the guard, so you could confirm a deletion that then silently did nothing.
- **Past events could be dragged or resized**, rewriting their time. On a recurring series this wrote a `RECURRENCE-ID` exception into the master ICS.
- **Deleting an event never persisted.** `_deleteEntireEvent` queued a `DestroyModelTask`, which the sync engine has no handler for — it hit the `else` branch at `TaskProcessor.cpp:487` ("Unsure of how to process this task type"), marked the task `remote`, and deleted nothing. The event vanished locally, then the next sync restored it from the server.

The four read-only checks also disagreed with each other: three used the `readOnlyCalendarIds` set, one used `state.calendars.find(...)?.readOnly`, which fails open (`undefined` is falsy) in the window before calendars load.

## Fix

- `_isCalendarReadOnly()` — one predicate for all four write paths, failing closed until the calendar subscription emits
- `isCalendarReadOnly` prop on the popover: no editable view, no edit pencil
- Delete partitions the selection before prompting, with a `showReadOnlyCalendarError()` dialog
- Delete now queues `DestroyEventTask.forRemoving({ events: [event] })`, which the engine *does* handle — `performLocalDestroyEvent` / `performRemoteDestroyEvent` (`TaskProcessor.cpp:484` and `:584`) already existed and call `DAVWorker::deleteEvent`. `DestroyEventTask` was present and exported but had zero call sites; it was orphaned, not dead. Its missing type export was added to `mailspring-exports.d.ts`.
- `isPastDate()` inside `canMoveEvent` (renamed from `canDragEvent`, now that the keyboard path calls it too). Cutoff is `end < now`, so in-progress events stay movable, dragging a future event *into* the past still works, and popover edits are unaffected.

## Behavior changes

- Cancelled events are no longer arrow-key movable — drag already refused them, and the keyboard path now shares the predicate (see caveat below)
- Deleting on a read-only calendar shows an error instead of doing nothing

## Caveat on the keyboard path

`_onMoveSelectedEvent` now shares `canMoveEvent` with drag, so read-only/past/cancelled are refused there too. But the arrow-key shortcuts are hard to reach at all today, for reasons that predate this branch: `CalendarEvent._onMouseDown` calls `preventDefault()` (only for movable events), so clicking one never focuses it and `localHandlers` never receive the key; the element remounts on a day-boundary move, destroying focus; and `state.selectedEvents` is never refreshed after a change, so repeated presses recompute from a stale position. Tracked separately — the guard here is correct but only partly demonstrable by hand.

## Test plan

- [x] `npx tsc -p ./app --noEmit` and `npm run lint` — clean
- [x] `npm test` — 1471 passing, incl. 8 new specs covering `isPastDate` and every `canMoveEvent` branch
- [x] Manual pass: a past event refuses to drag; an in-progress event still drags (confirming the `end < now` cutoff doesn't over-block); a read-only calendar's popover has no edit pencil; deleting via Menu → Calendar → Delete Event persists through a sync instead of reappearing.
- [ ] Keyboard path only partly verifiable by hand — see the caveat above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
