### PR TITLE
Fix uncaught "Unknown button clicked" crash in config load-error dialog

### DIFF
--- a/app/src/browser/config-persistence-manager.ts
+++ b/app/src/browser/config-persistence-manager.ts
@@ -73,16 +73,12 @@ export default class ConfigPersistenceManager {
       buttons: [localized('Quit'), localized('Try Again'), localized('Reset Configuration')],
     });
 
-    switch (clickedIndex) {
-      case 0:
-        return 'quit';
-      case 1:
-        return 'tryagain';
-      case 2:
-        return 'reset';
-      default:
-        throw new Error('Unknown button clicked');
-    }
+    // On Windows, `cancelId` is ignored by Electron, so dismissing the dialog without
+    // clicking a button (eg: via the window's close button, Alt+F4, or Esc) can return
+    // an index outside 0-2. Treat that the same as "Quit" rather than throwing, since
+    // this runs synchronously during app startup and an uncaught error here prevents
+    // the app from launching at all.
+    return ['quit', 'tryagain', 'reset'][clickedIndex] || 'quit';
   }
 
   load() {


### PR DESCRIPTION
## Summary

Fixes [MAILSPRING-CLIENT-EK](https://foundry-376-llc.sentry.io/issues/MAILSPRING-CLIENT-EK) — `Error: Unknown button clicked`, 8 users / 39 events, 100% on Windows (`win32`).

### What I observed

- The stack trace pointed to `ConfigPersistenceManager._showLoadErrorDialog`, called from `ConfigPersistenceManager.load()`, called synchronously from the constructor during `Application.start()` (`app/src/browser/application.ts`).
- `_showLoadErrorDialog` shows an error dialog (via `dialog.showMessageBoxSync`) with three buttons — Quit / Try Again / Reset Configuration — when `config.json` fails to load, then `switch`es on the clicked button index. The `default` branch of that switch threw `new Error('Unknown button clicked')` for any index other than `0`, `1`, or `2`.
- Querying all 39 events for this issue in Sentry showed `tags[platform]` was `win32` for 100% of them.
- Per Electron's docs, `dialog.showMessageBoxSync`'s `cancelId` option — which controls what index is returned if the user dismisses the dialog without clicking a labeled button (e.g. via the dialog's native close button, Alt+F4, or Esc) — is **explicitly ignored on Windows**. That means on Windows there's no way to force a "cancel" index into the 0-2 range, and dismissing the dialog returns an out-of-range index (typically `-1`).
- Because this all happens synchronously inside the `ConfigPersistenceManager` constructor, with no surrounding `try/catch` in `application.ts`, the thrown error propagates out of `Application.start()` uncaught — breaking app startup entirely. Since the underlying corrupted `config.json` is never fixed, affected users hit this again on every relaunch, which matches the 39 events across only 8 users.
- Notably, `_showSaveErrorDialog` right below it in the same file already avoids this exact trap by using safe array-index lookup (`['ignore', 'retry'][clickedIndex]`, which yields `undefined` — not a throw — for an out-of-range index) instead of a `switch` with a throwing `default`.

### Fix

Replace the throwing `switch` in `_showLoadErrorDialog` with the same safe array-index pattern already used by `_showSaveErrorDialog`, falling back to `'quit'` (the least destructive option — it neither deletes the user's config nor loops) when the dialog is dismissed without an explicit button click:

```ts
return ['quit', 'tryagain', 'reset'][clickedIndex] || 'quit';
```

`load()`'s existing handling of `action === 'quit'` (set `userWantsToPreserveErrors`, call `app.quit()`) already covers this path correctly, so no other changes were needed.

## Test plan

- [ ] Manually reproduce on Windows: corrupt `config.json`, launch, dismiss the error dialog via the window's close button/Alt+F4 instead of clicking a button, confirm the app quits cleanly instead of crashing with an uncaught exception.
- [x] Reviewed that `load()`'s existing `action === 'quit'` branch handles this path correctly (sets `userWantsToPreserveErrors`, calls `app.quit()`).


---
_Generated by [Claude Code](https://claude.ai/code/session_013o2MJfxYEMRxUr92RHeFZA)_