### PR TITLE
Live-reload the active theme's stylesheets when they change on disk

### DIFF
--- a/app/src/theme-manager.ts
+++ b/app/src/theme-manager.ts
@@ -52,6 +52,9 @@ export default class ThemeManager {
   private _systemAccentDisposable: Disposable | null = null;
   private _systemDarkMode = false;
 
+  private _themeStylesWatcher: fs.FSWatcher | null = null;
+  private _themeStylesReloadTimer: ReturnType<typeof setTimeout> | null = null;
+
   constructor({ packageManager, resourcePath, configDirPath, safeMode }) {
     this.packageManager = packageManager;
     this.resourcePath = resourcePath;
@@ -237,6 +240,40 @@ export default class ThemeManager {
 
     this.themeValueCache = {};
     this.activeThemePackage = next;
+    this.watchActiveThemeStyles();
+  }
+
+  // Watch the active theme's stylesheets and recompile LESS when they change
+  // on disk, so edits made outside the app - a theme developer iterating on a
+  // theme, or an external tool regenerating one (e.g. syncing the OS color
+  // palette) - appear in running windows without a restart. Packaged themes
+  // live inside the app archive, which cannot change at runtime, so only
+  // themes on the real filesystem are watched.
+  private watchActiveThemeStyles() {
+    if (this._themeStylesWatcher) {
+      this._themeStylesWatcher.close();
+      this._themeStylesWatcher = null;
+    }
+    const active = this.getActiveTheme();
+    if (!active) return;
+
+    const stylesPath = active.getStylesheetsPath();
+    if (stylesPath.includes('.asar') || !fs.existsSync(stylesPath)) return;
+
+    try {
+      this._themeStylesWatcher = fs.watch(stylesPath, (_eventType, filename) => {
+        if (filename && !/\.(less|css)$/.test(filename)) return;
+        // Debounce: regenerating a theme rewrites several files in quick
+        // succession, and one recompile covers all of them.
+        if (this._themeStylesReloadTimer) clearTimeout(this._themeStylesReloadTimer);
+        this._themeStylesReloadTimer = setTimeout(() => {
+          this._themeStylesReloadTimer = null;
+          this.updateThemePackageAndRecomputeLESS();
+        }, 100);
+      });
+    } catch (err) {
+      console.warn(`Unable to watch theme stylesheets at ${stylesPath}: ${err.message}`);
+    }
   }
 
   getImportPaths() {


### PR DESCRIPTION
## Description

Watches the active theme package's `styles/` directory and recompiles LESS when a stylesheet changes on disk, so a running Mailspring restyles without a restart.

The driver for this is theme syncing on Omarchy (Arch/Hyprland): a theme-set hook regenerates a Mailspring theme package from the OS palette whenever the system theme changes. OS dark/light flips already apply live, but switching between two dark themes rewrites the LESS under the same package name, and the running app doesn't pick that up until relaunch. This closes that gap. It also gives theme developers live iteration - edit, save, see it.

Notes:

- The watcher re-attaches in `activateThemePackage()`, so it follows automatic light/dark resolution.
- `.asar` paths are skipped - packaged themes can't change at runtime. In practice only themes in `~/.config/Mailspring/packages` (and source-tree themes in dev mode) are watched.
- Events are debounced 100ms since theme generators rewrite several files in quick succession; non-stylesheet events (editor/sed temp files) are filtered by extension.
- Known limit: adding a brand-new stylesheet file to an active theme still needs a re-activation. Content changes to existing stylesheets apply live.

## Verification

- Edited the active theme's `ui-variables.less` on disk - the running main window restyled in ~200ms, no restart (Linux, Wayland/Hyprland, real account).
- `sed -i` temp-file events were filtered, and multi-file rewrites collapsed into one recompute.
- Theme switching, automatic light/dark resolution, and onboarding (`forceBaseTheme`) behave as before.
- `npm run lint` and `tsc --noEmit` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)