### PR TITLE
Fix crash removing link mark when no link is active

### DIFF
--- a/app/src/components/composer-editor/toolbar-component-factories.tsx
+++ b/app/src/components/composer-editor/toolbar-component-factories.tsx
@@ -201,6 +201,13 @@ export function BuildMarkButtonWithValuePicker(config) {
       e.preventDefault();
       const { value, editor } = this.props;
       const active = safeActiveMarks(value).find((m) => m.type === config.type);
+      if (!active) {
+        // Nothing to remove — e.g. the user confirmed an empty URL field
+        // without ever having applied a mark. Calling into Slate with an
+        // undefined mark throws inside Mark.fromJSON.
+        editor.focus();
+        return;
+      }
       if (value.selection.isCollapsed) {
         const anchorNode = value.document.getNode(value.selection.anchor.key);
         const expanded = value.selection.moveToRangeOfNode(anchorNode);


### PR DESCRIPTION
## Summary

Fixes [MAILSPRING-CLIENT-10](https://foundry-376-llc.sentry.io/issues/MAILSPRING-CLIENT-10) — `Error: Mark.fromJS requires a type string`, thrown from deep inside Slate/`slate-react` (151 occurrences, 63 users impacted, ongoing since May 2026).

### Root cause

In `app/src/components/composer-editor/toolbar-component-factories.tsx`, `BuildMarkButtonWithValuePicker`'s `onRemove` handler looks up the currently active mark and unconditionally passes it to Slate:

```js
onRemove = (e: React.MouseEvent) => {
  e.preventDefault();
  const { value, editor } = this.props;
  const active = safeActiveMarks(value).find((m) => m.type === config.type);
  if (value.selection.isCollapsed) {
    const anchorNode = value.document.getNode(value.selection.anchor.key);
    const expanded = value.selection.moveToRangeOfNode(anchorNode);
    editor.removeMarkAtRange(expanded as any, active); // active can be undefined
  } else {
    editor.removeMark(active); // active can be undefined
  }
};
```

`active` is `undefined` whenever there is no link mark on the current selection. `onRemove` is called from `onConfirm` any time the user confirms the link popover (presses Enter, or clicks "Add") with an **empty URL field** — a common path, since the Link button is usually clicked with a collapsed cursor to insert a brand-new link, and it's easy to press Enter/click Add before typing a URL.

Slate's `Mark.create(properties = {})` silently defaults `undefined` to `{}`, which passes its "is a plain object" check and reaches `Mark.fromJSON({})`, where `type` is `undefined`, throwing `Mark.fromJS() requires a type string.` deep inside `slate`/`slate-react`, several frames away from the actual app-code bug — which is why the captured stack trace contains only library frames.

The sibling helper `removeMarksOfTypeInRange` in the same file already guards this exact case (`if (active) { editor.removeMark(active); }`), but `onRemove` was missing the same check.

### Fix

Add the missing guard: if there's no active mark to remove, focus the editor and return instead of calling into Slate with `undefined`.

## Test plan

- [x] `./node_modules/.bin/tsc -p app/tsconfig.json --noEmit` — passes
- [x] `node_modules/.bin/eslint -c .eslintrc app/src/components/composer-editor/toolbar-component-factories.tsx` — passes
- [ ] Manual: open composer, click the Link toolbar button with cursor placed in text (no selection), press Enter/click Add without typing a URL — previously threw, now no-ops as expected

---
_Generated by [Claude Code](https://claude.ai/code/session_01ArJJAaLoEUZekZhLpb9WXK)_