### PR TITLE
Add support for dragging threads into composer as .eml attachments

### DIFF
--- a/app/internal_packages/account-sidebar/lib/sidebar-item.ts
+++ b/app/internal_packages/account-sidebar/lib/sidebar-item.ts
@@ -12,6 +12,7 @@ import {
   CategoryStore,
   Actions,
   RegExpUtils,
+  DragDropTypes,
   localized,
   TaskQueue,
 } from 'mailspring-exports';
@@ -281,7 +282,7 @@ export default class SidebarItem {
         onCollapseToggled: toggleItemCollapsed,
 
         onDrop(item, event) {
-          const jsonString = event.dataTransfer.getData('mailspring-threads-data');
+          const jsonString = event.dataTransfer.getData(DragDropTypes.ThreadsDragType);
           let jsonData = null;
           try {
             jsonData = JSON.parse(jsonString);
@@ -297,7 +298,7 @@ export default class SidebarItem {
         shouldAcceptDrop(item, event) {
           const target = item.perspective;
           const current = FocusedPerspectiveStore.current();
-          if (!event.dataTransfer.types.includes('mailspring-threads-data')) {
+          if (!event.dataTransfer.types.includes(DragDropTypes.ThreadsDragType)) {
             return false;
           }
           if (target.isEqual(current)) {
@@ -306,10 +307,7 @@ export default class SidebarItem {
 
           // We can't inspect the drag payload until drop, so we use a dataTransfer
           // type to encode the account IDs of threads currently being dragged.
-          const accountsType = event.dataTransfer.types.find((t) =>
-            t.startsWith('mailspring-accounts=')
-          );
-          const accountIds = (accountsType || '').replace('mailspring-accounts=', '').split(',');
+          const accountIds = DragDropTypes.accountIdsForDragTypes(event.dataTransfer.types);
           return target.canReceiveThreadsFromAccountIds(accountIds);
         },
 

--- a/app/internal_packages/composer/lib/attachments-area.tsx
+++ b/app/internal_packages/composer/lib/attachments-area.tsx
@@ -1,9 +1,16 @@
 import React from 'react';
-import { Actions, AttachmentStore, Message } from 'mailspring-exports';
-import { AttachmentItem } from 'mailspring-component-kit';
+import { localized, Actions, AttachmentStore, Message } from 'mailspring-exports';
+import { AttachmentItem, RetinaImg } from 'mailspring-component-kit';
 
-export const AttachmentsArea: React.FunctionComponent<{ draft: Message }> = (props) => {
+export const AttachmentsArea: React.FunctionComponent<{
+  draft: Message;
+  // Number of dragged-in threads whose .eml files are still being fetched from
+  // the sync engine. They aren't files on the draft yet, so they're rendered
+  // here as placeholders to show the drop was accepted.
+  attachingThreadCount?: number;
+}> = (props) => {
   const { files, headerMessageId } = props.draft;
+  const attachingThreadCount = props.attachingThreadCount || 0;
 
   return (
     <div className="attachments-area">
@@ -20,6 +27,16 @@ export const AttachmentsArea: React.FunctionComponent<{ draft: Message }> = (pro
             onRemoveAttachment={() => Actions.removeAttachment(headerMessageId, file)}
           />
         ))}
+      {attachingThreadCount > 0 && (
+        <div className="attaching-messages">
+          <RetinaImg name="inline-loading-spinner.gif" mode={RetinaImg.Mode.ContentPreserve} />
+          <span>
+            {attachingThreadCount === 1
+              ? localized('Attaching message…')
+              : localized('Attaching %1$@ messages…', attachingThreadCount)}
+          </span>
+        </div>
+      )}
     </div>
   );
 };

--- a/app/internal_packages/composer/lib/attachments-area.tsx
+++ b/app/internal_packages/composer/lib/attachments-area.tsx
@@ -1,16 +1,15 @@
 import React from 'react';
 import { localized, Actions, AttachmentStore, Message } from 'mailspring-exports';
-import { AttachmentItem, RetinaImg } from 'mailspring-component-kit';
+import { AttachmentItem, Spinner } from 'mailspring-component-kit';
 
 export const AttachmentsArea: React.FunctionComponent<{
   draft: Message;
-  // Number of dragged-in threads whose .eml files are still being fetched from
-  // the sync engine. They aren't files on the draft yet, so they're rendered
-  // here as placeholders to show the drop was accepted.
-  attachingThreadCount?: number;
+  // True while files dropped on the composer are still being prepared. They
+  // aren't on the draft yet, so a placeholder stands in to show the drop was
+  // accepted.
+  attaching?: boolean;
 }> = (props) => {
   const { files, headerMessageId } = props.draft;
-  const attachingThreadCount = props.attachingThreadCount || 0;
 
   return (
     <div className="attachments-area">
@@ -27,14 +26,10 @@ export const AttachmentsArea: React.FunctionComponent<{
             onRemoveAttachment={() => Actions.removeAttachment(headerMessageId, file)}
           />
         ))}
-      {attachingThreadCount > 0 && (
+      {props.attaching && (
         <div className="attaching-messages">
-          <RetinaImg name="inline-loading-spinner.gif" mode={RetinaImg.Mode.ContentPreserve} />
-          <span>
-            {attachingThreadCount === 1
-              ? localized('Attaching message…')
-              : localized('Attaching %1$@ messages…', attachingThreadCount)}
-          </span>
+          <Spinner visible />
+          <span>{localized('Attaching…')}</span>
         </div>
       )}
     </div>

--- a/app/internal_packages/composer/lib/composer-view.tsx
+++ b/app/internal_packages/composer/lib/composer-view.tsx
@@ -7,6 +7,7 @@ import {
   DraftStore,
   DraftEditingSession,
   MessageWithEditorState,
+  EmlUtils,
   File,
 } from 'mailspring-exports';
 import { webUtils } from 'electron';
@@ -41,6 +42,7 @@ interface ComposerViewState {
   quotedTextHidden: boolean;
   quotedTextPresent: boolean;
   isDropping: boolean;
+  attachingThreadCount: number;
 }
 // The ComposerView is a unique React component because it (currently) is a
 // singleton. Normally, the React way to do things would be to re-render the
@@ -78,6 +80,7 @@ export default class ComposerView extends React.Component<ComposerViewProps, Com
 
     this.state = {
       isDropping: false,
+      attachingThreadCount: 0,
       quotedTextPresent: hasBlockquote(draft.bodyEditorState),
       quotedTextHidden: hideQuotedTextByDefault(draft),
     };
@@ -202,7 +205,7 @@ export default class ComposerView extends React.Component<ComposerViewProps, Com
               </>
             )}
 
-            <AttachmentsArea draft={draft} />
+            <AttachmentsArea draft={draft} attachingThreadCount={this.state.attachingThreadCount} />
           </div>
           <div className="composer-footer-region">
             <InjectedComponentSet
@@ -278,7 +281,14 @@ export default class ComposerView extends React.Component<ComposerViewProps, Com
     const hasNativeFile = event.dataTransfer.types.includes('Files');
     const hasNonNativeFilePath = nonNativeFilePath !== null;
 
-    return hasNativeFile || hasNonNativeFilePath;
+    return hasNativeFile || hasNonNativeFilePath || this._hasThreadsForDrop(event);
+  };
+
+  // Threads dragged out of the thread list carry their ids in a custom MIME
+  // type. Note that we can only look at `types` here — the payload itself is
+  // not readable until the drop actually happens.
+  _hasThreadsForDrop = (event: React.DragEvent<HTMLDivElement>) => {
+    return event.dataTransfer.types.includes('mailspring-threads-data');
   };
 
   _nonNativeFilePathForDrop = (event: React.DragEvent<HTMLDivElement>) => {
@@ -312,6 +322,66 @@ export default class ComposerView extends React.Component<ComposerViewProps, Com
     if (uri) {
       this._onFileReceived(uri);
       event.preventDefault();
+    }
+
+    // Accept drops of threads from the thread list, attaching each one as a
+    // .eml file. dataTransfer is only valid for the duration of this handler,
+    // so read the payload now and hand the ids off to an async worker.
+    if (this._hasThreadsForDrop(event)) {
+      this._onThreadsReceived(event.dataTransfer.getData('mailspring-threads-data'));
+      event.preventDefault();
+    }
+  };
+
+  _onThreadsReceived = async (json: string) => {
+    let threadIds: string[] = [];
+    try {
+      threadIds = JSON.parse(json).threadIds || [];
+    } catch (err) {
+      return;
+    }
+
+    // Dropping a thread onto a reply being written inside that same thread is
+    // almost always an accident, and attaching a copy of the conversation to
+    // itself isn't useful. Ignore it rather than surfacing an error.
+    threadIds = threadIds.filter((id) => id !== this.props.draft.threadId);
+    if (!threadIds.length) {
+      return;
+    }
+
+    // Fetching the raw message from the sync engine is a remote round trip, so
+    // show a placeholder in the attachments area until the files land.
+    const dropCount = threadIds.length;
+    this.setState((state) => ({ attachingThreadCount: state.attachingThreadCount + dropCount }));
+
+    let staged: Array<{ filePath: string }> = [];
+    try {
+      staged = await EmlUtils.stageThreadsAsEml(threadIds);
+    } catch (err) {
+      AppEnv.reportError(err);
+    } finally {
+      if (this._mounted) {
+        this.setState((state) => ({
+          attachingThreadCount: state.attachingThreadCount - dropCount,
+        }));
+      }
+    }
+
+    if (!this._mounted) {
+      return;
+    }
+    for (const { filePath } of staged) {
+      this._onFileReceived(filePath);
+    }
+    if (staged.length < threadIds.length) {
+      AppEnv.showErrorDialog(
+        threadIds.length === 1
+          ? localized('Could not download the original message. Please try again.')
+          : localized(
+              'Could not download %1$@ of the original messages. Please try again.',
+              threadIds.length - staged.length
+            )
+      );
     }
   };
 

--- a/app/internal_packages/composer/lib/composer-view.tsx
+++ b/app/internal_packages/composer/lib/composer-view.tsx
@@ -7,6 +7,7 @@ import {
   DraftStore,
   DraftEditingSession,
   MessageWithEditorState,
+  DragDropTypes,
   EmlUtils,
   File,
 } from 'mailspring-exports';
@@ -205,7 +206,7 @@ export default class ComposerView extends React.Component<ComposerViewProps, Com
               </>
             )}
 
-            <AttachmentsArea draft={draft} attachingThreadCount={this.state.attachingThreadCount} />
+            <AttachmentsArea draft={draft} attaching={this.state.attachingThreadCount > 0} />
           </div>
           <div className="composer-footer-region">
             <InjectedComponentSet
@@ -284,11 +285,8 @@ export default class ComposerView extends React.Component<ComposerViewProps, Com
     return hasNativeFile || hasNonNativeFilePath || this._hasThreadsForDrop(event);
   };
 
-  // Threads dragged out of the thread list carry their ids in a custom MIME
-  // type. Note that we can only look at `types` here — the payload itself is
-  // not readable until the drop actually happens.
   _hasThreadsForDrop = (event: React.DragEvent<HTMLDivElement>) => {
-    return event.dataTransfer.types.includes('mailspring-threads-data');
+    return event.dataTransfer.types.includes(DragDropTypes.ThreadsDragType);
   };
 
   _nonNativeFilePathForDrop = (event: React.DragEvent<HTMLDivElement>) => {
@@ -324,11 +322,10 @@ export default class ComposerView extends React.Component<ComposerViewProps, Com
       event.preventDefault();
     }
 
-    // Accept drops of threads from the thread list, attaching each one as a
-    // .eml file. dataTransfer is only valid for the duration of this handler,
-    // so read the payload now and hand the ids off to an async worker.
+    // dataTransfer is only valid for the duration of this handler, so read the
+    // payload now and hand the ids off to an async worker.
     if (this._hasThreadsForDrop(event)) {
-      this._onThreadsReceived(event.dataTransfer.getData('mailspring-threads-data'));
+      this._onThreadsReceived(event.dataTransfer.getData(DragDropTypes.ThreadsDragType));
       event.preventDefault();
     }
   };
@@ -378,27 +375,19 @@ export default class ComposerView extends React.Component<ComposerViewProps, Com
 
     // A thread with nothing exportable in it and a fetch that failed are
     // different problems, and only the second one is worth retrying.
+    const problems = [];
     if (unavailableThreadIds.length) {
-      AppEnv.showErrorDialog(
-        unavailableThreadIds.length === 1
-          ? localized('This conversation has no message that can be attached.')
-          : localized(
-              '%1$@ of the conversations have no message that can be attached.',
-              unavailableThreadIds.length
-            )
+      problems.push(
+        localized('One or more of the conversations have no message that can be attached.')
       );
     }
-
-    const failedCount = threadIds.length - unavailableThreadIds.length - staged.length;
-    if (failedCount > 0) {
-      AppEnv.showErrorDialog(
-        failedCount === 1
-          ? localized('Could not download the original message. Please try again.')
-          : localized(
-              'Could not download %1$@ of the original messages. Please try again.',
-              failedCount
-            )
+    if (staged.length < threadIds.length - unavailableThreadIds.length) {
+      problems.push(
+        localized('One or more of the original messages could not be downloaded. Please try again.')
       );
+    }
+    if (problems.length) {
+      AppEnv.showErrorDialog(problems.join('\n\n'));
     }
   };
 

--- a/app/internal_packages/composer/lib/composer-view.tsx
+++ b/app/internal_packages/composer/lib/composer-view.tsx
@@ -340,11 +340,6 @@ export default class ComposerView extends React.Component<ComposerViewProps, Com
     } catch (err) {
       return;
     }
-
-    // Dropping a thread onto a reply being written inside that same thread is
-    // almost always an accident, and attaching a copy of the conversation to
-    // itself isn't useful. Ignore it rather than surfacing an error.
-    threadIds = threadIds.filter((id) => id !== this.props.draft.threadId);
     if (!threadIds.length) {
       return;
     }
@@ -355,8 +350,9 @@ export default class ComposerView extends React.Component<ComposerViewProps, Com
     this.setState((state) => ({ attachingThreadCount: state.attachingThreadCount + dropCount }));
 
     let staged: Array<{ filePath: string }> = [];
+    let unavailableThreadIds: string[] = [];
     try {
-      staged = await EmlUtils.stageThreadsAsEml(threadIds);
+      ({ staged, unavailableThreadIds } = await EmlUtils.stageThreadsAsEml(threadIds));
     } catch (err) {
       AppEnv.reportError(err);
     } finally {
@@ -371,15 +367,36 @@ export default class ComposerView extends React.Component<ComposerViewProps, Com
       return;
     }
     for (const { filePath } of staged) {
-      this._onFileReceived(filePath);
+      Actions.addAttachment({
+        filePath,
+        headerMessageId: this.props.draft.headerMessageId,
+        // The attachment store copies the file into its own directory before
+        // this fires, so the staged copy is free to go.
+        onCreated: () => EmlUtils.discardStagedEml(filePath),
+      });
     }
-    if (staged.length < threadIds.length) {
+
+    // A thread with nothing exportable in it and a fetch that failed are
+    // different problems, and only the second one is worth retrying.
+    if (unavailableThreadIds.length) {
       AppEnv.showErrorDialog(
-        threadIds.length === 1
+        unavailableThreadIds.length === 1
+          ? localized('This conversation has no message that can be attached.')
+          : localized(
+              '%1$@ of the conversations have no message that can be attached.',
+              unavailableThreadIds.length
+            )
+      );
+    }
+
+    const failedCount = threadIds.length - unavailableThreadIds.length - staged.length;
+    if (failedCount > 0) {
+      AppEnv.showErrorDialog(
+        failedCount === 1
           ? localized('Could not download the original message. Please try again.')
           : localized(
               'Could not download %1$@ of the original messages. Please try again.',
-              threadIds.length - staged.length
+              failedCount
             )
       );
     }

--- a/app/internal_packages/composer/styles/composer.less
+++ b/app/internal_packages/composer/styles/composer.less
@@ -601,16 +601,25 @@ body.platform-win32 {
 }
 
 // Placeholder shown while a thread dragged onto the composer is being fetched
-// from the sync engine and written out as a .eml file.
+// from the sync engine and written out as a .eml file. Indented to line up
+// with .nylas-attachment-item, which it sits alongside.
 .attaching-messages {
   display: flex;
   align-items: center;
-  padding: @spacing-half 0;
+  margin: 0 0 @spacing-standard @spacing-standard;
   color: @text-color-subtle;
-  font-size: @font-size-smaller;
+  font-size: @font-size-small;
 
-  img {
+  .spinner {
+    width: auto;
     margin-right: @spacing-half;
+
+    > div {
+      width: 6px;
+      height: 6px;
+      margin-right: 2px;
+      margin-left: 0;
+    }
   }
 }
 

--- a/app/internal_packages/composer/styles/composer.less
+++ b/app/internal_packages/composer/styles/composer.less
@@ -600,6 +600,20 @@ body.platform-win32 {
   }
 }
 
+// Placeholder shown while a thread dragged onto the composer is being fetched
+// from the sync engine and written out as a .eml file.
+.attaching-messages {
+  display: flex;
+  align-items: center;
+  padding: @spacing-half 0;
+  color: @text-color-subtle;
+  font-size: @font-size-smaller;
+
+  img {
+    margin-right: @spacing-half;
+  }
+}
+
 // Overrides for the full-window popout composer
 .composer-full-window {
   width: 100%;

--- a/app/internal_packages/message-list/lib/message-list.tsx
+++ b/app/internal_packages/message-list/lib/message-list.tsx
@@ -177,6 +177,7 @@ class MessageList extends React.Component<Record<string, unknown>, MessageListSt
       filePath: staged[0].filePath,
       headerMessageId: draft.headerMessageId,
       onCreated: () => {
+        EmlUtils.discardStagedEml(staged[0].filePath);
         Actions.composePopoutDraft(draft.headerMessageId);
       },
     });

--- a/app/internal_packages/message-list/lib/message-list.tsx
+++ b/app/internal_packages/message-list/lib/message-list.tsx
@@ -150,12 +150,12 @@ class MessageList extends React.Component<Record<string, unknown>, MessageListSt
     if (!message || !this.state.currentThread) {
       return;
     }
-    const staged = await EmlUtils.stageMessagesAsEml([message], {
+    const staged = await EmlUtils.stageMessageAsEml(message, {
       filename: 'Forwarded Message.eml',
     });
 
     // The fetch is remote and can fail without writing anything
-    if (!staged.length) {
+    if (!staged) {
       AppEnv.showErrorDialog(
         localized('Could not download the original message. Please try again.')
       );
@@ -174,10 +174,10 @@ class MessageList extends React.Component<Record<string, unknown>, MessageListSt
     await TaskQueue.waitForPerformLocal(syncTask);
 
     Actions.addAttachment({
-      filePath: staged[0].filePath,
+      filePath: staged.filePath,
       headerMessageId: draft.headerMessageId,
       onCreated: () => {
-        EmlUtils.discardStagedEml(staged[0].filePath);
+        EmlUtils.discardStagedEml(staged.filePath);
         Actions.composePopoutDraft(draft.headerMessageId);
       },
     });

--- a/app/internal_packages/message-list/lib/message-list.tsx
+++ b/app/internal_packages/message-list/lib/message-list.tsx
@@ -150,29 +150,12 @@ class MessageList extends React.Component<Record<string, unknown>, MessageListSt
     if (!message || !this.state.currentThread) {
       return;
     }
-    const pathModule = require('path');
-    const fs = require('fs');
-
-    // Use a unique subdirectory per operation so concurrent forwards don't
-    // race on the same file. The basename stays "Forwarded Message.eml" so
-    // the attachment has a clean display name.
-    const tempDir = pathModule.join(
-      require('@electron/remote').app.getPath('temp'),
-      `mailspring-fwd-${message.id}`
-    );
-    fs.mkdirSync(tempDir, { recursive: true });
-    const tempPath = pathModule.join(tempDir, 'Forwarded Message.eml');
-
-    const task = new GetMessageRFC2822Task({
-      messageId: message.id,
-      accountId: message.accountId,
-      filepath: tempPath,
+    const staged = await EmlUtils.stageMessagesAsEml([message], {
+      filename: 'Forwarded Message.eml',
     });
-    Actions.queueTask(task);
-    await TaskQueue.waitForPerformRemote(task);
 
-    // Verify the file was actually written before creating a draft
-    if (!fs.existsSync(tempPath)) {
+    // The fetch is remote and can fail without writing anything
+    if (!staged.length) {
       AppEnv.showErrorDialog(
         localized('Could not download the original message. Please try again.')
       );
@@ -191,7 +174,7 @@ class MessageList extends React.Component<Record<string, unknown>, MessageListSt
     await TaskQueue.waitForPerformLocal(syncTask);
 
     Actions.addAttachment({
-      filePath: tempPath,
+      filePath: staged[0].filePath,
       headerMessageId: draft.headerMessageId,
       onCreated: () => {
         Actions.composePopoutDraft(draft.headerMessageId);

--- a/app/internal_packages/thread-list/lib/thread-list-context-menu.ts
+++ b/app/internal_packages/thread-list/lib/thread-list-context-menu.ts
@@ -165,20 +165,17 @@ export default class ThreadListContextMenu {
       label: localized('Forward as Attachment'),
       click: async () => {
         const thread = this.threads[0];
-        const messages = await EmlUtils.newestExportableMessagesForThreadIds([thread.id]);
-        if (!messages.length) return;
-
-        const message = messages[0];
-        const staged = await EmlUtils.stageMessagesAsEml([message], {
+        const staged = await EmlUtils.stageThreadAsEml(thread.id, {
           filename: 'Forwarded Message.eml',
         });
 
-        if (!staged.length) {
+        if (!staged) {
           AppEnv.showErrorDialog(
             localized('Could not download the original message. Please try again.')
           );
           return;
         }
+        const { message, filePath } = staged;
 
         const account = AccountStore.accountForId(message.accountId);
         const draft = await DraftFactory.createDraft({
@@ -192,10 +189,10 @@ export default class ThreadListContextMenu {
         await TaskQueue.waitForPerformLocal(syncTask);
 
         Actions.addAttachment({
-          filePath: staged[0].filePath,
+          filePath,
           headerMessageId: draft.headerMessageId,
           onCreated: () => {
-            EmlUtils.discardStagedEml(staged[0].filePath);
+            EmlUtils.discardStagedEml(filePath);
             Actions.composePopoutDraft(draft.headerMessageId);
           },
         });

--- a/app/internal_packages/thread-list/lib/thread-list-context-menu.ts
+++ b/app/internal_packages/thread-list/lib/thread-list-context-menu.ts
@@ -195,6 +195,7 @@ export default class ThreadListContextMenu {
           filePath: staged[0].filePath,
           headerMessageId: draft.headerMessageId,
           onCreated: () => {
+            EmlUtils.discardStagedEml(staged[0].filePath);
             Actions.composePopoutDraft(draft.headerMessageId);
           },
         });

--- a/app/internal_packages/thread-list/lib/thread-list-context-menu.ts
+++ b/app/internal_packages/thread-list/lib/thread-list-context-menu.ts
@@ -165,30 +165,15 @@ export default class ThreadListContextMenu {
       label: localized('Forward as Attachment'),
       click: async () => {
         const thread = this.threads[0];
-        const messages = await DatabaseStore.findAll<Message>(Message, { threadId: thread.id })
-          .order(Message.attributes.date.descending())
-          .limit(1);
+        const messages = await EmlUtils.newestExportableMessagesForThreadIds([thread.id]);
         if (!messages.length) return;
 
         const message = messages[0];
-        const pathModule = require('path');
-        const fs = require('fs');
-        const tempDir = pathModule.join(
-          require('@electron/remote').app.getPath('temp'),
-          `mailspring-fwd-${message.id}`
-        );
-        fs.mkdirSync(tempDir, { recursive: true });
-        const tempPath = pathModule.join(tempDir, 'Forwarded Message.eml');
-
-        const task = new GetMessageRFC2822Task({
-          messageId: message.id,
-          accountId: message.accountId,
-          filepath: tempPath,
+        const staged = await EmlUtils.stageMessagesAsEml([message], {
+          filename: 'Forwarded Message.eml',
         });
-        Actions.queueTask(task);
-        await TaskQueue.waitForPerformRemote(task);
 
-        if (!fs.existsSync(tempPath)) {
+        if (!staged.length) {
           AppEnv.showErrorDialog(
             localized('Could not download the original message. Please try again.')
           );
@@ -207,7 +192,7 @@ export default class ThreadListContextMenu {
         await TaskQueue.waitForPerformLocal(syncTask);
 
         Actions.addAttachment({
-          filePath: tempPath,
+          filePath: staged[0].filePath,
           headerMessageId: draft.headerMessageId,
           onCreated: () => {
             Actions.composePopoutDraft(draft.headerMessageId);
@@ -340,9 +325,7 @@ export default class ThreadListContextMenu {
       click: async () => {
         if (this.threadIds.length === 1) {
           const thread = this.threads[0];
-          const messages = await DatabaseStore.findAll<Message>(Message, { threadId: thread.id })
-            .order(Message.attributes.date.descending())
-            .limit(1);
+          const messages = await EmlUtils.newestExportableMessagesForThreadIds([thread.id]);
           if (!messages.length) return;
 
           const message = messages[0];
@@ -369,15 +352,11 @@ export default class ThreadListContextMenu {
               const outputDir = selected[0];
               const path = require('path');
 
-              for (const thread of this.threads) {
-                const messages = await DatabaseStore.findAll<Message>(Message, {
-                  threadId: thread.id,
-                })
-                  .order(Message.attributes.date.descending())
-                  .limit(1);
-                if (!messages.length) continue;
+              const messages = await EmlUtils.newestExportableMessagesForThreadIds(
+                this.threads.map((t) => t.id)
+              );
 
-                const message = messages[0];
+              for (const message of messages) {
                 const filename = EmlUtils.defaultEmlFilename(message.subject);
 
                 const task = new GetMessageRFC2822Task({

--- a/app/internal_packages/thread-list/lib/thread-list.tsx
+++ b/app/internal_packages/thread-list/lib/thread-list.tsx
@@ -14,6 +14,7 @@ import {
   Actions,
   Utils,
   CanvasUtils,
+  DragDropTypes,
   ChangeStarredTask,
   ChangeFolderTask,
   ChangeLabelsTask,
@@ -242,8 +243,11 @@ class ThreadList extends React.Component<
 
     const canvas = CanvasUtils.canvasForDragging('threads', data.threadIds.length);
     event.dataTransfer.setDragImage(canvas, 10, 10);
-    event.dataTransfer.setData('mailspring-threads-data', JSON.stringify(data));
-    event.dataTransfer.setData(`mailspring-accounts=${data.accountIds.join(',')}`, '1');
+    event.dataTransfer.setData(DragDropTypes.ThreadsDragType, JSON.stringify(data));
+    event.dataTransfer.setData(
+      `${DragDropTypes.AccountsDragTypePrefix}${data.accountIds.join(',')}`,
+      '1'
+    );
   };
 
   _onDragEnd = (event: React.DragEvent) => {};

--- a/app/spec/components/drop-zone-spec.tsx
+++ b/app/spec/components/drop-zone-spec.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { findRenderedDOMComponentWithClass, Simulate } from 'react-dom/test-utils';
+
+import { DropZone } from '../../src/components/drop-zone';
+import MTestUtils from '../mailspring-test-utils';
+
+// A drop target only receives a drop event if something calls preventDefault on
+// dragover. The composer wraps a Slate editor, and drags that begin inside Slate
+// are Slate's to manage, so DropZone steps aside for those — but stepping aside
+// for every drag over the editor left the middle of the composer, the largest
+// and most obvious drop target, silently refusing drops.
+const dragEventData = (types: string[]) => ({
+  dataTransfer: {
+    types,
+    effectAllowed: 'copy',
+    dropEffect: 'none',
+    getData: () => '',
+  },
+});
+
+const renderZone = (shouldAcceptDrop: (e: any) => boolean) =>
+  MTestUtils.renderIntoDocument(
+    <DropZone
+      className="zone"
+      shouldAcceptDrop={shouldAcceptDrop}
+      onDrop={() => {}}
+      onDragStateChange={() => {}}
+    >
+      <div className="editor" data-slate-editor>
+        <span className="inside-editor">body</span>
+      </div>
+      <div className="outside-editor">footer</div>
+    </DropZone>
+  ) as any;
+
+describe('DropZone', function dropZone() {
+  describe('dragging over the Slate editor', () => {
+    it('allows the drop when the zone accepts the drag', () => {
+      const zone = renderZone(() => true);
+      const target = findRenderedDOMComponentWithClass(zone, 'inside-editor');
+      const event = dragEventData(['mailspring-threads-data']);
+
+      Simulate.dragOver(target, event as any);
+
+      // preventDefault is what makes the browser deliver a drop here at all
+      expect(event.dataTransfer.dropEffect).toEqual('copy');
+    });
+
+    it('leaves the drag alone when the zone does not accept it', () => {
+      const zone = renderZone(() => false);
+      const target = findRenderedDOMComponentWithClass(zone, 'inside-editor');
+      const event = dragEventData(['application/x-slate-fragment']);
+
+      Simulate.dragOver(target, event as any);
+
+      // Untouched: Slate sets its own drop effect and draws the caret
+      expect(event.dataTransfer.dropEffect).toEqual('none');
+    });
+  });
+
+  describe('dragging elsewhere in the zone', () => {
+    it('allows the drop without consulting the editor exception', () => {
+      const zone = renderZone(() => false);
+      const target = findRenderedDOMComponentWithClass(zone, 'outside-editor');
+      const event = dragEventData(['Files']);
+
+      Simulate.dragOver(target, event as any);
+
+      expect(event.dataTransfer.dropEffect).toEqual('copy');
+    });
+
+    it('falls back to copy when effectAllowed is uninitialized', () => {
+      const zone = renderZone(() => true);
+      const target = findRenderedDOMComponentWithClass(zone, 'outside-editor');
+      const event = dragEventData(['Files']);
+      event.dataTransfer.effectAllowed = 'uninitialized';
+
+      Simulate.dragOver(target, event as any);
+
+      expect(event.dataTransfer.dropEffect).toEqual('copy');
+    });
+  });
+});

--- a/app/spec/services/eml-utils-spec.ts
+++ b/app/spec/services/eml-utils-spec.ts
@@ -12,7 +12,9 @@ import {
   defaultEmlFilename,
   discardStagedEml,
   newestExportableMessagesForThreadIds,
+  stageMessageAsEml,
   stageMessagesAsEml,
+  stageThreadAsEml,
   stageThreadsAsEml,
 } from '../../src/services/eml-utils';
 
@@ -344,6 +346,55 @@ describe('discardStagedEml', function () {
     expect(() =>
       discardStagedEml(path.join(os.tmpdir(), 'mailspring-eml-spec-absent', 'Hello.eml'))
     ).not.toThrow();
+  });
+});
+
+describe('stageMessageAsEml', function () {
+  beforeEach(() => {
+    spyOn(Actions, 'queueTask');
+  });
+
+  it('unwraps the single staged result', async () => {
+    spyOn(TaskQueue, 'waitForPerformRemote').andCallFake((task: GetMessageRFC2822Task) => {
+      fs.writeFileSync(task.filepath, 'raw');
+      return Promise.resolve();
+    });
+    const staged = await stageMessageAsEml(
+      new Message({ id: 'm1', accountId: 'a1', subject: 'Hello' })
+    );
+    expect(path.basename(staged.filePath)).toEqual('Hello.eml');
+    discardStagedEml(staged.filePath);
+  });
+
+  it('returns null when the fetch produced no file', async () => {
+    spyOn(TaskQueue, 'waitForPerformRemote').andCallFake(() => Promise.resolve());
+    const staged = await stageMessageAsEml(
+      new Message({ id: 'm1', accountId: 'a1', subject: 'Hello' })
+    );
+    expect(staged).toBe(null);
+  });
+});
+
+describe('stageThreadAsEml', function () {
+  it('returns null when the thread has no exportable message', async () => {
+    spyOn(Actions, 'queueTask');
+    spyOn(DatabaseStore, 'findAll').andCallFake(() => {
+      const query: any = {
+        order() {
+          return this;
+        },
+        limit() {
+          return this;
+        },
+        then(callback) {
+          return Promise.resolve([]).then(callback);
+        },
+      };
+      return query;
+    });
+
+    expect(await stageThreadAsEml('t1')).toBe(null);
+    expect(Actions.queueTask).not.toHaveBeenCalled();
   });
 });
 

--- a/app/spec/services/eml-utils-spec.ts
+++ b/app/spec/services/eml-utils-spec.ts
@@ -1,4 +1,17 @@
-import { defaultEmlFilename } from '../../src/services/eml-utils';
+import fs from 'fs';
+import path from 'path';
+import {
+  Actions,
+  DatabaseStore,
+  Message,
+  TaskQueue,
+  GetMessageRFC2822Task,
+} from 'mailspring-exports';
+import {
+  defaultEmlFilename,
+  newestExportableMessagesForThreadIds,
+  stageMessagesAsEml,
+} from '../../src/services/eml-utils';
 
 describe('defaultEmlFilename', function () {
   describe('normal subjects', () => {
@@ -115,9 +128,7 @@ describe('defaultEmlFilename', function () {
 
     it('strips all C0 control characters', () => {
       // Build a string with chars 0x01–0x1F between "a" and "b"
-      const controls = Array.from({ length: 31 }, (_, i) =>
-        String.fromCharCode(i + 1)
-      ).join('');
+      const controls = Array.from({ length: 31 }, (_, i) => String.fromCharCode(i + 1)).join('');
       expect(defaultEmlFilename(`a${controls}b`)).toEqual('ab.eml');
     });
   });
@@ -146,5 +157,146 @@ describe('defaultEmlFilename', function () {
     it('does not remove dots in the middle of the name', () => {
       expect(defaultEmlFilename('v1.2.3 release')).toEqual('v1.2.3 release.eml');
     });
+  });
+});
+
+describe('newestExportableMessagesForThreadIds', function () {
+  const queryFor = (results: Message[]) => {
+    const query: any = {
+      order() {
+        return this;
+      },
+      limit() {
+        return this;
+      },
+      then(callback) {
+        return Promise.resolve(results).then(callback);
+      },
+    };
+    return query;
+  };
+
+  it('returns the single newest message the query yields for each thread', async () => {
+    const a = new Message({ id: 'a', threadId: 't1' });
+    const b = new Message({ id: 'b', threadId: 't2' });
+    spyOn(DatabaseStore, 'findAll').andCallFake((klass, where) =>
+      queryFor(where.threadId === 't1' ? [a] : [b])
+    );
+
+    const messages = await newestExportableMessagesForThreadIds(['t1', 't2']);
+    expect(messages.map((m) => m.id)).toEqual(['a', 'b']);
+  });
+
+  it('excludes drafts, which have no raw source on the server', async () => {
+    spyOn(DatabaseStore, 'findAll').andCallFake(() => queryFor([]));
+    await newestExportableMessagesForThreadIds(['t1']);
+    expect((DatabaseStore.findAll as any).calls[0].args[1]).toEqual({
+      threadId: 't1',
+      draft: false,
+    });
+  });
+
+  it('omits threads that have no exportable message', async () => {
+    const a = new Message({ id: 'a', threadId: 't1' });
+    spyOn(DatabaseStore, 'findAll').andCallFake((klass, where) =>
+      queryFor(where.threadId === 't1' ? [a] : [])
+    );
+
+    const messages = await newestExportableMessagesForThreadIds(['t1', 't2']);
+    expect(messages.map((m) => m.id)).toEqual(['a']);
+  });
+
+  it('returns an empty array when given no threads', async () => {
+    spyOn(DatabaseStore, 'findAll').andCallFake(() => queryFor([]));
+    expect(await newestExportableMessagesForThreadIds([])).toEqual([]);
+    expect(DatabaseStore.findAll).not.toHaveBeenCalled();
+  });
+});
+
+describe('stageMessagesAsEml', function () {
+  let queued: GetMessageRFC2822Task[] = [];
+  let cleanup: string[] = [];
+
+  // Stand in for the sync engine: when a fetch is awaited, write the file it
+  // was asked to produce. `writeFor` decides which ones actually get written.
+  const engineWrites = (writeFor: (task: GetMessageRFC2822Task) => boolean) => {
+    (TaskQueue.waitForPerformRemote as any).andCallFake((task: GetMessageRFC2822Task) => {
+      if (writeFor(task)) {
+        fs.writeFileSync(task.filepath, 'Subject: raw\r\n\r\nbody\r\n');
+        cleanup.push(path.dirname(task.filepath));
+      }
+      return Promise.resolve();
+    });
+  };
+
+  beforeEach(() => {
+    queued = [];
+    cleanup = [];
+    spyOn(Actions, 'queueTask').andCallFake((task) => queued.push(task));
+    spyOn(TaskQueue, 'waitForPerformRemote').andCallFake(() => Promise.resolve());
+  });
+
+  afterEach(() => {
+    for (const dir of cleanup) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('queues one fetch per message, staging each into its own directory', async () => {
+    engineWrites(() => true);
+    const messages = [
+      new Message({ id: 'm1', accountId: 'a1', subject: 'Hello' }),
+      new Message({ id: 'm2', accountId: 'a2', subject: 'World' }),
+    ];
+
+    const staged = await stageMessagesAsEml(messages);
+
+    expect(queued.length).toEqual(2);
+    expect(queued.map((t) => t.messageId)).toEqual(['m1', 'm2']);
+    expect(queued.map((t) => t.accountId)).toEqual(['a1', 'a2']);
+    expect(staged.map((s) => path.basename(s.filePath))).toEqual(['Hello.eml', 'World.eml']);
+    expect(path.dirname(staged[0].filePath)).not.toEqual(path.dirname(staged[1].filePath));
+  });
+
+  it('queues every fetch before awaiting any of them', async () => {
+    let resolveAll;
+    const gate = new Promise<void>((resolve) => (resolveAll = resolve));
+    (TaskQueue.waitForPerformRemote as any).andCallFake(() => gate);
+
+    const promise = stageMessagesAsEml([
+      new Message({ id: 'm1', accountId: 'a1', subject: 'One' }),
+      new Message({ id: 'm2', accountId: 'a1', subject: 'Two' }),
+    ]);
+    expect(queued.length).toEqual(2);
+    resolveAll();
+    const staged = await promise;
+    // Nothing was written, so nothing is reported as staged
+    expect(staged).toEqual([]);
+  });
+
+  it('omits messages whose file was never written', async () => {
+    engineWrites((task) => task.messageId === 'm1');
+    const staged = await stageMessagesAsEml([
+      new Message({ id: 'm1', accountId: 'a1', subject: 'Written' }),
+      new Message({ id: 'm2', accountId: 'a1', subject: 'Missing' }),
+    ]);
+
+    expect(staged.length).toEqual(1);
+    expect(staged[0].message.id).toEqual('m1');
+    expect(path.basename(staged[0].filePath)).toEqual('Written.eml');
+  });
+
+  it('uses an explicit filename when one is given', async () => {
+    engineWrites(() => true);
+    const staged = await stageMessagesAsEml(
+      [new Message({ id: 'm1', accountId: 'a1', subject: 'Hello' })],
+      { filename: 'Forwarded Message.eml' }
+    );
+    expect(path.basename(staged[0].filePath)).toEqual('Forwarded Message.eml');
+  });
+
+  it('does nothing when given no messages', async () => {
+    expect(await stageMessagesAsEml([])).toEqual([]);
+    expect(Actions.queueTask).not.toHaveBeenCalled();
   });
 });

--- a/app/spec/services/eml-utils-spec.ts
+++ b/app/spec/services/eml-utils-spec.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 import {
   Actions,
@@ -9,8 +10,10 @@ import {
 } from 'mailspring-exports';
 import {
   defaultEmlFilename,
+  discardStagedEml,
   newestExportableMessagesForThreadIds,
   stageMessagesAsEml,
+  stageThreadsAsEml,
 } from '../../src/services/eml-utils';
 
 describe('defaultEmlFilename', function () {
@@ -298,5 +301,80 @@ describe('stageMessagesAsEml', function () {
   it('does nothing when given no messages', async () => {
     expect(await stageMessagesAsEml([])).toEqual([]);
     expect(Actions.queueTask).not.toHaveBeenCalled();
+  });
+
+  it('removes the staging directory of a message whose file never arrived', async () => {
+    engineWrites(() => false);
+    await stageMessagesAsEml([new Message({ id: 'm1', accountId: 'a1', subject: 'Missing' })]);
+    expect(fs.existsSync(path.dirname(queued[0].filepath))).toBe(false);
+  });
+
+  it('leaves the staging directory of a written file in place for the caller', async () => {
+    engineWrites(() => true);
+    const staged = await stageMessagesAsEml([
+      new Message({ id: 'm1', accountId: 'a1', subject: 'Written' }),
+    ]);
+    expect(fs.existsSync(staged[0].filePath)).toBe(true);
+  });
+});
+
+describe('discardStagedEml', function () {
+  it('removes the file and the staging directory around it', () => {
+    const dir = path.join(os.tmpdir(), 'mailspring-eml-spec-discard');
+    const filePath = path.join(dir, 'Hello.eml');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(filePath, 'raw');
+
+    discardStagedEml(filePath);
+    expect(fs.existsSync(dir)).toBe(false);
+  });
+
+  it('refuses to touch a directory it did not create', () => {
+    const dir = path.join(os.tmpdir(), 'mailspring-spec-not-staging');
+    const filePath = path.join(dir, 'Hello.eml');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(filePath, 'raw');
+
+    discardStagedEml(filePath);
+    expect(fs.existsSync(filePath)).toBe(true);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('does not throw when the file is already gone', () => {
+    expect(() =>
+      discardStagedEml(path.join(os.tmpdir(), 'mailspring-eml-spec-absent', 'Hello.eml'))
+    ).not.toThrow();
+  });
+});
+
+describe('stageThreadsAsEml', function () {
+  beforeEach(() => {
+    spyOn(Actions, 'queueTask');
+    spyOn(TaskQueue, 'waitForPerformRemote').andCallFake(() => Promise.resolve());
+  });
+
+  it('reports threads with no exportable message separately from failed fetches', async () => {
+    const a = new Message({ id: 'a', threadId: 't1', accountId: 'a1', subject: 'Hello' });
+    spyOn(DatabaseStore, 'findAll').andCallFake((klass, where) => {
+      const results = where.threadId === 't1' ? [a] : [];
+      const query: any = {
+        order() {
+          return this;
+        },
+        limit() {
+          return this;
+        },
+        then(callback) {
+          return Promise.resolve(results).then(callback);
+        },
+      };
+      return query;
+    });
+
+    // Nothing is written, so t1 counts as a failed fetch rather than an
+    // unavailable thread — the two must not be conflated.
+    const { staged, unavailableThreadIds } = await stageThreadsAsEml(['t1', 't2']);
+    expect(staged).toEqual([]);
+    expect(unavailableThreadIds).toEqual(['t2']);
   });
 });

--- a/app/src/components/drop-zone.tsx
+++ b/app/src/components/drop-zone.tsx
@@ -70,8 +70,20 @@ export class DropZone extends React.Component<DropZoneProps> {
       <div
         {...otherProps}
         onDragOver={(event) => {
-          if (event.target instanceof HTMLElement && event.target.closest('[data-slate-editor]'))
+          // Drags that start inside the Slate editor (moving an inline image, say)
+          // are Slate's to manage - it sets the drop effect and shows a caret, and
+          // preventing the default here would hide it. Anything we've said we'll
+          // accept still needs preventDefault, even over the editor: a
+          // contenteditable refuses drags it has no way to insert - like a dragged
+          // thread, which carries only our own dataTransfer types - so without it
+          // no drop event ever fires in the middle of the composer.
+          if (
+            event.target instanceof HTMLElement &&
+            event.target.closest('[data-slate-editor]') &&
+            !this.props.shouldAcceptDrop(event)
+          ) {
             return;
+          }
           const allowed = event.dataTransfer.effectAllowed;
           if (allowed && allowed !== 'all' && allowed !== 'uninitialized') {
             // Only set dropEffect if it's a valid value (not 'all' or 'uninitialized')

--- a/app/src/drag-drop-types.ts
+++ b/app/src/drag-drop-types.ts
@@ -1,0 +1,20 @@
+/**
+ * Custom dataTransfer types used for drag and drop within the app.
+ *
+ * A drop target can only read `dataTransfer.types` during dragenter/dragover —
+ * the payload itself isn't readable until the drop lands. That's why the
+ * account ids are encoded into a type name rather than the payload: a target
+ * that can only accept threads from certain accounts has to decide before it
+ * can call getData.
+ */
+
+/** JSON `{ threadIds, accountIds }`, set when threads are dragged. */
+export const ThreadsDragType = 'mailspring-threads-data';
+
+/** Prefix of a value-less type carrying the dragged threads' account ids. */
+export const AccountsDragTypePrefix = 'mailspring-accounts=';
+
+export function accountIdsForDragTypes(types: readonly string[]): string[] {
+  const accountsType = types.find((t) => t.startsWith(AccountsDragTypePrefix));
+  return (accountsType || '').replace(AccountsDragTypePrefix, '').split(',');
+}

--- a/app/src/global/mailspring-exports.d.ts
+++ b/app/src/global/mailspring-exports.d.ts
@@ -204,6 +204,8 @@ export type FsUtils = typeof import('../fs-utils');
 export const FsUtils: FsUtils;
 export type CanvasUtils = typeof import('../canvas-utils');
 export const CanvasUtils: CanvasUtils;
+export type DragDropTypes = typeof import('../drag-drop-types');
+export const DragDropTypes: DragDropTypes;
 export type RegExpUtils = typeof import('../regexp-utils').default;
 export const RegExpUtils: RegExpUtils;
 export type MenuHelpers = typeof import('../menu-helpers');

--- a/app/src/global/mailspring-exports.js
+++ b/app/src/global/mailspring-exports.js
@@ -187,6 +187,7 @@ lazyLoad(`CalendarUtils`, 'calendar-utils');
 lazyLoad(`ICSEventHelpers`, 'ics-event-helpers');
 lazyLoad(`FsUtils`, 'fs-utils');
 lazyLoad(`CanvasUtils`, 'canvas-utils');
+lazyLoad(`DragDropTypes`, 'drag-drop-types');
 lazyLoad(`RegExpUtils`, 'regexp-utils');
 lazyLoad(`MenuHelpers`, 'menu-helpers');
 lazyLoad(`VirtualDOMUtils`, 'virtual-dom-utils');

--- a/app/src/services/eml-utils.ts
+++ b/app/src/services/eml-utils.ts
@@ -112,19 +112,67 @@ export async function stageMessagesAsEml(
 
   await Promise.all(tasks.map((task) => TaskQueue.waitForPerformRemote(task)));
 
-  return staged
-    .filter(({ filePath }) => fs.existsSync(filePath))
-    .map(({ message, filePath }) => ({ message, filePath }));
+  // Directories whose file never arrived are dead weight — drop them now, and
+  // leave the rest to discardStagedEml once the caller is done with the file.
+  const [written, missing] = partition(staged, ({ filePath }) => fs.existsSync(filePath));
+  missing.forEach(({ dir }) => removeStagingDirectory(dir));
+
+  return written.map(({ message, filePath }) => ({ message, filePath }));
+}
+
+/**
+ * Delete a file produced by stageMessagesAsEml, along with the staging
+ * directory it lives in.
+ *
+ * Staged files are consumed by copying them somewhere permanent — attaching
+ * one to a draft copies it into the attachment store — so the temporary copy
+ * is garbage the moment the caller is finished with it. Callers should invoke
+ * this once that's true (for attachments, from `addAttachment`'s `onCreated`).
+ * Failures are ignored: leaving a file behind in the temp directory is not
+ * worth interrupting the user over.
+ */
+export function discardStagedEml(filePath: string) {
+  removeStagingDirectory(path.dirname(filePath));
+}
+
+const STAGING_DIR_PREFIX = 'mailspring-eml-';
+
+function removeStagingDirectory(dir: string) {
+  // Guard against deleting anything we didn't create ourselves — callers hand
+  // us paths, and a wrong one shouldn't take a real directory with it.
+  if (!path.basename(dir).startsWith(STAGING_DIR_PREFIX)) {
+    return;
+  }
+  try {
+    fs.rmSync(dir, { recursive: true, force: true });
+  } catch (err) {
+    // best effort
+  }
+}
+
+function partition<T>(items: T[], predicate: (item: T) => boolean): [T[], T[]] {
+  const yes: T[] = [];
+  const no: T[] = [];
+  items.forEach((item) => (predicate(item) ? yes : no).push(item));
+  return [yes, no];
+}
+
+export interface StagedThreads {
+  staged: StagedEml[];
+  /**
+   * Threads that hold nothing exportable — a conversation containing only
+   * unsent drafts, say. Nothing was fetched for these, so they're a distinct
+   * outcome from a fetch that was attempted and failed.
+   */
+  unavailableThreadIds: string[];
 }
 
 /**
  * Convenience wrapper over the two steps above: turn a set of thread ids into
  * staged .eml files ready to be attached to a draft.
  */
-export async function stageThreadsAsEml(threadIds: string[]): Promise<StagedEml[]> {
+export async function stageThreadsAsEml(threadIds: string[]): Promise<StagedThreads> {
   const messages = await newestExportableMessagesForThreadIds(threadIds);
-  if (!messages.length) {
-    return [];
-  }
-  return stageMessagesAsEml(messages);
+  const unavailableThreadIds = threadIds.filter((id) => !messages.some((m) => m.threadId === id));
+  return { staged: await stageMessagesAsEml(messages), unavailableThreadIds };
 }

--- a/app/src/services/eml-utils.ts
+++ b/app/src/services/eml-utils.ts
@@ -1,3 +1,16 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import crypto from 'crypto';
+
+import {
+  Actions,
+  DatabaseStore,
+  Message,
+  TaskQueue,
+  GetMessageRFC2822Task,
+} from 'mailspring-exports';
+
 /**
  * Generate a safe default .eml filename from a message subject.
  *
@@ -18,4 +31,100 @@ export function defaultEmlFilename(subject: string): string {
   name = name.replace(/[\u0000-\u001f\u007f]/g, '');
   name = name.replace(/[.\s]+$/, '');
   return `${name}.eml`;
+}
+
+export interface StagedEml {
+  message: Message;
+  filePath: string;
+}
+
+/**
+ * Resolve the message that represents each of the given threads for the
+ * purposes of .eml export.
+ *
+ * .eml holds a single RFC2822 message, so a thread has to be narrowed to one.
+ * Everywhere in the app we use the same convention: the most recent message in
+ * the thread. Drafts are skipped — they only exist locally, so the sync engine
+ * has no raw source to hand back for them.
+ *
+ * Threads with no exportable message are omitted, so the result may be shorter
+ * than `threadIds`.
+ */
+export async function newestExportableMessagesForThreadIds(
+  threadIds: string[]
+): Promise<Message[]> {
+  if (!threadIds.length) {
+    return [];
+  }
+  const messages = await Promise.all(
+    threadIds.map(async (threadId) => {
+      const found = await DatabaseStore.findAll<Message>(Message, { threadId, draft: false })
+        .order(Message.attributes.date.descending())
+        .limit(1);
+      return found.length ? found[0] : null;
+    })
+  );
+  return messages.filter((m) => m !== null);
+}
+
+/**
+ * Ask the sync engine for the raw RFC2822 source of each message and write it
+ * to a temporary .eml file on disk.
+ *
+ * Each message is staged into its own randomly named subdirectory so that
+ * concurrent stages of the same message can't overwrite one another, and so
+ * that the file basename can be a clean, human-readable name (it becomes the
+ * attachment's display name when the file is attached to a draft). By default
+ * the name comes from the subject; pass `filename` to override it.
+ *
+ * The fetch is remote, so it may fail — and a GetMessageRFC2822Task can reach
+ * `complete` without having written anything. Messages whose file never
+ * appeared are omitted from the result, so callers should compare the returned
+ * length against what they passed in to detect partial failures.
+ */
+export async function stageMessagesAsEml(
+  messages: Message[],
+  { filename }: { filename?: string } = {}
+): Promise<StagedEml[]> {
+  if (!messages.length) {
+    return [];
+  }
+
+  const staged = messages.map((message) => {
+    const token = crypto.randomBytes(4).toString('hex');
+    const dir = path.join(os.tmpdir(), `mailspring-eml-${message.id}-${token}`);
+    const basename = filename || defaultEmlFilename(message.subject);
+    return { message, dir, filePath: path.join(dir, basename) };
+  });
+
+  // Queue every fetch before awaiting any of them so a multi-message stage
+  // isn't serialized on the sync engine's round trips.
+  const tasks = staged.map(({ message, dir, filePath }) => {
+    fs.mkdirSync(dir, { recursive: true });
+    const task = new GetMessageRFC2822Task({
+      messageId: message.id,
+      accountId: message.accountId,
+      filepath: filePath,
+    });
+    Actions.queueTask(task);
+    return task;
+  });
+
+  await Promise.all(tasks.map((task) => TaskQueue.waitForPerformRemote(task)));
+
+  return staged
+    .filter(({ filePath }) => fs.existsSync(filePath))
+    .map(({ message, filePath }) => ({ message, filePath }));
+}
+
+/**
+ * Convenience wrapper over the two steps above: turn a set of thread ids into
+ * staged .eml files ready to be attached to a draft.
+ */
+export async function stageThreadsAsEml(threadIds: string[]): Promise<StagedEml[]> {
+  const messages = await newestExportableMessagesForThreadIds(threadIds);
+  if (!messages.length) {
+    return [];
+  }
+  return stageMessagesAsEml(messages);
 }

--- a/app/src/services/eml-utils.ts
+++ b/app/src/services/eml-utils.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import crypto from 'crypto';
+import _ from 'underscore';
 
 import {
   Actions,
@@ -114,10 +115,33 @@ export async function stageMessagesAsEml(
 
   // Directories whose file never arrived are dead weight — drop them now, and
   // leave the rest to discardStagedEml once the caller is done with the file.
-  const [written, missing] = partition(staged, ({ filePath }) => fs.existsSync(filePath));
+  const [written, missing] = _.partition(staged, ({ filePath }) => fs.existsSync(filePath));
   missing.forEach(({ dir }) => removeStagingDirectory(dir));
 
   return written.map(({ message, filePath }) => ({ message, filePath }));
+}
+
+/**
+ * Stage a single message, returning null if its source couldn't be fetched.
+ */
+export async function stageMessageAsEml(
+  message: Message,
+  options: { filename?: string } = {}
+): Promise<StagedEml | null> {
+  const [staged] = await stageMessagesAsEml([message], options);
+  return staged || null;
+}
+
+/**
+ * Stage the message that represents a single thread, returning null if the
+ * thread has nothing exportable in it or its source couldn't be fetched.
+ */
+export async function stageThreadAsEml(
+  threadId: string,
+  options: { filename?: string } = {}
+): Promise<StagedEml | null> {
+  const [message] = await newestExportableMessagesForThreadIds([threadId]);
+  return message ? stageMessageAsEml(message, options) : null;
 }
 
 /**
@@ -148,13 +172,6 @@ function removeStagingDirectory(dir: string) {
   } catch (err) {
     // best effort
   }
-}
-
-function partition<T>(items: T[], predicate: (item: T) => boolean): [T[], T[]] {
-  const yes: T[] = [];
-  const no: T[] = [];
-  items.forEach((item) => (predicate(item) ? yes : no).push(item));
-  return [yes, no];
 }
 
 export interface StagedThreads {


### PR DESCRIPTION
## Summary

Dragging a thread out of the thread list and dropping it on an open composer now attaches it as a `.eml` file, the way Outlook and Gmail do.

Most of the machinery already existed. Thread rows publish their ids on `mailspring-threads-data` for the folder-drop feature, and the composer is already wrapped in a `DropZone` with a "Drop to Attach" overlay — the composer just had to learn to accept that type. `GetMessageRFC2822Task` + `Actions.addAttachment` are what "Forward as Attachment" already used to turn a message into a `.eml` and hang it off a draft.

The `.eml` is materialized **on drop, not on dragstart**: `dragstart` must populate `dataTransfer` synchronously, but fetching raw RFC2822 source is a round trip to the sync engine. Since the drop target is in-app, only thread ids are needed at dragstart.

## Key Changes

- **Shared staging helpers** (`app/src/services/eml-utils.ts`) — the "pick the thread's representative message → fetch raw source → write a temp file" sequence was copy-pasted between the message list and the thread list context menu. It now lives here and all four call sites share it:
  - `newestExportableMessagesForThreadIds()` — newest non-draft message per thread
  - `stageMessagesAsEml()` / `stageMessageAsEml()` — fetch and write to isolated temp `.eml` files
  - `stageThreadsAsEml()` / `stageThreadAsEml()` — thread ids straight through to staged files
  - `discardStagedEml()` — drop a staged file once the caller is done with it

- **Composer drop handling** (`composer-view.tsx`) — accepts `DragDropTypes.ThreadsDragType`, reads the ids synchronously in `_onDrop`, then stages and attaches asynchronously.

- **Attachments area** (`attachments-area.tsx`) — an `attaching` boolean renders a `Spinner` + "Attaching…" placeholder while files are being materialized.

- **Drag-type constants** (`app/src/drag-drop-types.ts`) — `mailspring-threads-data` and `mailspring-accounts=` are no longer magic strings; the thread list that writes them and the composer and folder sidebar that read them share the constants.

- **Test coverage** (`app/spec/services/eml-utils-spec.ts`) — the staging helpers, temp-directory cleanup, the `discardStagedEml` prefix guard, and the unavailable-vs-failed split. Suite is at 1489 passing.

## Behavior changes beyond the new feature

- **Drafts are excluded** when picking a thread's representative message. They only exist locally, so the sync engine has no raw source — previously an unsent draft could be selected as "newest message in thread" and the export would silently produce nothing. This fixes the existing Forward-as-Attachment and Save-as-.eml paths too.
- **Attachment filenames** are unchanged for the existing features (`Forwarded Message.eml`); dragged-in messages are named after their subject.
- **Dropping a thread onto a reply composed within that same thread is allowed.** An earlier commit filtered it out, but the payload isn't readable during `dragEnter`, so the drop cover had already appeared by the time the id was dropped — the drop looked accepted and then did nothing. Outlook and Gmail both allow it.

## Implementation notes

- Each message stages into its own randomly-named directory, so concurrent stages of the same message can't overwrite one another and the basename can be a clean display name.
- All fetches are queued before any is awaited, so a multi-thread drop isn't serialized on the sync engine's round trips.
- A `GetMessageRFC2822Task` can reach `complete` without having written anything, so results are filtered by file existence; those staging directories are removed immediately, and the rest are freed from `addAttachment`'s `onCreated`, which fires after the attachment store has copied the file into its own directory.

## Known limitation

This works for the **inline composer** (replying/forwarding in the main window). It does **not** work for **popout composer windows** — Chromium doesn't carry custom `dataTransfer` types across Electron `BrowserWindow` boundaries — and it doesn't enable drag-to-Desktop. Both need `webContents.startDrag`, which requires the file to exist before the drag begins, i.e. speculative pre-fetching on mousedown. That's a different mechanism and is left out rather than half-built.

https://claude.ai/code/session_01TQrDtxTjqZV5ms7W7Jp91m