### PR TITLE
Fix crash inserting fragment into empty composer document

### DIFF
--- a/app/src/flux/stores/draft-editing-session.ts
+++ b/app/src/flux/stores/draft-editing-session.ts
@@ -1,5 +1,6 @@
+import * as Immutable from 'immutable';
 import MailspringStore from 'mailspring-store';
-import { Editor, Value, Block } from 'slate';
+import { Editor, Value, Block, Text } from 'slate';
 
 import RegExpUtils from '../../regexp-utils';
 import { localized } from '../../intl';
@@ -86,8 +87,14 @@ function hotwireDraftBodyState(draft: any, session: DraftEditingSession): Messag
             }
           }
 
+          // Note: an empty block must still contain a Text node — a block with zero
+          // children leaves the document in a state Slate can't compute a selection
+          // range over (moveToRangeOfDocument crashes on Point.moveToStartOfNode).
           edits = edits
-            .replaceNodeByKey(first.key, Block.create({ type: 'div' }))
+            .replaceNodeByKey(
+              first.key,
+              Block.create({ type: 'div', nodes: Immutable.List([Text.create('')]) })
+            )
             .moveToRangeOfDocument()
             .insertFragment(inHTMLEditorValue.document);
 


### PR DESCRIPTION
## Summary

Fixes [MAILSPRING-CLIENT-X](https://foundry-376-llc.sentry.io/issues/MAILSPRING-CLIENT-X) — `Error: Unable to insert fragment into existing document.` (5 users impacted, ongoing on release 1.21.1 / 1.23.0).

## What I observed

The reported error is already caught in `hotwireDraftBodyState`'s `body` setter (`app/src/flux/stores/draft-editing-session.ts`), which is designed to fall back gracefully rather than crash the composer. But it also reports the failure to Sentry along with a shape-only snapshot of the offending document, specifically so the real bug could be diagnosed later. That data made root-causing this straightforward:

- `existingSlateShape` from a real event showed a document containing a single block: `{"type":"div","data":{},"nodes":[]}` — a block with **zero children**.
- The attached `underlyingError` was `TypeError: Cannot read properties of undefined (reading 'key')` at `Point.moveToStartOfNode`, called from `Selection.moveToRangeOfNode` → `Commands.moveToRangeOfNode`.

Slate blocks are expected to always contain at least one `Text` node; `Point.moveToStartOfNode` finds the start of a node by walking to its first text leaf, and blows up when there isn't one. The code path that produces this state is in the setter itself:

```ts
edits = edits
  .replaceNodeByKey(first.key, Block.create({ type: 'div' }))
  .moveToRangeOfDocument()
  .insertFragment(inHTMLEditorValue.document);
```

`Block.create({ type: 'div' })` with no `nodes` creates a block with no children, so the immediately following `moveToRangeOfDocument()` crashes computing a selection over the empty block — e.g. whenever a signature (or any body change routed through this setter) is applied to a draft whose Slate document has been reduced to a single empty node (such as right after clearing/replacing the body).

This exact invariant is already handled correctly elsewhere in the codebase — the broken-document recovery logic in `composer-editor.tsx` always gives an empty `div` a `Text('')` child:

```ts
node: Block.create({ type: 'div', nodes: Immutable.List([Text.create('')]) }),
```

## The fix

Apply the same pattern in `draft-editing-session.ts` so the placeholder block created before `insertFragment` always has a `Text` child, keeping the document in a state Slate can compute selections over:

```ts
edits = edits
  .replaceNodeByKey(
    first.key,
    Block.create({ type: 'div', nodes: Immutable.List([Text.create('')]) })
  )
  .moveToRangeOfDocument()
  .insertFragment(inHTMLEditorValue.document);
```

The existing `try/catch` fallback (and its Sentry report) is left in place as a safety net for any other document shapes that might hit this path, but this specific, frequently-reported crash should no longer occur.

## Test plan

- [ ] Reproduce: create a draft, clear the body down to a single empty paragraph, then apply a signature — confirm no error is reported and the signature is inserted correctly, preserving undo history.
- [ ] Existing composer/draft-editing-session specs pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RyZKTiDD7ktCRddcTKVPd2)_