### PR TITLE
Model all-day calendar events as dates, not timestamps

### DIFF
--- a/app/internal_packages/main-calendar/lib/core/agenda-view.tsx
+++ b/app/internal_packages/main-calendar/lib/core/agenda-view.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import moment, { Moment } from 'moment-timezone';
 import { ScrollRegion, InjectedComponentSet } from 'mailspring-component-kit';
-import { localized, Actions } from 'mailspring-exports';
+import { localized, Actions, CalendarDateUtils } from 'mailspring-exports';
 import { MailspringCalendarViewProps } from './mailspring-calendar';
 import { CalendarView } from './calendar-constants';
 import { HeaderControls } from './header-controls';
 import { CalendarEventPopover } from './calendar-event-popover';
-import { EventOccurrence } from './calendar-data-source';
+import { EventOccurrence, eventCoversDate } from './calendar-data-source';
 import { Disposable } from 'rx-core';
 import { calcEventColors, extractMeetingDomain } from './calendar-helpers';
 
@@ -86,11 +86,10 @@ export class AgendaView extends React.Component<MailspringCalendarViewProps, Age
 
     for (let i = 0; i < DAYS_IN_VIEW; i++) {
       const day = moment(focusedMoment).startOf('day').add(i, 'days');
-      const dayStart = day.unix();
-      const dayEnd = day.clone().endOf('day').unix();
+      const date = CalendarDateUtils.calendarDateFromUnix(day.unix());
 
       const events = this.state.events
-        .filter((event) => event.start < dayEnd && event.end > dayStart)
+        .filter((event) => eventCoversDate(event, date))
         .sort((a, b) => {
           // All-day events first, then sort by start time
           if (a.isAllDay && !b.isAllDay) return -1;

--- a/app/internal_packages/main-calendar/lib/core/calendar-data-source.ts
+++ b/app/internal_packages/main-calendar/lib/core/calendar-data-source.ts
@@ -278,9 +278,9 @@ export function occurrencesForEvents(
         });
       } catch (err) {
         console.error(`Failed to expand ICS for event ${master.id}:`, err);
-        // Fallback: show the master event as a single occurrence so it doesn't vanish
-        // A row whose JSON lacks rs/re can't be placed on a calendar, and reading a date off a
-        // non-finite value throws — which would abandon every other event in the batch.
+        // Fallback: show the master event as a single occurrence so it doesn't vanish.
+        // Skip rows with null/non-finite rs/re: those derive to NaN or 1970 dates that
+        // render nowhere, so a phantom occurrence is worse than none.
         if (!Number.isFinite(master.recurrenceStart) || !Number.isFinite(master.recurrenceEnd)) {
           continue;
         }

--- a/app/internal_packages/main-calendar/lib/core/calendar-data-source.ts
+++ b/app/internal_packages/main-calendar/lib/core/calendar-data-source.ts
@@ -279,40 +279,40 @@ export function occurrencesForEvents(
       } catch (err) {
         console.error(`Failed to expand ICS for event ${master.id}:`, err);
         // Fallback: show the master event as a single occurrence so it doesn't vanish.
-        // Skip rows with null/non-finite rs/re: those derive to NaN or 1970 dates that
-        // render nowhere, so a phantom occurrence is worse than none.
-        if (!Number.isFinite(master.recurrenceStart) || !Number.isFinite(master.recurrenceEnd)) {
-          continue;
-        }
-        const isAllDay = master.recurrenceEnd - master.recurrenceStart >= 82800;
-        const { startDate, endDate } = coveredDates(
-          master.recurrenceStart,
-          master.recurrenceEnd,
-          isAllDay
-        );
+        // Push it only when rs/re are finite — null/non-finite derive to NaN or 1970 dates
+        // that render nowhere. Guard the push, not the iteration: a bad master must still
+        // fall through to this UID's standalone exceptions below.
+        if (Number.isFinite(master.recurrenceStart) && Number.isFinite(master.recurrenceEnd)) {
+          const isAllDay = master.recurrenceEnd - master.recurrenceStart >= 82800;
+          const { startDate, endDate } = coveredDates(
+            master.recurrenceStart,
+            master.recurrenceEnd,
+            isAllDay
+          );
 
-        occurrences.push({
-          start: master.recurrenceStart,
-          end: master.recurrenceEnd,
-          id: `${master.id}-e0`,
-          accountId: master.accountId,
-          calendarId: master.calendarId,
-          title: '(Error expanding event)',
-          location: '',
-          description: '',
-          // Expansion failed, so there's no DATE flag to read — fall back on duration. A
-          // recurring master's columns can hold one occurrence's span, so a series can
-          // misread as all-day here.
-          isAllDay,
-          startDate,
-          endDate,
-          isCancelled: false,
-          isPending: false,
-          isException: false,
-          isRecurring: false,
-          organizer: null,
-          attendees: [],
-        });
+          occurrences.push({
+            start: master.recurrenceStart,
+            end: master.recurrenceEnd,
+            id: `${master.id}-e0`,
+            accountId: master.accountId,
+            calendarId: master.calendarId,
+            title: '(Error expanding event)',
+            location: '',
+            description: '',
+            // Expansion failed, so there's no DATE flag to read — fall back on duration. A
+            // recurring master's columns can hold one occurrence's span, so a series can
+            // misread as all-day here.
+            isAllDay,
+            startDate,
+            endDate,
+            isCancelled: false,
+            isPending: false,
+            isException: false,
+            isRecurring: false,
+            organizer: null,
+            attendees: [],
+          });
+        }
       }
     }
 

--- a/app/internal_packages/main-calendar/lib/core/calendar-data-source.ts
+++ b/app/internal_packages/main-calendar/lib/core/calendar-data-source.ts
@@ -35,6 +35,11 @@ function dateFromICALTime(time: ICALTime): CalendarDate {
   return CalendarDateUtils.calendarDateFromParts(time.year, time.month, time.day);
 }
 
+/** Whether an occurrence covers the given day. */
+export function eventCoversDate(event: EventOccurrence, date: CalendarDate): boolean {
+  return event.startDate <= date && date <= event.endDate;
+}
+
 /**
  * The dates an event covers, inclusive, from its start and exclusive end instants.
  *

--- a/app/internal_packages/main-calendar/lib/core/calendar-data-source.ts
+++ b/app/internal_packages/main-calendar/lib/core/calendar-data-source.ts
@@ -79,9 +79,8 @@ export interface EventOccurrence {
   /**
    * The days covered, inclusive both ends — a one-day event has `startDate === endDate`.
    *
-   * Stored rather than derived per render because reading a date costs ~2µs and the day-cell
-   * filters would call it per event per cell. Those filters still compare timestamps, so
-   * nothing reads these yet.
+   * Stored rather than derived per render: the day-cell filters read them per event per cell,
+   * via eventCoversDate.
    */
   startDate: CalendarDate;
   endDate: CalendarDate;
@@ -286,9 +285,11 @@ export function occurrencesForEvents(
           continue;
         }
         const isAllDay = master.recurrenceEnd - master.recurrenceStart >= 82800;
-        const startDate = CalendarDateUtils.calendarDateFromUnix(master.recurrenceStart);
-        const exclusiveEnd = CalendarDateUtils.calendarDateFromUnix(master.recurrenceEnd);
-        const endDate = isAllDay ? lastCoveredDate(exclusiveEnd, startDate) : exclusiveEnd;
+        const { startDate, endDate } = coveredDates(
+          master.recurrenceStart,
+          master.recurrenceEnd,
+          isAllDay
+        );
 
         occurrences.push({
           start: master.recurrenceStart,

--- a/app/internal_packages/main-calendar/lib/core/calendar-data-source.ts
+++ b/app/internal_packages/main-calendar/lib/core/calendar-data-source.ts
@@ -4,6 +4,8 @@ import {
   Matcher,
   DatabaseStore,
   CalendarUtils,
+  CalendarDateUtils,
+  CalendarDate,
   ICSEventHelpers,
   AndCompositeMatcher,
   OrCompositeMatcher,
@@ -24,9 +26,60 @@ export interface EventAttendee {
   partstat?: ParticipationStatus;
 }
 
+type ICAL = typeof import('ical.js').default;
+type ICALEvent = InstanceType<ICAL['Event']>;
+type ICALTime = InstanceType<ICAL['Time']>;
+
+/** An ICAL.Time's date, taken from its parts so no timezone is applied on the way. */
+function dateFromICALTime(time: ICALTime): CalendarDate {
+  return CalendarDateUtils.calendarDateFromParts(time.year, time.month, time.day);
+}
+
+/**
+ * The dates an event covers, inclusive, from its start and exclusive end instants.
+ *
+ * All-day ends land on a day boundary, so the last covered date is one date back; timed ends
+ * are instants, so step inside the end before reading it — a 22:00-00:00 event covers one day,
+ * not two. For events with parsed ICS, read the DATE parts instead; this is for callers that
+ * only hold instants.
+ */
+export function coveredDates(
+  startUnix: number,
+  endUnix: number,
+  isAllDay: boolean
+): { startDate: CalendarDate; endDate: CalendarDate } {
+  const startDate = CalendarDateUtils.calendarDateFromUnix(startUnix);
+  const endDate = isAllDay
+    ? CalendarDateUtils.addCalendarDays(CalendarDateUtils.calendarDateFromUnix(endUnix), -1)
+    : CalendarDateUtils.calendarDateFromUnix(Math.max(endUnix - 1, startUnix));
+  return { startDate, endDate: endDate > startDate ? endDate : startDate };
+}
+
+/**
+ * The last day an all-day span covers, given an exclusive end date.
+ *
+ * Subtracted in date space rather than by a second. For ends parsed from ICS the two agree,
+ * since ical.js hands back an exact midnight — but the expansion-failure path reads the
+ * denormalized columns, which the sync engine writes an hour late for any date inside DST.
+ * There `dateOf(end - 1s)` lands a day late and this doesn't. Floored at the start so a
+ * malformed span can't end before it begins.
+ */
+function lastCoveredDate(exclusiveEnd: CalendarDate, startDate: CalendarDate): CalendarDate {
+  return Math.max(CalendarDateUtils.addCalendarDays(exclusiveEnd, -1), startDate) as CalendarDate;
+}
+
 export interface EventOccurrence {
   start: number; // unix
   end: number; // unix
+  /**
+   * The days covered, inclusive both ends — a one-day event has `startDate === endDate`.
+   *
+   * Stored rather than derived per render because reading a date costs ~2µs and the day-cell
+   * filters would call it per event per cell. Those filters still compare timestamps, so
+   * nothing reads these yet.
+   */
+  startDate: CalendarDate;
+  endDate: CalendarDate;
   id: string;
   accountId: string;
   calendarId: string;
@@ -102,6 +155,71 @@ export class CalendarDataSource {
   }
 }
 
+/**
+ * `startTime`/`endTime` are separate from `item` because an expanded occurrence's times differ
+ * from the component its properties come from.
+ */
+function occurrenceFromICS(args: {
+  id: string;
+  event: Event;
+  item: ICALEvent;
+  startTime: ICALTime;
+  endTime: ICALTime;
+  isRecurring: boolean;
+  /** Defaults to whether the component carries a RECURRENCE-ID */
+  isException?: boolean;
+}): EventOccurrence {
+  const { id, event, item, startTime, endTime } = args;
+  const startUnix = startTime.toJSDate().getTime() / 1000;
+  const endUnix = endTime.toJSDate().getTime() / 1000;
+
+  const statusValue = item.component?.getFirstPropertyValue('status');
+  const status = (typeof statusValue === 'string' ? statusValue : '').toUpperCase();
+
+  const attendees: EventAttendee[] = item.attendees.map((a) => ({
+    email: normalizeEmail(String(a.getFirstValue() || '')),
+    name: a.getFirstParameter('cn') || '',
+    partstat: (a.getFirstParameter('partstat') || 'NEEDS-ACTION') as ParticipationStatus,
+  }));
+
+  // Pending styling also covers an event I'm invited to but haven't answered
+  const myAttendee = attendees.find((a) => a.email && new Contact({ email: a.email }).isMe());
+  const myPartstat = myAttendee?.partstat?.toUpperCase();
+  const isAwaitingMyResponse = myAttendee && myPartstat !== 'ACCEPTED' && myPartstat !== 'DECLINED';
+
+  const isAllDay = !!startTime.isDate;
+  const startDate = isAllDay
+    ? dateFromICALTime(startTime)
+    : CalendarDateUtils.calendarDateFromUnix(startUnix);
+  const endDate = isAllDay
+    ? lastCoveredDate(dateFromICALTime(endTime), startDate)
+    : // the end instant is exclusive, so step inside it before reading the date
+      CalendarDateUtils.calendarDateFromUnix(Math.max(endUnix - 1, startUnix));
+
+  const rid = item.component?.getFirstPropertyValue('recurrence-id');
+
+  return {
+    start: startUnix,
+    end: endUnix,
+    id,
+    accountId: event.accountId,
+    calendarId: event.calendarId,
+    title: item.summary || '',
+    location: item.location || '',
+    description: item.description || '',
+    isAllDay,
+    startDate,
+    endDate,
+    isCancelled: status === 'CANCELLED',
+    isPending: status === 'TENTATIVE' || !!isAwaitingMyResponse,
+    isException: args.isException ?? !!rid,
+    recurrenceIdStart: rid ? (rid as any).toJSDate().getTime() / 1000 : undefined,
+    isRecurring: args.isRecurring,
+    organizer: item.organizer ? { email: item.organizer } : null,
+    attendees,
+  };
+}
+
 export function occurrencesForEvents(
   results: Event[],
   { startUnix, endUnix }: { startUnix: number; endUnix: number }
@@ -141,54 +259,32 @@ export function occurrencesForEvents(
           const end = e.endDate.toJSDate().getTime() / 1000;
           // For occurrences, the actual event data is in e.item; for events, e is the event itself
           const item = 'item' in e ? e.item : e;
-          const statusValue = item.component?.getFirstPropertyValue('status');
-          const status = typeof statusValue === 'string' ? statusValue : '';
-
           expandedStartTimes.add(start);
 
-          // Parse attendees with their participation status
-          const attendees: EventAttendee[] = item.attendees.map((a) => ({
-            email: normalizeEmail(String(a.getFirstValue() || '')),
-            name: a.getFirstParameter('cn') || '',
-            partstat: (a.getFirstParameter('partstat') || 'NEEDS-ACTION') as ParticipationStatus,
-          }));
-
-          // Determine if event should show "pending" styling:
-          // 1. Event status is TENTATIVE, or
-          // 2. Current user is an attendee who hasn't accepted
-          const isTentativeStatus = status.toUpperCase() === 'TENTATIVE';
-          const myAttendee = attendees.find(
-            (a) => a.email && new Contact({ email: a.email }).isMe()
+          occurrences.push(
+            occurrenceFromICS({
+              id: `${master.id}-e${idx}`,
+              event: master,
+              item,
+              startTime: e.startDate,
+              endTime: e.endDate,
+              isRecurring: masterIsRecurring,
+            })
           );
-          const myPartstat = myAttendee?.partstat?.toUpperCase();
-          const isAwaitingMyResponse =
-            myAttendee && myPartstat !== 'ACCEPTED' && myPartstat !== 'DECLINED';
-
-          occurrences.push({
-            start,
-            end,
-            id: `${master.id}-e${idx}`,
-            accountId: master.accountId,
-            calendarId: master.calendarId,
-            title: item.summary || '',
-            location: item.location || '',
-            description: item.description || '',
-            isAllDay: !!e.startDate.isDate,
-            isCancelled: status.toUpperCase() === 'CANCELLED',
-            isPending: isTentativeStatus || isAwaitingMyResponse,
-            isException: !!item.component?.getFirstPropertyValue('recurrence-id'),
-            recurrenceIdStart: (() => {
-              const rid = item.component?.getFirstPropertyValue('recurrence-id');
-              return rid ? (rid as any).toJSDate().getTime() / 1000 : undefined;
-            })(),
-            isRecurring: masterIsRecurring,
-            organizer: item.organizer ? { email: item.organizer } : null,
-            attendees,
-          });
         });
       } catch (err) {
         console.error(`Failed to expand ICS for event ${master.id}:`, err);
         // Fallback: show the master event as a single occurrence so it doesn't vanish
+        // A row whose JSON lacks rs/re can't be placed on a calendar, and reading a date off a
+        // non-finite value throws — which would abandon every other event in the batch.
+        if (!Number.isFinite(master.recurrenceStart) || !Number.isFinite(master.recurrenceEnd)) {
+          continue;
+        }
+        const isAllDay = master.recurrenceEnd - master.recurrenceStart >= 82800;
+        const startDate = CalendarDateUtils.calendarDateFromUnix(master.recurrenceStart);
+        const exclusiveEnd = CalendarDateUtils.calendarDateFromUnix(master.recurrenceEnd);
+        const endDate = isAllDay ? lastCoveredDate(exclusiveEnd, startDate) : exclusiveEnd;
+
         occurrences.push({
           start: master.recurrenceStart,
           end: master.recurrenceEnd,
@@ -201,7 +297,9 @@ export function occurrencesForEvents(
           // Expansion failed, so there's no DATE flag to read — fall back on duration. A
           // recurring master's columns can hold one occurrence's span, so a series can
           // misread as all-day here.
-          isAllDay: master.recurrenceEnd - master.recurrenceStart >= 82800,
+          isAllDay,
+          startDate,
+          endDate,
           isCancelled: false,
           isPending: false,
           isException: false,
@@ -233,44 +331,17 @@ export function occurrencesForEvents(
           continue;
         }
 
-        const vevent = icsEvent.component;
-        const statusValue = vevent?.getFirstPropertyValue('status');
-        const status = typeof statusValue === 'string' ? statusValue : '';
-
-        // Parse attendees with their participation status
-        const attendees: EventAttendee[] = icsEvent.attendees.map((a) => ({
-          email: normalizeEmail(String(a.getFirstValue() || '')),
-          name: a.getFirstParameter('cn') || '',
-          partstat: (a.getFirstParameter('partstat') || 'NEEDS-ACTION') as ParticipationStatus,
-        }));
-
-        // Determine if event should show "pending" styling
-        const isTentativeStatus = status.toUpperCase() === 'TENTATIVE';
-        const myAttendee = attendees.find((a) => a.email && new Contact({ email: a.email }).isMe());
-        const myPartstat = myAttendee?.partstat?.toUpperCase();
-        const isAwaitingMyResponse =
-          myAttendee && myPartstat !== 'ACCEPTED' && myPartstat !== 'DECLINED';
-
-        const ridValue = vevent?.getFirstPropertyValue('recurrence-id');
-
-        occurrences.push({
-          start: occStart,
-          end: occEnd,
-          id: `${exception.id}-e0`,
-          accountId: exception.accountId,
-          calendarId: exception.calendarId,
-          title: icsEvent.summary || '',
-          location: icsEvent.location || '',
-          description: icsEvent.description || '',
-          isAllDay: !!icsEvent.startDate.isDate,
-          isCancelled: status.toUpperCase() === 'CANCELLED',
-          isPending: isTentativeStatus || isAwaitingMyResponse,
-          isException: true,
-          recurrenceIdStart: ridValue ? (ridValue as any).toJSDate().getTime() / 1000 : undefined,
-          isRecurring: true, // Exceptions are always from recurring series
-          organizer: icsEvent.organizer ? { email: icsEvent.organizer } : null,
-          attendees,
-        });
+        occurrences.push(
+          occurrenceFromICS({
+            id: `${exception.id}-e0`,
+            event: exception,
+            item: icsEvent,
+            startTime: icsEvent.startDate,
+            endTime: icsEvent.endDate,
+            isRecurring: true, // exceptions only exist for a series
+            isException: true,
+          })
+        );
       } catch (err) {
         console.error(`Failed to parse ICS for exception ${exception.id}:`, err);
       }

--- a/app/internal_packages/main-calendar/lib/core/calendar-drag-utils.ts
+++ b/app/internal_packages/main-calendar/lib/core/calendar-drag-utils.ts
@@ -8,7 +8,7 @@ import {
 } from './calendar-drag-types';
 import { EventOccurrence, coveredDates } from './calendar-data-source';
 import { CalendarDateUtils } from 'mailspring-exports';
-import { inclusiveAllDayEnd, exclusiveAllDayEnd } from './calendar-helpers';
+import { inclusiveAllDayEnd } from './calendar-helpers';
 
 /**
  * Snap a timestamp to the nearest interval
@@ -42,7 +42,9 @@ export function snapAllDayTimes(start: number, end: number): { start: number; en
  * @returns Exclusive end, as a unix timestamp
  */
 function exclusiveDayEnd(end: number, floor: number): number {
-  return exclusiveAllDayEnd(Math.max(inclusiveAllDayEnd(end), floor));
+  return CalendarDateUtils.nextDayStartUnix(
+    CalendarDateUtils.calendarDateFromUnix(Math.max(inclusiveAllDayEnd(end), floor))
+  );
 }
 
 /**
@@ -299,7 +301,9 @@ export function updateDragState(
         // would drop the cursor's own day. Include that day, then take the next midnight.
         previewStart = moment.unix(state.originalStart).startOf('day').unix();
         const lastDay = Math.max(moment.unix(mouseTime).startOf('day').unix(), previewStart);
-        previewEnd = exclusiveAllDayEnd(lastDay);
+        previewEnd = CalendarDateUtils.nextDayStartUnix(
+          CalendarDateUtils.calendarDateFromUnix(lastDay)
+        );
       } else {
         const newEnd = Math.max(mouseTime - state.clickOffset, state.originalStart + minDuration);
         previewStart = state.originalStart;

--- a/app/internal_packages/main-calendar/lib/core/calendar-drag-utils.ts
+++ b/app/internal_packages/main-calendar/lib/core/calendar-drag-utils.ts
@@ -7,7 +7,8 @@ import {
   ViewDirection,
 } from './calendar-drag-types';
 import { EventOccurrence, coveredDates } from './calendar-data-source';
-import { inclusiveAllDayEnd, exclusiveAllDayEnd, addCalendarDays } from './calendar-helpers';
+import { CalendarDateUtils } from 'mailspring-exports';
+import { inclusiveAllDayEnd, exclusiveAllDayEnd } from './calendar-helpers';
 
 /**
  * Snap a timestamp to the nearest interval
@@ -261,7 +262,12 @@ export function updateDragState(
         previewStart = moment.unix(newStart).startOf('day').unix();
         // Via the helpers, not a raw add: where the drop day's midnight doesn't exist, add()
         // keeps the 01:00 wall clock and snapAllDayTimes then rounds it up an extra day.
-        previewEnd = exclusiveAllDayEnd(addCalendarDays(previewStart, numDays - 1));
+        previewEnd = CalendarDateUtils.nextDayStartUnix(
+          CalendarDateUtils.addCalendarDays(
+            CalendarDateUtils.calendarDateFromUnix(previewStart),
+            numDays - 1
+          )
+        );
       } else {
         previewStart = snapToInterval(newStart, snapInterval);
         previewEnd = previewStart + eventDuration;

--- a/app/internal_packages/main-calendar/lib/core/calendar-drag-utils.ts
+++ b/app/internal_packages/main-calendar/lib/core/calendar-drag-utils.ts
@@ -6,7 +6,7 @@ import {
   HitZone,
   ViewDirection,
 } from './calendar-drag-types';
-import { EventOccurrence } from './calendar-data-source';
+import { EventOccurrence, coveredDates } from './calendar-data-source';
 import { inclusiveAllDayEnd, exclusiveAllDayEnd, addCalendarDays } from './calendar-helpers';
 
 /**
@@ -58,6 +58,8 @@ export function createDragPreviewEvent(dragState: DragState): EventOccurrence {
     id: `${event.id}-drag-preview`,
     start: previewStart,
     end: previewEnd,
+    // The spread carries the pre-drag dates, which no longer agree with the preview instants
+    ...coveredDates(previewStart, previewEnd, event.isAllDay),
     isDragPreview: true,
     originalEventId: event.id,
   };

--- a/app/internal_packages/main-calendar/lib/core/calendar-event-popover.tsx
+++ b/app/internal_packages/main-calendar/lib/core/calendar-event-popover.tsx
@@ -12,6 +12,7 @@ import {
   ICSEventHelpers,
   CalendarUtils,
   SyncbackEventTask,
+  CalendarDateUtils,
 } from 'mailspring-exports';
 import {
   DatePicker,
@@ -26,7 +27,6 @@ import { EventPropertyRow } from './event-property-row';
 import {
   createCalendarEvent,
   inclusiveAllDayEnd,
-  exclusiveAllDayEnd,
   shiftEndWithStart,
   clampEnd,
 } from './calendar-helpers';
@@ -515,7 +515,15 @@ export class CalendarEventPopover extends React.Component<
           <EventPropertyRow label={localized('ends:')}>
             <DatePicker
               value={(allDay ? inclusiveAllDayEnd(end) : end) * 1000}
-              onChange={(ts) => this.updateEnd(allDay ? exclusiveAllDayEnd(ts / 1000) : ts / 1000)}
+              onChange={(ts) =>
+                this.updateEnd(
+                  allDay
+                    ? CalendarDateUtils.nextDayStartUnix(
+                        CalendarDateUtils.calendarDateFromUnix(ts / 1000)
+                      )
+                    : ts / 1000
+                )
+              }
             />
             {!allDay && (
               <TimePicker value={end * 1000} onChange={(ts) => this.updateEnd(ts / 1000)} />

--- a/app/internal_packages/main-calendar/lib/core/calendar-helpers.tsx
+++ b/app/internal_packages/main-calendar/lib/core/calendar-helpers.tsx
@@ -9,6 +9,7 @@ import {
   SyncbackEventTask,
   TaskQueue,
   localized,
+  CalendarDateUtils,
 } from 'mailspring-exports';
 import { MIN_EVENT_DURATION_SECONDS } from './calendar-constants';
 
@@ -270,26 +271,6 @@ export function inclusiveAllDayEnd(end: number): number {
 }
 
 /**
- * Shift a timestamp by whole calendar days, landing on the target day's start. Adding 86400
- * seconds would move by an hour on a transition day; add() alone leaves an instant on the
- * previous day where the target midnight doesn't exist, which collapses a one-day event.
- */
-export function addCalendarDays(unix: number, days: number): number {
-  return moment.unix(unix).add(days, 'days').startOf('day').unix();
-}
-
-/**
- * Whole calendar days from one timestamp to another, ignoring the time of day.
- * Rounds because where DST starts at midnight (Santiago, Havana, Beirut), startOf('day') on
- * the transition day itself normalizes to 01:00, leaving a 1/24 residual: 4.958, not 5.
- */
-export function calendarDaysBetween(from: number, to: number): number {
-  return Math.round(
-    moment.unix(to).startOf('day').diff(moment.unix(from).startOf('day'), 'days', true)
-  );
-}
-
-/**
  * Inverse of inclusiveAllDayEnd: turns a picked last-covered day back into the
  * exclusive end that gets stored.
  */
@@ -313,8 +294,13 @@ export function shiftEndWithStart(
   if (!isAllDay) {
     return endUnix + (newStartUnix - startUnix);
   }
-  const days = calendarDaysBetween(startUnix, newStartUnix);
-  return exclusiveAllDayEnd(addCalendarDays(inclusiveAllDayEnd(endUnix), days));
+  const days = CalendarDateUtils.calendarDaysBetween(
+    CalendarDateUtils.calendarDateFromUnix(startUnix),
+    CalendarDateUtils.calendarDateFromUnix(newStartUnix)
+  );
+  return exclusiveAllDayEnd(
+    CalendarDateUtils.shiftedDayStartUnix(inclusiveAllDayEnd(endUnix), days)
+  );
 }
 
 /**

--- a/app/internal_packages/main-calendar/lib/core/calendar-helpers.tsx
+++ b/app/internal_packages/main-calendar/lib/core/calendar-helpers.tsx
@@ -271,15 +271,6 @@ export function inclusiveAllDayEnd(end: number): number {
 }
 
 /**
- * Inverse of inclusiveAllDayEnd: turns a picked last-covered day back into the
- * exclusive end that gets stored.
- */
-export function exclusiveAllDayEnd(lastDay: number): number {
-  // add before startOf: truncating first lands on 01:00 where local midnight doesn't exist
-  return moment.unix(lastDay).add(1, 'day').startOf('day').unix();
-}
-
-/**
  * The end an event should take when its start moves, preserving the duration.
  * All-day events shift in whole days: a seconds delta across a DST transition would
  * land the end off midnight and gain or lose a day once serialized.
@@ -298,8 +289,11 @@ export function shiftEndWithStart(
     CalendarDateUtils.calendarDateFromUnix(startUnix),
     CalendarDateUtils.calendarDateFromUnix(newStartUnix)
   );
-  return exclusiveAllDayEnd(
-    CalendarDateUtils.shiftedDayStartUnix(inclusiveAllDayEnd(endUnix), days)
+  return CalendarDateUtils.nextDayStartUnix(
+    CalendarDateUtils.addCalendarDays(
+      CalendarDateUtils.calendarDateFromUnix(inclusiveAllDayEnd(endUnix)),
+      days
+    )
   );
 }
 
@@ -309,7 +303,9 @@ export function shiftEndWithStart(
  * @returns The clamped end, as a unix timestamp
  */
 export function clampEnd(startUnix: number, endUnix: number, isAllDay: boolean): number {
-  const floor = isAllDay ? exclusiveAllDayEnd(startUnix) : startUnix + MIN_EVENT_DURATION_SECONDS;
+  const floor = isAllDay
+    ? CalendarDateUtils.nextDayStartUnix(CalendarDateUtils.calendarDateFromUnix(startUnix))
+    : startUnix + MIN_EVENT_DURATION_SECONDS;
   return Math.max(endUnix, floor);
 }
 

--- a/app/internal_packages/main-calendar/lib/core/mailspring-calendar.tsx
+++ b/app/internal_packages/main-calendar/lib/core/mailspring-calendar.tsx
@@ -8,6 +8,7 @@ import {
   Account,
   Actions,
   localized,
+  CalendarDateUtils,
   DestroyEventTask,
   Event,
   SyncbackEventTask,
@@ -336,10 +337,13 @@ export class MailspringCalendar extends React.Component<
     const endUnix = isAllDay ? exclusiveAllDayEnd(startUnix) : startUnix + 3600;
 
     // Build a temporary EventOccurrence to open the popover in "new event" mode
+    const clickedDate = CalendarDateUtils.calendarDateFromUnix(startUnix);
     const newEventOccurrence: EventOccurrence = {
       id: `__new_event_${Date.now()}`,
       start: startUnix,
       end: endUnix,
+      startDate: clickedDate,
+      endDate: isAllDay ? clickedDate : CalendarDateUtils.calendarDateFromUnix(endUnix),
       title: '',
       description: '',
       location: '',

--- a/app/internal_packages/main-calendar/lib/core/mailspring-calendar.tsx
+++ b/app/internal_packages/main-calendar/lib/core/mailspring-calendar.tsx
@@ -36,7 +36,6 @@ import {
   showNoEditableCalendarsError,
   showReadOnlyCalendarError,
   invalidateThemeTextColorCache,
-  exclusiveAllDayEnd,
   shiftEndWithStart,
   clampEnd,
 } from './calendar-helpers';
@@ -333,7 +332,9 @@ export class MailspringCalendar extends React.Component<
       startUnix = Math.round(args.time / thirtyMinutes) * thirtyMinutes;
     }
 
-    const endUnix = isAllDay ? exclusiveAllDayEnd(startUnix) : startUnix + 3600;
+    const endUnix = isAllDay
+      ? CalendarDateUtils.nextDayStartUnix(CalendarDateUtils.calendarDateFromUnix(startUnix))
+      : startUnix + 3600;
 
     // Build a temporary EventOccurrence to open the popover in "new event" mode
     const clickedDate = CalendarDateUtils.calendarDateFromUnix(startUnix);

--- a/app/internal_packages/main-calendar/lib/core/mailspring-calendar.tsx
+++ b/app/internal_packages/main-calendar/lib/core/mailspring-calendar.tsx
@@ -26,7 +26,12 @@ import { WeekView } from './week-view';
 import { MonthView } from './month-view';
 import { AgendaView } from './agenda-view';
 import { CalendarSourceList } from './calendar-source-list';
-import { CalendarDataSource, EventOccurrence, FocusedEventInfo } from './calendar-data-source';
+import {
+  CalendarDataSource,
+  EventOccurrence,
+  FocusedEventInfo,
+  coveredDates,
+} from './calendar-data-source';
 import { CalendarView } from './calendar-constants';
 import { CalendarEmptyState } from './calendar-empty-state';
 import {
@@ -337,13 +342,11 @@ export class MailspringCalendar extends React.Component<
       : startUnix + 3600;
 
     // Build a temporary EventOccurrence to open the popover in "new event" mode
-    const clickedDate = CalendarDateUtils.calendarDateFromUnix(startUnix);
     const newEventOccurrence: EventOccurrence = {
       id: `__new_event_${Date.now()}`,
       start: startUnix,
       end: endUnix,
-      startDate: clickedDate,
-      endDate: isAllDay ? clickedDate : CalendarDateUtils.calendarDateFromUnix(endUnix),
+      ...coveredDates(startUnix, endUnix, isAllDay),
       title: '',
       description: '',
       location: '',

--- a/app/internal_packages/main-calendar/lib/core/mailspring-calendar.tsx
+++ b/app/internal_packages/main-calendar/lib/core/mailspring-calendar.tsx
@@ -36,7 +36,6 @@ import {
   showNoEditableCalendarsError,
   showReadOnlyCalendarError,
   invalidateThemeTextColorCache,
-  addCalendarDays,
   exclusiveAllDayEnd,
   shiftEndWithStart,
   clampEnd,
@@ -681,9 +680,11 @@ export class MailspringCalendar extends React.Component<
         // by calendar days rather than 86400 seconds keeps the times on midnight across a
         // DST transition, where a seconds shift overshoots and snaps up an extra day.
         const days = Math.sign(timeDelta);
-        newStart = isResize ? occurrence.start : addCalendarDays(occurrence.start, days);
+        newStart = isResize
+          ? occurrence.start
+          : CalendarDateUtils.shiftedDayStartUnix(occurrence.start, days);
         newEnd = isResize
-          ? clampEnd(newStart, addCalendarDays(occurrence.end, days), true)
+          ? clampEnd(newStart, CalendarDateUtils.shiftedDayStartUnix(occurrence.end, days), true)
           : shiftEndWithStart(occurrence.start, occurrence.end, newStart, true);
         const snapped = snapAllDayTimes(newStart, newEnd);
         newStart = snapped.start;

--- a/app/internal_packages/main-calendar/lib/core/month-view.tsx
+++ b/app/internal_packages/main-calendar/lib/core/month-view.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import moment, { Moment } from 'moment-timezone';
 import { InjectedComponentSet } from 'mailspring-component-kit';
+import { CalendarDateUtils } from 'mailspring-exports';
 import { MailspringCalendarViewProps } from './mailspring-calendar';
 import { CalendarEventContainer } from './calendar-event-container';
 import { CalendarView } from './calendar-constants';
 import { HeaderControls } from './header-controls';
-import { EventOccurrence } from './calendar-data-source';
+import { EventOccurrence, eventCoversDate } from './calendar-data-source';
 import { Disposable } from 'rx-core';
 import { MonthViewDayCell } from './month-view-day-cell';
 import { getEventsWithDragPreview } from './calendar-drag-utils';
@@ -95,14 +96,10 @@ export class MonthView extends React.Component<MailspringCalendarViewProps, Mont
   }
 
   _getEventsForDay(day: Moment): EventOccurrence[] {
-    const dayStart = day.clone().startOf('day').unix();
-    const dayEnd = day.clone().endOf('day').unix();
+    const date = CalendarDateUtils.calendarDateFromUnix(day.unix());
     const events = getEventsWithDragPreview(this.state.events, this.props.dragState);
 
-    return events.filter((event) => {
-      // Event overlaps with this day
-      return event.start < dayEnd && event.end > dayStart;
-    });
+    return events.filter((event) => eventCoversDate(event, date));
   }
 
   _isToday(day: Moment): boolean {

--- a/app/spec/calendar-data-source-spec.ts
+++ b/app/spec/calendar-data-source-spec.ts
@@ -247,7 +247,7 @@ describe('eventCoversDate', function () {
     expect(eventCoversDate(occ, day('2026-06-23'))).toBe(true);
   });
 
-  it('covers the transition day of an all-day span across a DST change', function () {
+  it('covers the middle days of a multi-day span, not just the ends', function () {
     const occ = only(icsFor('DTSTART;VALUE=DATE:20260307', 'DTEND;VALUE=DATE:20260310'));
     expect(
       ['2026-03-07', '2026-03-08', '2026-03-09'].map((iso) => eventCoversDate(occ, day(iso)))

--- a/app/spec/calendar-data-source-spec.ts
+++ b/app/spec/calendar-data-source-spec.ts
@@ -193,6 +193,30 @@ describe('occurrencesForEvents when expansion fails', function () {
     expect(formatCalendarDate(occ.startDate)).toBe('2026-06-22');
     expect(formatCalendarDate(occ.endDate)).toBe('2026-06-22');
   });
+
+  it('still surfaces a standalone exception when the master fails to expand with non-finite columns', function () {
+    // The non-finite guard must skip only the phantom fallback push, not the whole UID
+    // iteration: a master that throws AND lacks usable columns must not drop this UID's
+    // separate exception records. Fails if the guard `continue`s the iteration instead.
+    const master = makeEvent('this is not valid ics', {
+      id: 'master-1',
+      recurrenceStart: NaN,
+      recurrenceEnd: NaN,
+    } as any);
+    const exception = makeEvent(
+      icsFor(
+        'DTSTART;VALUE=DATE:20260622',
+        'DTEND;VALUE=DATE:20260623',
+        'RECURRENCE-ID;VALUE=DATE:20260622'
+      ),
+      { id: 'exc-1', recurrenceId: '20260622', recurrenceStart: new Date(2026, 5, 22).getTime() / 1000 } as any
+    );
+    const occs = occurrencesForEvents([master, exception], {
+      startUnix: new Date(2026, 0, 1).getTime() / 1000,
+      endUnix: new Date(2027, 0, 1).getTime() / 1000,
+    });
+    expect(occs.some((o) => o.id === 'exc-1-e0')).toBe(true);
+  });
 });
 
 describe('eventCoversDate', function () {

--- a/app/spec/calendar-data-source-spec.ts
+++ b/app/spec/calendar-data-source-spec.ts
@@ -2,6 +2,7 @@
 // We use a relative path because the plugin is not registered in mailspring-exports.
 import { Event as MailspringEvent } from '../src/flux/models/event';
 import { occurrencesForEvents } from '../internal_packages/main-calendar/lib/core/calendar-data-source';
+import { formatCalendarDate } from '../src/calendar-date';
 
 // All-day-ness comes from the ICS DATE type, never from duration.
 function makeEvent(ics: string, overrides: Partial<MailspringEvent> = {}): MailspringEvent {
@@ -73,5 +74,120 @@ describe('occurrencesForEvents isAllDay classification', function () {
     );
     expect(occurrences.length).toBe(4);
     occurrences.forEach((occ) => expect(occ.isAllDay).toBe(true));
+  });
+});
+
+describe('occurrencesForEvents covered dates', function () {
+  // Asserted as ISO strings so a failure reads 2026-06-22, not an epoch-day integer
+  const covered = (occ: { startDate: any; endDate: any }) => [
+    formatCalendarDate(occ.startDate),
+    formatCalendarDate(occ.endDate),
+  ];
+
+  describe('for all-day events', function () {
+    it('gives a one-day event the same start and end date', function () {
+      const [occ] = expand(
+        makeEvent(icsFor('DTSTART;VALUE=DATE:20260622', 'DTEND;VALUE=DATE:20260623'))
+      );
+      expect(covered(occ)).toEqual(['2026-06-22', '2026-06-22']);
+    });
+
+    it('converts the exclusive DTEND to the last day covered', function () {
+      const [occ] = expand(
+        makeEvent(icsFor('DTSTART;VALUE=DATE:20260622', 'DTEND;VALUE=DATE:20260625'))
+      );
+      expect(covered(occ)).toEqual(['2026-06-22', '2026-06-24']);
+    });
+
+    it('defaults a missing DTEND to a single day', function () {
+      const ics = icsFor('DTSTART;VALUE=DATE:20260622', '');
+      const [occ] = expand(makeEvent(ics));
+      expect(covered(occ)).toEqual(['2026-06-22', '2026-06-22']);
+    });
+
+    it('reads a spring-forward day as one day', function () {
+      const [occ] = expand(
+        makeEvent(icsFor('DTSTART;VALUE=DATE:20260308', 'DTEND;VALUE=DATE:20260309'))
+      );
+      expect(covered(occ)).toEqual(['2026-03-08', '2026-03-08']);
+    });
+
+    // A DTEND equal to DTSTART is malformed but common from real servers; without the floor
+    // the exclusive-to-inclusive conversion would put endDate a day before startDate.
+    it('floors a zero-length span at the start day', function () {
+      const [occ] = expand(
+        makeEvent(icsFor('DTSTART;VALUE=DATE:20260622', 'DTEND;VALUE=DATE:20260622'))
+      );
+      expect(covered(occ)).toEqual(['2026-06-22', '2026-06-22']);
+    });
+
+    it('covers only the start day when a timed event ends at midnight', function () {
+      const fmt = (dt: Date) =>
+        `${dt.getFullYear()}${String(dt.getMonth() + 1).padStart(2, '0')}${String(
+          dt.getDate()
+        ).padStart(2, '0')}T${String(dt.getHours()).padStart(2, '0')}0000`;
+      const [occ] = expand(
+        makeEvent(
+          icsFor(
+            `DTSTART:${fmt(new Date(2026, 5, 22, 22))}`,
+            `DTEND:${fmt(new Date(2026, 5, 23, 0))}`
+          )
+        )
+      );
+      expect(covered(occ)).toEqual(['2026-06-22', '2026-06-22']);
+    });
+
+    it('carries the dates onto every occurrence of a series', function () {
+      const occs = expand(
+        makeEvent(
+          icsFor(
+            'DTSTART;VALUE=DATE:20260601',
+            'DTEND;VALUE=DATE:20260602',
+            'RRULE:FREQ=MONTHLY;COUNT=3'
+          )
+        )
+      );
+      expect(occs.map(covered)).toEqual([
+        ['2026-06-01', '2026-06-01'],
+        ['2026-07-01', '2026-07-01'],
+        ['2026-08-01', '2026-08-01'],
+      ]);
+    });
+  });
+
+  describe('for timed events', function () {
+    it('spans two dates when it crosses local midnight', function () {
+      // 23:30 to 00:30 the next day, in the host zone
+      const start = new Date(2026, 5, 22, 23, 30);
+      const end = new Date(2026, 5, 23, 0, 30);
+      const fmt = (dt: Date) =>
+        `${dt.getFullYear()}${String(dt.getMonth() + 1).padStart(2, '0')}${String(
+          dt.getDate()
+        ).padStart(2, '0')}T${String(dt.getHours()).padStart(2, '0')}${String(
+          dt.getMinutes()
+        ).padStart(2, '0')}00`;
+      const [occ] = expand(makeEvent(icsFor(`DTSTART:${fmt(start)}`, `DTEND:${fmt(end)}`)));
+      expect(covered(occ)).toEqual(['2026-06-22', '2026-06-23']);
+    });
+  });
+});
+
+describe('occurrencesForEvents when expansion fails', function () {
+  // The only path that derives dates from the denormalized columns rather than the ICS. The
+  // sync engine writes those an hour late for any date inside DST (its mktime call asserts
+  // standard time), so this is where subtracting a day rather than a second is load-bearing.
+  it('takes the last covered day from the columns despite an hour of slop', function () {
+    const startSlop = new Date(2026, 5, 22, 1, 0).getTime() / 1000; // 01:00, as the engine writes
+    const endSlop = new Date(2026, 5, 23, 1, 0).getTime() / 1000; // exclusive, also 01:00
+    const [occ] = expand(
+      makeEvent('this is not valid ics', {
+        recurrenceStart: startSlop,
+        recurrenceEnd: endSlop,
+      } as any)
+    );
+    expect(occ).toBeDefined();
+    expect(occ.title).toBe('(Error expanding event)');
+    expect(formatCalendarDate(occ.startDate)).toBe('2026-06-22');
+    expect(formatCalendarDate(occ.endDate)).toBe('2026-06-22');
   });
 });

--- a/app/spec/calendar-data-source-spec.ts
+++ b/app/spec/calendar-data-source-spec.ts
@@ -1,8 +1,11 @@
 // Import the function under test directly from the source file.
 // We use a relative path because the plugin is not registered in mailspring-exports.
 import { Event as MailspringEvent } from '../src/flux/models/event';
-import { occurrencesForEvents } from '../internal_packages/main-calendar/lib/core/calendar-data-source';
-import { formatCalendarDate } from '../src/calendar-date';
+import {
+  occurrencesForEvents,
+  eventCoversDate,
+} from '../internal_packages/main-calendar/lib/core/calendar-data-source';
+import { formatCalendarDate, parseCalendarDate } from '../src/calendar-date';
 
 // All-day-ness comes from the ICS DATE type, never from duration.
 function makeEvent(ics: string, overrides: Partial<MailspringEvent> = {}): MailspringEvent {
@@ -189,5 +192,65 @@ describe('occurrencesForEvents when expansion fails', function () {
     expect(occ.title).toBe('(Error expanding event)');
     expect(formatCalendarDate(occ.startDate)).toBe('2026-06-22');
     expect(formatCalendarDate(occ.endDate)).toBe('2026-06-22');
+  });
+});
+
+describe('eventCoversDate', function () {
+  // What the month and agenda day cells filter on. Fed straight from occurrencesForEvents so
+  // the fixtures are shapes the app actually produces.
+  const only = (ics: string) => expand(makeEvent(ics))[0];
+  const day = (iso: string) => parseCalendarDate(iso);
+
+  it('covers each day of a multi-day all-day span and neither neighbour', function () {
+    const occ = only(icsFor('DTSTART;VALUE=DATE:20260622', 'DTEND;VALUE=DATE:20260625'));
+    expect(
+      ['2026-06-21', '2026-06-22', '2026-06-23', '2026-06-24', '2026-06-25'].map((iso) =>
+        eventCoversDate(occ, day(iso))
+      )
+    ).toEqual([false, true, true, true, false]);
+  });
+
+  it('covers exactly one day for a one-day all-day event', function () {
+    const occ = only(icsFor('DTSTART;VALUE=DATE:20260622', 'DTEND;VALUE=DATE:20260623'));
+    expect(eventCoversDate(occ, day('2026-06-22'))).toBe(true);
+    expect(eventCoversDate(occ, day('2026-06-23'))).toBe(false);
+  });
+
+  // The old timestamp filter compared `end > dayStart`, which the exclusive midnight made work
+  // by luck. A timed event ending exactly at midnight must not light up the following cell.
+  it('does not cover the next day for a timed event ending at midnight', function () {
+    const fmt = (dt: Date) =>
+      `${dt.getFullYear()}${String(dt.getMonth() + 1).padStart(2, '0')}${String(
+        dt.getDate()
+      ).padStart(2, '0')}T${String(dt.getHours()).padStart(2, '0')}0000`;
+    const occ = only(
+      icsFor(`DTSTART:${fmt(new Date(2026, 5, 22, 22))}`, `DTEND:${fmt(new Date(2026, 5, 23, 0))}`)
+    );
+    expect(eventCoversDate(occ, day('2026-06-22'))).toBe(true);
+    expect(eventCoversDate(occ, day('2026-06-23'))).toBe(false);
+  });
+
+  it('covers both days for a timed event that really crosses midnight', function () {
+    const fmt = (dt: Date) =>
+      `${dt.getFullYear()}${String(dt.getMonth() + 1).padStart(2, '0')}${String(
+        dt.getDate()
+      ).padStart(2, '0')}T${String(dt.getHours()).padStart(2, '0')}${String(
+        dt.getMinutes()
+      ).padStart(2, '0')}00`;
+    const occ = only(
+      icsFor(
+        `DTSTART:${fmt(new Date(2026, 5, 22, 23, 30))}`,
+        `DTEND:${fmt(new Date(2026, 5, 23, 0, 30))}`
+      )
+    );
+    expect(eventCoversDate(occ, day('2026-06-22'))).toBe(true);
+    expect(eventCoversDate(occ, day('2026-06-23'))).toBe(true);
+  });
+
+  it('covers the transition day of an all-day span across a DST change', function () {
+    const occ = only(icsFor('DTSTART;VALUE=DATE:20260307', 'DTEND;VALUE=DATE:20260310'));
+    expect(
+      ['2026-03-07', '2026-03-08', '2026-03-09'].map((iso) => eventCoversDate(occ, day(iso)))
+    ).toEqual([true, true, true]);
   });
 });

--- a/app/spec/calendar-date-spec.ts
+++ b/app/spec/calendar-date-spec.ts
@@ -1,13 +1,10 @@
 import {
   CalendarDate,
-  calendarDateOf,
-  unixDayStart,
-  unixDayEndExclusive,
+  calendarDateFromUnix,
+  dayStartUnix,
+  nextDayStartUnix,
   addCalendarDays,
   calendarDaysBetween,
-  calendarDaySpan,
-  parseICSDate,
-  formatICSDate,
   formatCalendarDate,
   parseCalendarDate,
 } from '../src/calendar-date';
@@ -21,115 +18,132 @@ const at = (iso: string, hour = 0, minute = 0): number => {
   return new Date(y, m - 1, day, hour, minute).getTime() / 1000;
 };
 
-describe('calendarDateOf', function () {
+// Literals, not round-trips: every other assertion here compares the module against itself,
+// so a consistently wrong epoch origin would survive all of them.
+describe('the epoch-day encoding', function () {
+  it('counts days from 1970-01-01', function () {
+    expect(parseCalendarDate('1970-01-01')).toBe(0 as CalendarDate);
+    expect(parseCalendarDate('1970-01-02')).toBe(1 as CalendarDate);
+    expect(parseCalendarDate('1969-12-31')).toBe(-1 as CalendarDate);
+    expect(parseCalendarDate('2026-06-21')).toBe(20625 as CalendarDate);
+  });
+
+  it('reads an instant onto the same integer', function () {
+    expect(calendarDateFromUnix(Date.UTC(2026, 5, 21, 12) / 1000, 'UTC')).toBe(20625 as CalendarDate);
+  });
+});
+
+describe('calendarDateFromUnix', function () {
   // The property the whole design rests on: the date is read off the instant's components,
   // never computed from a boundary, so the time of day cannot change the answer. Each of
   // these times of day is one we've actually seen in production for an all-day event.
   it('gives the same date whatever the time of day', function () {
     const expected = d('2026-06-21');
-    expect(calendarDateOf(at('2026-06-21', 0, 0))).toBe(expected); // local midnight
-    expect(calendarDateOf(at('2026-06-21', 1, 0))).toBe(expected); // the engine's mktime slop
-    expect(calendarDateOf(at('2026-06-21', 12, 30))).toBe(expected);
-    expect(calendarDateOf(at('2026-06-21', 23, 0))).toBe(expected); // moment's gap resolution
-    expect(calendarDateOf(at('2026-06-21', 23, 59))).toBe(expected);
+    expect(calendarDateFromUnix(at('2026-06-21', 0, 0))).toBe(expected); // local midnight
+    expect(calendarDateFromUnix(at('2026-06-21', 1, 0))).toBe(expected); // the engine's mktime slop
+    expect(calendarDateFromUnix(at('2026-06-21', 12, 30))).toBe(expected);
+    expect(calendarDateFromUnix(at('2026-06-21', 23, 0))).toBe(expected); // moment's gap resolution
+    expect(calendarDateFromUnix(at('2026-06-21', 23, 59))).toBe(expected);
   });
 
   it('does not bleed into the neighbouring days', function () {
-    expect(calendarDateOf(at('2026-06-20', 23, 59))).toBe(d('2026-06-20'));
-    expect(calendarDateOf(at('2026-06-22', 0, 0))).toBe(d('2026-06-22'));
-  });
-
-  it('reads dates across month, year and leap boundaries', function () {
-    expect(calendarDateOf(at('2026-06-30', 13, 0))).toBe(d('2026-06-30'));
-    expect(calendarDateOf(at('2026-12-31', 13, 0))).toBe(d('2026-12-31'));
-    expect(calendarDateOf(at('2028-02-29', 13, 0))).toBe(d('2028-02-29'));
+    expect(calendarDateFromUnix(at('2026-06-20', 23, 59))).toBe(d('2026-06-20'));
+    expect(calendarDateFromUnix(at('2026-06-22', 0, 0))).toBe(d('2026-06-22'));
   });
 });
 
 // These pass an explicit zone, so they discriminate under CI's UTC — a host-zone read can't.
 // Verified boundary values, not guesses: 2026-06-21T02:00Z is still the 20th in Chicago.
-describe('calendarDateOf with an explicit zone', function () {
+describe('calendarDateFromUnix with an explicit zone', function () {
   const INSTANT = Date.UTC(2026, 5, 21, 2, 0) / 1000;
 
   it('reads the date in the zone it is given, not the host zone', function () {
-    expect(calendarDateOf(INSTANT, 'UTC')).toBe(d('2026-06-21'));
-    expect(calendarDateOf(INSTANT, 'America/Chicago')).toBe(d('2026-06-20'));
-    expect(calendarDateOf(INSTANT, 'Asia/Tokyo')).toBe(d('2026-06-21'));
+    expect(calendarDateFromUnix(INSTANT, 'UTC')).toBe(d('2026-06-21'));
+    expect(calendarDateFromUnix(INSTANT, 'America/Chicago')).toBe(d('2026-06-20'));
+    expect(calendarDateFromUnix(INSTANT, 'Asia/Tokyo')).toBe(d('2026-06-21'));
   });
 
   it('stays on one date for every hour of a 23-hour day', function () {
     // Mar 8 2026 is the US spring-forward day: 23 local hours, not 24
     for (let hour = 6; hour < 29; hour++) {
       const instant = Date.UTC(2026, 2, 8, hour) / 1000;
-      expect(calendarDateOf(instant, 'America/Chicago')).toBe(d('2026-03-08'));
+      expect(calendarDateFromUnix(instant, 'America/Chicago')).toBe(d('2026-03-08'));
     }
-    expect(calendarDateOf(Date.UTC(2026, 2, 8, 29) / 1000, 'America/Chicago')).toBe(
+    expect(calendarDateFromUnix(Date.UTC(2026, 2, 8, 29) / 1000, 'America/Chicago')).toBe(
       d('2026-03-09')
     );
   });
 
   it('handles a zone whose local midnight does not exist', function () {
     // Santiago springs forward at 24:00 on the 5th, so the 6th begins at 01:00 = 04:00Z
-    expect(calendarDateOf(Date.UTC(2026, 8, 6, 3) / 1000, 'America/Santiago')).toBe(
+    expect(calendarDateFromUnix(Date.UTC(2026, 8, 6, 3) / 1000, 'America/Santiago')).toBe(
       d('2026-09-05')
     );
-    expect(calendarDateOf(Date.UTC(2026, 8, 6, 4) / 1000, 'America/Santiago')).toBe(
+    expect(calendarDateFromUnix(Date.UTC(2026, 8, 6, 4) / 1000, 'America/Santiago')).toBe(
       d('2026-09-06')
     );
   });
 
   it('handles an offset that is not a whole hour', function () {
     // Kathmandu is +05:45, so 18:20Z is 00:05 the next day
-    expect(calendarDateOf(Date.UTC(2026, 5, 20, 18, 20) / 1000, 'Asia/Kathmandu')).toBe(
+    expect(calendarDateFromUnix(Date.UTC(2026, 5, 20, 18, 20) / 1000, 'Asia/Kathmandu')).toBe(
       d('2026-06-21')
     );
-    expect(calendarDateOf(Date.UTC(2026, 5, 20, 18, 10) / 1000, 'Asia/Kathmandu')).toBe(
+    expect(calendarDateFromUnix(Date.UTC(2026, 5, 20, 18, 10) / 1000, 'Asia/Kathmandu')).toBe(
       d('2026-06-20')
     );
   });
 
-  it('reuses one formatter per zone rather than building one per call', function () {
-    // Guards the cache: 12x slower uncached, and this is called per occurrence on load
-    const first = calendarDateOf(INSTANT, 'Europe/Berlin');
-    for (let i = 0; i < 100; i++) {
-      expect(calendarDateOf(INSTANT, 'Europe/Berlin')).toBe(first);
+  it('builds one formatter per zone, not one per call', function () {
+    const real = Intl.DateTimeFormat;
+    let built = 0;
+    (Intl as any).DateTimeFormat = function (...args: any[]) {
+      built += 1;
+      return new (real as any)(...args);
+    };
+    try {
+      // A zone no earlier spec has touched, since the cache outlives each spec
+      for (let i = 0; i < 5; i++) calendarDateFromUnix(INSTANT, 'Europe/Oslo');
+    } finally {
+      (Intl as any).DateTimeFormat = real;
     }
+    expect(built).toBe(1);
   });
 });
 
-describe('unixDayStart', function () {
+describe('dayStartUnix', function () {
   it('lands on the date it was given, whatever that day starts at', function () {
     // Not asserted as a wall clock: where local midnight doesn't exist the day starts at
     // 01:00, and that instant is still the correct start of the date.
     ['2026-06-21', '2026-03-08', '2026-11-01', '2026-09-06'].forEach((iso) => {
-      expect(calendarDateOf(unixDayStart(d(iso)))).toBe(d(iso));
+      expect(calendarDateFromUnix(dayStartUnix(d(iso)))).toBe(d(iso));
     });
   });
 
   it('round-trips any instant through its date', function () {
-    const start = unixDayStart(calendarDateOf(at('2026-06-21', 17, 45)));
-    expect(calendarDateOf(start)).toBe(d('2026-06-21'));
+    const start = dayStartUnix(calendarDateFromUnix(at('2026-06-21', 17, 45)));
+    expect(calendarDateFromUnix(start)).toBe(d('2026-06-21'));
   });
 });
 
-describe('unixDayEndExclusive', function () {
+describe('nextDayStartUnix', function () {
   // month-view.tsx and agenda-view.tsx filter on `start < dayEnd && end > dayStart`, which
   // needs the exclusive boundary: the covered day lights up and the next one must not.
   it('satisfies the overlap test for exactly the days covered', function () {
-    const end = unixDayEndExclusive(d('2026-06-21')); // one-day event on the 21st
-    expect(end > unixDayStart(d('2026-06-21'))).toBe(true);
-    expect(end > unixDayStart(d('2026-06-22'))).toBe(false);
+    const end = nextDayStartUnix(d('2026-06-21')); // one-day event on the 21st
+    expect(end > dayStartUnix(d('2026-06-21'))).toBe(true);
+    expect(end > dayStartUnix(d('2026-06-22'))).toBe(false);
   });
 
   it('is the next day-start', function () {
-    expect(unixDayEndExclusive(d('2026-06-21'))).toBe(unixDayStart(d('2026-06-22')));
+    expect(nextDayStartUnix(d('2026-06-21'))).toBe(dayStartUnix(d('2026-06-22')));
   });
 
   it('holds across a transition day, where the span is not 86400 seconds', function () {
     ['2026-03-08', '2026-11-01', '2026-09-06'].forEach((iso) => {
       const next = addCalendarDays(d(iso), 1);
-      expect(unixDayEndExclusive(d(iso))).toBe(unixDayStart(next));
-      expect(unixDayEndExclusive(d(iso)) > unixDayStart(d(iso))).toBe(true);
+      expect(nextDayStartUnix(d(iso))).toBe(dayStartUnix(next));
+      expect(nextDayStartUnix(d(iso)) > dayStartUnix(d(iso))).toBe(true);
     });
   });
 });
@@ -147,9 +161,7 @@ describe('addCalendarDays', function () {
     expect(addCalendarDays(d('2028-02-28'), 1)).toBe(d('2028-02-29'));
   });
 
-  // The bug class this type exists to remove: a DST transition inside the range used to make
-  // a "day" 23 or 25 hours and shift the answer. Dates have no hours to get wrong.
-  it('is unaffected by DST transitions inside the range', function () {
+  it('crosses dates that a timestamp shift would have gotten wrong', function () {
     expect(addCalendarDays(d('2026-03-07'), 2)).toBe(d('2026-03-09'));
     expect(addCalendarDays(d('2026-10-31'), 3)).toBe(d('2026-11-03'));
     expect(addCalendarDays(d('2026-09-05'), 2)).toBe(d('2026-09-07'));
@@ -163,7 +175,7 @@ describe('calendarDaysBetween', function () {
     expect(calendarDaysBetween(d('2026-06-21'), d('2026-06-21'))).toBe(0);
   });
 
-  it('counts across a DST transition without a fractional residue', function () {
+  it('counts across dates a timestamp diff would have made fractional', function () {
     expect(calendarDaysBetween(d('2026-03-07'), d('2026-03-09'))).toBe(2);
     expect(calendarDaysBetween(d('2026-09-05'), d('2026-09-07'))).toBe(2);
   });
@@ -176,33 +188,7 @@ describe('calendarDaysBetween', function () {
   });
 });
 
-describe('calendarDaySpan', function () {
-  it('counts a single-day event as one day', function () {
-    expect(calendarDaySpan(d('2026-06-21'), d('2026-06-21'))).toBe(1);
-  });
-
-  it('counts an inclusive multi-day range', function () {
-    expect(calendarDaySpan(d('2026-06-21'), d('2026-06-23'))).toBe(3);
-  });
-});
-
-describe('ICS date encoding', function () {
-  it('parses the DATE form', function () {
-    expect(parseICSDate('20260621')).toBe(d('2026-06-21'));
-    expect(parseICSDate('20270101')).toBe(d('2027-01-01'));
-  });
-
-  it('formats the DATE form, zero-padded', function () {
-    expect(formatICSDate(d('2026-06-21'))).toBe('20260621');
-    expect(formatICSDate(d('2026-01-05'))).toBe('20260105');
-  });
-
-  it('round-trips through the wire format', function () {
-    ['20260621', '20260101', '20261231', '20280229'].forEach((wire) => {
-      expect(formatICSDate(parseICSDate(wire))).toBe(wire);
-    });
-  });
-
+describe('the readable form', function () {
   // The value is a plain number at runtime, so a spec asserting the wrong day would otherwise
   // read as "expected 20627, got 20628". These keep failures legible.
   it('round-trips through the readable form', function () {

--- a/app/spec/calendar-date-spec.ts
+++ b/app/spec/calendar-date-spec.ts
@@ -29,7 +29,9 @@ describe('the epoch-day encoding', function () {
   });
 
   it('reads an instant onto the same integer', function () {
-    expect(calendarDateFromUnix(Date.UTC(2026, 5, 21, 12) / 1000, 'UTC')).toBe(20625 as CalendarDate);
+    expect(calendarDateFromUnix(Date.UTC(2026, 5, 21, 12) / 1000, 'UTC')).toBe(
+      20625 as CalendarDate
+    );
   });
 });
 
@@ -127,8 +129,8 @@ describe('dayStartUnix', function () {
 });
 
 describe('nextDayStartUnix', function () {
-  // month-view.tsx and agenda-view.tsx filter on `start < dayEnd && end > dayStart`, which
-  // needs the exclusive boundary: the covered day lights up and the next one must not.
+  // The exclusive boundary a stored or serialized end needs: one day's worth past the last
+  // covered day, and not two.
   it('satisfies the overlap test for exactly the days covered', function () {
     const end = nextDayStartUnix(d('2026-06-21')); // one-day event on the 21st
     expect(end > dayStartUnix(d('2026-06-21'))).toBe(true);

--- a/app/spec/calendar-date-spec.ts
+++ b/app/spec/calendar-date-spec.ts
@@ -1,0 +1,213 @@
+import {
+  CalendarDate,
+  calendarDateOf,
+  unixDayStart,
+  unixDayEndExclusive,
+  addCalendarDays,
+  calendarDaysBetween,
+  calendarDaySpan,
+  parseICSDate,
+  formatICSDate,
+  formatCalendarDate,
+  parseCalendarDate,
+} from '../src/calendar-date';
+
+/** Fixtures read as dates, not epoch-day integers — a failure says 2026-06-21, not 20627 */
+const d = (iso: string): CalendarDate => parseCalendarDate(iso);
+
+/** A local instant on the given date, at the given time of day */
+const at = (iso: string, hour = 0, minute = 0): number => {
+  const [y, m, day] = iso.split('-').map(Number);
+  return new Date(y, m - 1, day, hour, minute).getTime() / 1000;
+};
+
+describe('calendarDateOf', function () {
+  // The property the whole design rests on: the date is read off the instant's components,
+  // never computed from a boundary, so the time of day cannot change the answer. Each of
+  // these times of day is one we've actually seen in production for an all-day event.
+  it('gives the same date whatever the time of day', function () {
+    const expected = d('2026-06-21');
+    expect(calendarDateOf(at('2026-06-21', 0, 0))).toBe(expected); // local midnight
+    expect(calendarDateOf(at('2026-06-21', 1, 0))).toBe(expected); // the engine's mktime slop
+    expect(calendarDateOf(at('2026-06-21', 12, 30))).toBe(expected);
+    expect(calendarDateOf(at('2026-06-21', 23, 0))).toBe(expected); // moment's gap resolution
+    expect(calendarDateOf(at('2026-06-21', 23, 59))).toBe(expected);
+  });
+
+  it('does not bleed into the neighbouring days', function () {
+    expect(calendarDateOf(at('2026-06-20', 23, 59))).toBe(d('2026-06-20'));
+    expect(calendarDateOf(at('2026-06-22', 0, 0))).toBe(d('2026-06-22'));
+  });
+
+  it('reads dates across month, year and leap boundaries', function () {
+    expect(calendarDateOf(at('2026-06-30', 13, 0))).toBe(d('2026-06-30'));
+    expect(calendarDateOf(at('2026-12-31', 13, 0))).toBe(d('2026-12-31'));
+    expect(calendarDateOf(at('2028-02-29', 13, 0))).toBe(d('2028-02-29'));
+  });
+});
+
+// These pass an explicit zone, so they discriminate under CI's UTC — a host-zone read can't.
+// Verified boundary values, not guesses: 2026-06-21T02:00Z is still the 20th in Chicago.
+describe('calendarDateOf with an explicit zone', function () {
+  const INSTANT = Date.UTC(2026, 5, 21, 2, 0) / 1000;
+
+  it('reads the date in the zone it is given, not the host zone', function () {
+    expect(calendarDateOf(INSTANT, 'UTC')).toBe(d('2026-06-21'));
+    expect(calendarDateOf(INSTANT, 'America/Chicago')).toBe(d('2026-06-20'));
+    expect(calendarDateOf(INSTANT, 'Asia/Tokyo')).toBe(d('2026-06-21'));
+  });
+
+  it('stays on one date for every hour of a 23-hour day', function () {
+    // Mar 8 2026 is the US spring-forward day: 23 local hours, not 24
+    for (let hour = 6; hour < 29; hour++) {
+      const instant = Date.UTC(2026, 2, 8, hour) / 1000;
+      expect(calendarDateOf(instant, 'America/Chicago')).toBe(d('2026-03-08'));
+    }
+    expect(calendarDateOf(Date.UTC(2026, 2, 8, 29) / 1000, 'America/Chicago')).toBe(
+      d('2026-03-09')
+    );
+  });
+
+  it('handles a zone whose local midnight does not exist', function () {
+    // Santiago springs forward at 24:00 on the 5th, so the 6th begins at 01:00 = 04:00Z
+    expect(calendarDateOf(Date.UTC(2026, 8, 6, 3) / 1000, 'America/Santiago')).toBe(
+      d('2026-09-05')
+    );
+    expect(calendarDateOf(Date.UTC(2026, 8, 6, 4) / 1000, 'America/Santiago')).toBe(
+      d('2026-09-06')
+    );
+  });
+
+  it('handles an offset that is not a whole hour', function () {
+    // Kathmandu is +05:45, so 18:20Z is 00:05 the next day
+    expect(calendarDateOf(Date.UTC(2026, 5, 20, 18, 20) / 1000, 'Asia/Kathmandu')).toBe(
+      d('2026-06-21')
+    );
+    expect(calendarDateOf(Date.UTC(2026, 5, 20, 18, 10) / 1000, 'Asia/Kathmandu')).toBe(
+      d('2026-06-20')
+    );
+  });
+
+  it('reuses one formatter per zone rather than building one per call', function () {
+    // Guards the cache: 12x slower uncached, and this is called per occurrence on load
+    const first = calendarDateOf(INSTANT, 'Europe/Berlin');
+    for (let i = 0; i < 100; i++) {
+      expect(calendarDateOf(INSTANT, 'Europe/Berlin')).toBe(first);
+    }
+  });
+});
+
+describe('unixDayStart', function () {
+  it('lands on the date it was given, whatever that day starts at', function () {
+    // Not asserted as a wall clock: where local midnight doesn't exist the day starts at
+    // 01:00, and that instant is still the correct start of the date.
+    ['2026-06-21', '2026-03-08', '2026-11-01', '2026-09-06'].forEach((iso) => {
+      expect(calendarDateOf(unixDayStart(d(iso)))).toBe(d(iso));
+    });
+  });
+
+  it('round-trips any instant through its date', function () {
+    const start = unixDayStart(calendarDateOf(at('2026-06-21', 17, 45)));
+    expect(calendarDateOf(start)).toBe(d('2026-06-21'));
+  });
+});
+
+describe('unixDayEndExclusive', function () {
+  // month-view.tsx and agenda-view.tsx filter on `start < dayEnd && end > dayStart`, which
+  // needs the exclusive boundary: the covered day lights up and the next one must not.
+  it('satisfies the overlap test for exactly the days covered', function () {
+    const end = unixDayEndExclusive(d('2026-06-21')); // one-day event on the 21st
+    expect(end > unixDayStart(d('2026-06-21'))).toBe(true);
+    expect(end > unixDayStart(d('2026-06-22'))).toBe(false);
+  });
+
+  it('is the next day-start', function () {
+    expect(unixDayEndExclusive(d('2026-06-21'))).toBe(unixDayStart(d('2026-06-22')));
+  });
+
+  it('holds across a transition day, where the span is not 86400 seconds', function () {
+    ['2026-03-08', '2026-11-01', '2026-09-06'].forEach((iso) => {
+      const next = addCalendarDays(d(iso), 1);
+      expect(unixDayEndExclusive(d(iso))).toBe(unixDayStart(next));
+      expect(unixDayEndExclusive(d(iso)) > unixDayStart(d(iso))).toBe(true);
+    });
+  });
+});
+
+describe('addCalendarDays', function () {
+  it('shifts whole days in either direction', function () {
+    expect(addCalendarDays(d('2026-06-21'), 1)).toBe(d('2026-06-22'));
+    expect(addCalendarDays(d('2026-06-21'), -1)).toBe(d('2026-06-20'));
+    expect(addCalendarDays(d('2026-06-21'), 0)).toBe(d('2026-06-21'));
+  });
+
+  it('crosses month, year and leap boundaries', function () {
+    expect(addCalendarDays(d('2026-06-30'), 1)).toBe(d('2026-07-01'));
+    expect(addCalendarDays(d('2026-12-31'), 1)).toBe(d('2027-01-01'));
+    expect(addCalendarDays(d('2028-02-28'), 1)).toBe(d('2028-02-29'));
+  });
+
+  // The bug class this type exists to remove: a DST transition inside the range used to make
+  // a "day" 23 or 25 hours and shift the answer. Dates have no hours to get wrong.
+  it('is unaffected by DST transitions inside the range', function () {
+    expect(addCalendarDays(d('2026-03-07'), 2)).toBe(d('2026-03-09'));
+    expect(addCalendarDays(d('2026-10-31'), 3)).toBe(d('2026-11-03'));
+    expect(addCalendarDays(d('2026-09-05'), 2)).toBe(d('2026-09-07'));
+  });
+});
+
+describe('calendarDaysBetween', function () {
+  it('counts whole days, signed', function () {
+    expect(calendarDaysBetween(d('2026-06-21'), d('2026-06-24'))).toBe(3);
+    expect(calendarDaysBetween(d('2026-06-24'), d('2026-06-21'))).toBe(-3);
+    expect(calendarDaysBetween(d('2026-06-21'), d('2026-06-21'))).toBe(0);
+  });
+
+  it('counts across a DST transition without a fractional residue', function () {
+    expect(calendarDaysBetween(d('2026-03-07'), d('2026-03-09'))).toBe(2);
+    expect(calendarDaysBetween(d('2026-09-05'), d('2026-09-07'))).toBe(2);
+  });
+
+  it('round-trips with addCalendarDays', function () {
+    [-30, -1, 0, 1, 45, 400].forEach((days) => {
+      const from = d('2026-03-07');
+      expect(calendarDaysBetween(from, addCalendarDays(from, days))).toBe(days);
+    });
+  });
+});
+
+describe('calendarDaySpan', function () {
+  it('counts a single-day event as one day', function () {
+    expect(calendarDaySpan(d('2026-06-21'), d('2026-06-21'))).toBe(1);
+  });
+
+  it('counts an inclusive multi-day range', function () {
+    expect(calendarDaySpan(d('2026-06-21'), d('2026-06-23'))).toBe(3);
+  });
+});
+
+describe('ICS date encoding', function () {
+  it('parses the DATE form', function () {
+    expect(parseICSDate('20260621')).toBe(d('2026-06-21'));
+    expect(parseICSDate('20270101')).toBe(d('2027-01-01'));
+  });
+
+  it('formats the DATE form, zero-padded', function () {
+    expect(formatICSDate(d('2026-06-21'))).toBe('20260621');
+    expect(formatICSDate(d('2026-01-05'))).toBe('20260105');
+  });
+
+  it('round-trips through the wire format', function () {
+    ['20260621', '20260101', '20261231', '20280229'].forEach((wire) => {
+      expect(formatICSDate(parseICSDate(wire))).toBe(wire);
+    });
+  });
+
+  // The value is a plain number at runtime, so a spec asserting the wrong day would otherwise
+  // read as "expected 20627, got 20628". These keep failures legible.
+  it('round-trips through the readable form', function () {
+    ['2026-06-21', '2026-01-05', '2026-12-31', '2028-02-29'].forEach((iso) => {
+      expect(formatCalendarDate(parseCalendarDate(iso))).toBe(iso);
+    });
+  });
+});

--- a/app/spec/calendar-drag-utils-spec.ts
+++ b/app/spec/calendar-drag-utils-spec.ts
@@ -244,31 +244,9 @@ describe('updateDragState move with day snapping', function () {
     });
   });
 
-  describe('onto a day whose local midnight does not exist', function () {
-    const ZONE = 'America/Santiago';
-    const dayStart = (iso: string) => moment.tz(iso, ZONE).unix();
-
-    afterEach(function () {
-      moment.tz.setDefault();
-    });
-
-    // A raw add() keeps the 01:00 wall clock the missing midnight forces, and snapAllDayTimes
-    // then rounds it up, so a one-day event lands as two.
-    it('still previews exactly one day', function () {
-      moment.tz.setDefault(ZONE);
-      const start = dayStart('2026-01-10');
-      const moved = dragMove(start, dayStart('2026-01-11'), dayStart('2026-09-06'));
-      expect(moved.start).toBe(dayStart('2026-09-06'));
-      expect(moved.end).toBe(dayStart('2026-09-07'));
-    });
-
-    it('still previews exactly three days for a three-day event', function () {
-      moment.tz.setDefault(ZONE);
-      const start = dayStart('2026-01-10');
-      const moved = dragMove(start, dayStart('2026-01-13'), dayStart('2026-09-06'));
-      expect(moved.end).toBe(dayStart('2026-09-09'));
-    });
-  });
+  // A midnight-gap block used to live here, pinned with moment.tz.setDefault. The move path
+  // now computes through calendar-date (plain Date/Intl), which setDefault cannot reach, so
+  // that coverage needs the runner's own zone instead — see scripts/test.js.
 });
 
 describe('createDragPreviewEvent', function () {

--- a/app/spec/calendar-drag-utils-spec.ts
+++ b/app/spec/calendar-drag-utils-spec.ts
@@ -1,7 +1,9 @@
 import moment from 'moment-timezone';
+import { formatCalendarDate } from '../src/calendar-date';
 // Import the functions under test directly from the source file.
 // We use a relative path because the plugin is not registered in mailspring-exports.
 import {
+  createDragPreviewEvent,
   isPastDate,
   canMoveEvent,
   snapAllDayTimes,
@@ -9,13 +11,16 @@ import {
   updateDragState,
 } from '../internal_packages/main-calendar/lib/core/calendar-drag-utils';
 import { MONTH_VIEW_DRAG_CONFIG } from '../internal_packages/main-calendar/lib/core/calendar-drag-types';
-import { EventOccurrence } from '../internal_packages/main-calendar/lib/core/calendar-data-source';
+import {
+  EventOccurrence,
+  coveredDates,
+} from '../internal_packages/main-calendar/lib/core/calendar-data-source';
 
 const HOUR = 60 * 60;
 
 function makeOccurrence(overrides: Partial<EventOccurrence> = {}): EventOccurrence {
   const nowUnix = Date.now() / 1000;
-  return {
+  const base = {
     id: 'event-1-e0',
     accountId: 'acct-1',
     calendarId: 'cal-1',
@@ -33,6 +38,9 @@ function makeOccurrence(overrides: Partial<EventOccurrence> = {}): EventOccurren
     attendees: [],
     ...overrides,
   };
+  // Through the same derivation production uses, so fixtures can't encode a shape
+  // occurrencesForEvents would never emit
+  return { ...base, ...coveredDates(base.start, base.end, base.isAllDay) };
 }
 
 describe('isPastDate', function () {
@@ -162,33 +170,38 @@ describe('updateDragState with day snapping', function () {
 
   it('never previews less than one whole day', function () {
     // resize-end dragged back before the start
-    expect(
-      dragEdge(day(2026, 8, 14), day(2026, 8, 15), 'resize-end', day(2026, 8, 12))
-    ).toEqual({ start: day(2026, 8, 14), end: day(2026, 8, 15) });
+    expect(dragEdge(day(2026, 8, 14), day(2026, 8, 15), 'resize-end', day(2026, 8, 12))).toEqual({
+      start: day(2026, 8, 14),
+      end: day(2026, 8, 15),
+    });
     // resize-start dragged past the end
-    expect(
-      dragEdge(day(2026, 8, 14), day(2026, 8, 15), 'resize-start', day(2026, 8, 20))
-    ).toEqual({ start: day(2026, 8, 14), end: day(2026, 8, 15) });
+    expect(dragEdge(day(2026, 8, 14), day(2026, 8, 15), 'resize-start', day(2026, 8, 20))).toEqual({
+      start: day(2026, 8, 14),
+      end: day(2026, 8, 15),
+    });
   });
 
   it('extends a multi-day span to the day the cursor is in', function () {
-    expect(
-      dragEdge(day(2026, 8, 14), day(2026, 8, 16), 'resize-end', day(2026, 8, 18))
-    ).toEqual({ start: day(2026, 8, 14), end: day(2026, 8, 19) });
+    expect(dragEdge(day(2026, 8, 14), day(2026, 8, 16), 'resize-end', day(2026, 8, 18))).toEqual({
+      start: day(2026, 8, 14),
+      end: day(2026, 8, 19),
+    });
   });
 
   it('keeps the last day when the right edge is grabbed without moving', function () {
     // Containers hand over the day's exact midnight, so a jiggle inside the last cell
     // must not shrink the event. Aug 14 -> Aug 17 covers 14-16; cursor sits on the 16th.
-    expect(
-      dragEdge(day(2026, 8, 14), day(2026, 8, 17), 'resize-end', day(2026, 8, 16))
-    ).toEqual({ start: day(2026, 8, 14), end: day(2026, 8, 17) });
+    expect(dragEdge(day(2026, 8, 14), day(2026, 8, 17), 'resize-end', day(2026, 8, 16))).toEqual({
+      start: day(2026, 8, 14),
+      end: day(2026, 8, 17),
+    });
   });
 
   it('shrinks a span to the cursor day rather than one short of it', function () {
-    expect(
-      dragEdge(day(2026, 8, 14), day(2026, 8, 20), 'resize-end', day(2026, 8, 16))
-    ).toEqual({ start: day(2026, 8, 14), end: day(2026, 8, 17) });
+    expect(dragEdge(day(2026, 8, 14), day(2026, 8, 20), 'resize-end', day(2026, 8, 16))).toEqual({
+      start: day(2026, 8, 14),
+      end: day(2026, 8, 17),
+    });
   });
 });
 
@@ -218,15 +231,17 @@ describe('updateDragState move with day snapping', function () {
   }
 
   it('moves a one-day event to the drop day, ending on the next midnight', function () {
-    expect(
-      dragMove(localDay(2026, 8, 14), localDay(2026, 8, 15), localDay(2026, 8, 20))
-    ).toEqual({ start: localDay(2026, 8, 20), end: localDay(2026, 8, 21) });
+    expect(dragMove(localDay(2026, 8, 14), localDay(2026, 8, 15), localDay(2026, 8, 20))).toEqual({
+      start: localDay(2026, 8, 20),
+      end: localDay(2026, 8, 21),
+    });
   });
 
   it('preserves the span of a multi-day event', function () {
-    expect(
-      dragMove(localDay(2026, 8, 14), localDay(2026, 8, 17), localDay(2026, 8, 20))
-    ).toEqual({ start: localDay(2026, 8, 20), end: localDay(2026, 8, 23) });
+    expect(dragMove(localDay(2026, 8, 14), localDay(2026, 8, 17), localDay(2026, 8, 20))).toEqual({
+      start: localDay(2026, 8, 20),
+      end: localDay(2026, 8, 23),
+    });
   });
 
   describe('onto a day whose local midnight does not exist', function () {
@@ -253,5 +268,57 @@ describe('updateDragState move with day snapping', function () {
       const moved = dragMove(start, dayStart('2026-01-13'), dayStart('2026-09-06'));
       expect(moved.end).toBe(dayStart('2026-09-09'));
     });
+  });
+});
+
+describe('createDragPreviewEvent', function () {
+  const localDay = (y: number, m: number, d: number) => new Date(y, m - 1, d).getTime() / 1000;
+  const covered = (occ: EventOccurrence) => [
+    formatCalendarDate(occ.startDate),
+    formatCalendarDate(occ.endDate),
+  ];
+
+  // The preview spreads the original occurrence, so its dates have to be recomputed from the
+  // preview instants or they describe where the event was before the drag.
+  it('moves an all-day preview onto the dragged days', function () {
+    const event = makeOccurrence({
+      isAllDay: true,
+      start: localDay(2026, 6, 21),
+      end: localDay(2026, 6, 22),
+    });
+    const preview = createDragPreviewEvent({
+      event,
+      previewStart: localDay(2026, 6, 24),
+      previewEnd: localDay(2026, 6, 25),
+    } as any);
+    expect(covered(preview)).toEqual(['2026-06-24', '2026-06-24']);
+  });
+
+  it('keeps a multi-day all-day span the same length', function () {
+    const event = makeOccurrence({
+      isAllDay: true,
+      start: localDay(2026, 6, 21),
+      end: localDay(2026, 6, 24),
+    });
+    const preview = createDragPreviewEvent({
+      event,
+      previewStart: localDay(2026, 6, 28),
+      previewEnd: localDay(2026, 7, 1),
+    } as any);
+    expect(covered(preview)).toEqual(['2026-06-28', '2026-06-30']);
+  });
+
+  it('moves a timed preview onto the dragged day', function () {
+    const event = makeOccurrence({
+      isAllDay: false,
+      start: localDay(2026, 6, 21) + 10 * HOUR,
+      end: localDay(2026, 6, 21) + 11 * HOUR,
+    });
+    const preview = createDragPreviewEvent({
+      event,
+      previewStart: localDay(2026, 6, 25) + 10 * HOUR,
+      previewEnd: localDay(2026, 6, 25) + 11 * HOUR,
+    } as any);
+    expect(covered(preview)).toEqual(['2026-06-25', '2026-06-25']);
   });
 });

--- a/app/spec/calendar-drag-utils-spec.ts
+++ b/app/spec/calendar-drag-utils-spec.ts
@@ -1,4 +1,3 @@
-import moment from 'moment-timezone';
 import { formatCalendarDate } from '../src/calendar-date';
 // Import the functions under test directly from the source file.
 // We use a relative path because the plugin is not registered in mailspring-exports.
@@ -244,9 +243,9 @@ describe('updateDragState move with day snapping', function () {
     });
   });
 
-  // A midnight-gap block used to live here, pinned with moment.tz.setDefault. The move path
-  // now computes through calendar-date (plain Date/Intl), which setDefault cannot reach, so
-  // that coverage needs the runner's own zone instead — see scripts/test.js.
+  // A midnight-gap block lived here, pinned with moment.tz.setDefault. The move path now
+  // computes through calendar-date, which setDefault cannot reach — and the runner's pinned
+  // zone transitions at 2am, so it has no missing midnight either. That case is uncovered.
 });
 
 describe('createDragPreviewEvent', function () {

--- a/app/spec/calendar-helpers-spec.ts
+++ b/app/spec/calendar-helpers-spec.ts
@@ -1,14 +1,15 @@
 // Import directly from the source file; the plugin isn't registered in mailspring-exports.
-import moment from 'moment-timezone';
 import {
   inclusiveAllDayEnd,
   shiftEndWithStart,
   clampEnd,
 } from '../internal_packages/main-calendar/lib/core/calendar-helpers';
-import { shiftedDayStartUnix, calendarDateFromUnix, nextDayStartUnix } from '../src/calendar-date';
-
-/** The stored exclusive end for a last-covered day, as the production callers now build it */
-const exclusiveEnd = (lastDay: number) => nextDayStartUnix(calendarDateFromUnix(lastDay));
+import {
+  shiftedDayStartUnix,
+  dayStartUnix,
+  calendarDateFromUnix,
+  calendarDaysBetween,
+} from '../src/calendar-date';
 
 /** Local midnight, as unix seconds — all-day times are built from local date components */
 function localDay(year: number, month1Indexed: number, day: number): number {
@@ -119,10 +120,55 @@ describe('clampEnd', function () {
 
 // A moment.tz.setDefault-pinned DST block lived here. It's gone rather than patched: setDefault
 // only reaches code still computing through moment, and the day math it covered now runs on
-// epoch-day integers, which have no zone behaviour to pin. That coverage is in
-// calendar-date-spec.ts, zone-independent by construction.
+// epoch-day integers, which have no zone behaviour to pin. What it covered at the CALL sites
+// is restored below with transition-date fixtures in the runner's pinned zone.
 //
 // inclusiveAllDayEnd is the last moment holdout, and it needed no pinned coverage: for an exact
 // midnight its truncation is correct in every zone, transition days included. Its one bad input
 // is an end an hour past midnight, which it cannot tell from the all-day toggle wall-clock ends
-// - indistinguishable by construction, and unreachable while callers pass ical.js values.
+// - indistinguishable by construction. Reachable via the expansion-failure path, which passes
+// the engine-written columns rather than ical.js values.
+
+// Restores what the deleted setDefault block was reaching for, without pinning a zone: these
+// use the runner's own transition dates (scripts/test.js pins one that has them) and assert an
+// invariant rather than a magnitude, so they hold in every zone and still fail if any of these
+// call sites is rewritten as `+ days * 86400`.
+describe('all-day day math at a DST transition', function () {
+  const localDay = (y: number, m: number, d: number) => new Date(y, m - 1, d).getTime() / 1000;
+  /** A day boundary is the start of its own date — false for anything landing mid-day */
+  const isDayStart = (unix: number) => unix === dayStartUnix(calendarDateFromUnix(unix));
+
+  // 2026-03-08 and 2026-11-01 are 23 and 25 hours long in the pinned zone
+  const TRANSITIONS = [localDay(2026, 3, 8), localDay(2026, 11, 1)];
+  const ORDINARY = localDay(2026, 6, 21);
+
+  it('lands clampEnd floors on a day boundary', function () {
+    [...TRANSITIONS, ORDINARY].forEach((start) => {
+      expect(isDayStart(clampEnd(start, start, true))).toBe(true);
+    });
+  });
+
+  it('gives clampEnd floors a full day, whatever its length', function () {
+    TRANSITIONS.forEach((start) => {
+      const floor = clampEnd(start, start, true);
+      expect(calendarDaysBetween(calendarDateFromUnix(start), calendarDateFromUnix(floor))).toBe(1);
+    });
+  });
+
+  it('lands shiftEndWithStart on a day boundary across a transition', function () {
+    TRANSITIONS.forEach((start) => {
+      const end = clampEnd(start, start, true); // one-day event
+      const moved = shiftEndWithStart(start, end, shiftedDayStartUnix(start, 1), true);
+      expect(isDayStart(moved)).toBe(true);
+    });
+  });
+
+  it('keeps a span the same number of days when its start crosses a transition', function () {
+    TRANSITIONS.forEach((start) => {
+      const end = shiftedDayStartUnix(start, 3); // exclusive end of a 3-day span
+      const moved = shiftEndWithStart(start, end, shiftedDayStartUnix(start, 1), true);
+      const from = calendarDateFromUnix(shiftedDayStartUnix(start, 1));
+      expect(calendarDaysBetween(from, calendarDateFromUnix(moved))).toBe(3);
+    });
+  });
+});

--- a/app/spec/calendar-helpers-spec.ts
+++ b/app/spec/calendar-helpers-spec.ts
@@ -3,11 +3,14 @@ import moment from 'moment-timezone';
 import {
   inclusiveAllDayEnd,
   exclusiveAllDayEnd,
-  addCalendarDays,
-  calendarDaysBetween,
   shiftEndWithStart,
   clampEnd,
 } from '../internal_packages/main-calendar/lib/core/calendar-helpers';
+import {
+  shiftedDayStartUnix,
+  calendarDateFromUnix,
+  calendarDaysBetween,
+} from '../src/calendar-date';
 
 /** Local midnight, as unix seconds — all-day times are built from local date components */
 function localDay(year: number, month1Indexed: number, day: number): number {
@@ -58,31 +61,6 @@ describe('exclusiveAllDayEnd', function () {
   it('is stable when a picked day is re-picked', function () {
     const picked = localDay(2026, 6, 21);
     expect(inclusiveAllDayEnd(exclusiveAllDayEnd(picked))).toBe(picked);
-  });
-});
-
-describe('addCalendarDays', function () {
-  it('shifts backwards', function () {
-    expect(addCalendarDays(localDay(2026, 6, 24), -2)).toBe(localDay(2026, 6, 22));
-  });
-
-  it('crosses month and year boundaries', function () {
-    expect(addCalendarDays(localDay(2026, 6, 30), 1)).toBe(localDay(2026, 7, 1));
-    expect(addCalendarDays(localDay(2026, 12, 31), 1)).toBe(localDay(2027, 1, 1));
-  });
-});
-
-describe('calendarDaysBetween', function () {
-  it('is zero for the same day and negative going backwards', function () {
-    expect(calendarDaysBetween(localDay(2026, 6, 22), localDay(2026, 6, 22))).toBe(0);
-    expect(calendarDaysBetween(localDay(2026, 6, 24), localDay(2026, 6, 22))).toBe(-2);
-  });
-
-  it('round-trips with addCalendarDays', function () {
-    [-3, -1, 0, 1, 5, 40].forEach((days) => {
-      const from = localDay(2026, 6, 22);
-      expect(calendarDaysBetween(from, addCalendarDays(from, days))).toBe(days);
-    });
   });
 });
 
@@ -139,9 +117,9 @@ describe('clampEnd', function () {
   it('returns the end unchanged when a one-day event is shrunk', function () {
     const start = localDay(2026, 6, 22);
     const end = localDay(2026, 6, 23);
-    expect(clampEnd(start, addCalendarDays(end, -1), true)).toBe(end);
+    expect(clampEnd(start, shiftedDayStartUnix(end, -1), true)).toBe(end);
     // a longer span really does shrink
-    expect(clampEnd(start, addCalendarDays(localDay(2026, 6, 25), -1), true)).toBe(
+    expect(clampEnd(start, shiftedDayStartUnix(localDay(2026, 6, 25), -1), true)).toBe(
       localDay(2026, 6, 24)
     );
   });
@@ -170,7 +148,9 @@ describe('clampEnd', function () {
 
 // Calendar-day arithmetic only differs from a naive +86400 on a DST transition day, so these
 // pin the zone rather than relying on the machine's. moment-timezone augments the same moment
-// instance calendar-helpers imports, so setDefault reaches the code under test; fixtures use
+// instance calendar-helpers imports, so setDefault reaches what still computes through moment.
+// It does NOT reach anything routed through calendar-date (plain Date/Intl) — shiftEndWithStart
+// is now half each, so its DST coverage lives with the runner's zone instead. Fixtures use
 // an explicit zone so every assertion holds under CI's UTC too.
 describe('calendar-day arithmetic across DST transitions', function () {
   afterEach(function () {
@@ -179,6 +159,10 @@ describe('calendar-day arithmetic across DST transitions', function () {
 
   /** Start of a calendar day in `zone`, whatever wall clock that instant carries */
   const dayStart = (zone: string, iso: string) => moment.tz(iso, zone).unix();
+  /** Fixture shift. Must be moment-based: setDefault only reaches moment, so a Date-based
+   *  shift would build the fixture in the host zone while the code under test is in ZONE. */
+  const shiftFixture = (unix: number, days: number) =>
+    moment.unix(unix).add(days, 'days').startOf('day').unix();
 
   describe('where the transition is at 2am', function () {
     const ZONE = 'America/Chicago';
@@ -186,30 +170,21 @@ describe('calendar-day arithmetic across DST transitions', function () {
     it('advances to the next day-start across spring-forward, where +86400 overshoots', function () {
       moment.tz.setDefault(ZONE);
       const mar8 = dayStart(ZONE, '2026-03-08');
-      expect(addCalendarDays(mar8, 1)).toBe(dayStart(ZONE, '2026-03-09'));
-      expect(addCalendarDays(mar8, 1) - mar8).toBe(23 * 3600);
+      expect(shiftFixture(mar8, 1)).toBe(dayStart(ZONE, '2026-03-09'));
+      expect(shiftFixture(mar8, 1) - mar8).toBe(23 * 3600);
     });
 
     it('advances to the next day-start across fall-back, where +86400 undershoots', function () {
       moment.tz.setDefault(ZONE);
       const nov1 = dayStart(ZONE, '2026-11-01');
-      expect(addCalendarDays(nov1, 1)).toBe(dayStart(ZONE, '2026-11-02'));
-      expect(addCalendarDays(nov1, 1) - nov1).toBe(25 * 3600);
+      expect(shiftFixture(nov1, 1)).toBe(dayStart(ZONE, '2026-11-02'));
+      expect(shiftFixture(nov1, 1) - nov1).toBe(25 * 3600);
     });
 
     it('gives a 23-hour day a full exclusive end', function () {
       moment.tz.setDefault(ZONE);
       expect(exclusiveAllDayEnd(dayStart(ZONE, '2026-03-08'))).toBe(dayStart(ZONE, '2026-03-09'));
       expect(inclusiveAllDayEnd(dayStart(ZONE, '2026-03-09'))).toBe(dayStart(ZONE, '2026-03-08'));
-    });
-
-    it('keeps a multi-day span the same number of days across a transition', function () {
-      moment.tz.setDefault(ZONE);
-      // Mar 6 -> Mar 8 exclusive covers 2 days; move the start to Mar 7, spanning the transition
-      const start = dayStart(ZONE, '2026-03-06');
-      const end = dayStart(ZONE, '2026-03-08');
-      const newStart = dayStart(ZONE, '2026-03-07');
-      expect(shiftEndWithStart(start, end, newStart, true)).toBe(dayStart(ZONE, '2026-03-09'));
     });
 
     it('floors an all-day end to a whole calendar day, not 86400 seconds', function () {
@@ -227,33 +202,33 @@ describe('calendar-day arithmetic across DST transitions', function () {
     it('returns whole days when an endpoint is the transition day', function () {
       moment.tz.setDefault(ZONE);
       const sep6 = dayStart(ZONE, '2026-09-06');
-      expect(calendarDaysBetween(sep6, addCalendarDays(sep6, 5))).toBe(5);
-      expect(calendarDaysBetween(sep6, addCalendarDays(sep6, -5))).toBe(-5);
-      expect(calendarDaysBetween(sep6, addCalendarDays(sep6, 1))).toBe(1);
+      expect(
+        calendarDaysBetween(calendarDateFromUnix(sep6), calendarDateFromUnix(shiftFixture(sep6, 5)))
+      ).toBe(5);
+      expect(
+        calendarDaysBetween(
+          calendarDateFromUnix(sep6),
+          calendarDateFromUnix(shiftFixture(sep6, -5))
+        )
+      ).toBe(-5);
+      expect(
+        calendarDaysBetween(calendarDateFromUnix(sep6), calendarDateFromUnix(shiftFixture(sep6, 1)))
+      ).toBe(1);
     });
 
     // These compare calendar days, not instants. Where midnight doesn't exist the day starts
-    // at 01:00, and addCalendarDays carries that wall clock, so a round trip can shift by an
+    // at 01:00, and the shift carries that wall clock, so a round trip can shift by an
     // hour within the same day. Both encode the same DATE, so only the day is contractual.
     it('round-trips inclusive and exclusive ends onto the same day', function () {
       moment.tz.setDefault(ZONE);
       const sep6 = dayStart(ZONE, '2026-09-06');
       [-1, 0, 1].forEach((offset) => {
-        const start = addCalendarDays(sep6, offset);
+        const start = shiftFixture(sep6, offset);
         const roundTripped = inclusiveAllDayEnd(exclusiveAllDayEnd(start));
-        expect(calendarDaysBetween(start, roundTripped)).toBe(0);
+        expect(
+          calendarDaysBetween(calendarDateFromUnix(start), calendarDateFromUnix(roundTripped))
+        ).toBe(0);
       });
-    });
-
-    it('carries an end with its start without losing or gaining a day', function () {
-      moment.tz.setDefault(ZONE);
-      const start = dayStart(ZONE, '2026-09-04');
-      const end = exclusiveAllDayEnd(start); // one-day event
-      const newStart = dayStart(ZONE, '2026-09-06'); // the transition day
-      const moved = shiftEndWithStart(start, end, newStart, true);
-      // Still exactly one day long, and still the day after the new start
-      expect(calendarDaysBetween(newStart, moved)).toBe(1);
-      expect(calendarDaysBetween(newStart, inclusiveAllDayEnd(moved))).toBe(0);
     });
 
     // The only input shape where `add` before `startOf` differs from the reverse: the day
@@ -267,8 +242,13 @@ describe('calendar-day arithmetic across DST transitions', function () {
     it('spans the transition day itself without dropping it', function () {
       moment.tz.setDefault(ZONE);
       const start = dayStart(ZONE, '2026-09-05');
-      const end = exclusiveAllDayEnd(addCalendarDays(start, 2)); // covers 5th, 6th, 7th
-      expect(calendarDaysBetween(start, inclusiveAllDayEnd(end))).toBe(2);
+      const end = exclusiveAllDayEnd(shiftFixture(start, 2)); // covers 5th, 6th, 7th
+      expect(
+        calendarDaysBetween(
+          calendarDateFromUnix(start),
+          calendarDateFromUnix(inclusiveAllDayEnd(end))
+        )
+      ).toBe(2);
     });
   });
 });

--- a/app/spec/calendar-helpers-spec.ts
+++ b/app/spec/calendar-helpers-spec.ts
@@ -2,15 +2,13 @@
 import moment from 'moment-timezone';
 import {
   inclusiveAllDayEnd,
-  exclusiveAllDayEnd,
   shiftEndWithStart,
   clampEnd,
 } from '../internal_packages/main-calendar/lib/core/calendar-helpers';
-import {
-  shiftedDayStartUnix,
-  calendarDateFromUnix,
-  calendarDaysBetween,
-} from '../src/calendar-date';
+import { shiftedDayStartUnix, calendarDateFromUnix, nextDayStartUnix } from '../src/calendar-date';
+
+/** The stored exclusive end for a last-covered day, as the production callers now build it */
+const exclusiveEnd = (lastDay: number) => nextDayStartUnix(calendarDateFromUnix(lastDay));
 
 /** Local midnight, as unix seconds — all-day times are built from local date components */
 function localDay(year: number, month1Indexed: number, day: number): number {
@@ -34,33 +32,6 @@ describe('inclusiveAllDayEnd', function () {
   it('crosses month and year boundaries', function () {
     expect(inclusiveAllDayEnd(localDay(2026, 7, 1))).toBe(localDay(2026, 6, 30));
     expect(inclusiveAllDayEnd(localDay(2027, 1, 1))).toBe(localDay(2026, 12, 31));
-  });
-});
-
-describe('exclusiveAllDayEnd', function () {
-  it('turns a picked day into the midnight after it', function () {
-    expect(exclusiveAllDayEnd(localDay(2026, 6, 21))).toBe(localDay(2026, 6, 22));
-  });
-
-  it('crosses month and year boundaries', function () {
-    expect(exclusiveAllDayEnd(localDay(2026, 6, 30))).toBe(localDay(2026, 7, 1));
-    expect(exclusiveAllDayEnd(localDay(2026, 12, 31))).toBe(localDay(2027, 1, 1));
-  });
-
-  it('round-trips with inclusiveAllDayEnd', function () {
-    [
-      localDay(2026, 6, 22),
-      localDay(2026, 6, 23),
-      localDay(2026, 7, 1),
-      localDay(2027, 1, 1),
-    ].forEach((storedEnd) => {
-      expect(exclusiveAllDayEnd(inclusiveAllDayEnd(storedEnd))).toBe(storedEnd);
-    });
-  });
-
-  it('is stable when a picked day is re-picked', function () {
-    const picked = localDay(2026, 6, 21);
-    expect(inclusiveAllDayEnd(exclusiveAllDayEnd(picked))).toBe(picked);
   });
 });
 
@@ -146,109 +117,12 @@ describe('clampEnd', function () {
   });
 });
 
-// Calendar-day arithmetic only differs from a naive +86400 on a DST transition day, so these
-// pin the zone rather than relying on the machine's. moment-timezone augments the same moment
-// instance calendar-helpers imports, so setDefault reaches what still computes through moment.
-// It does NOT reach anything routed through calendar-date (plain Date/Intl) — shiftEndWithStart
-// is now half each, so its DST coverage lives with the runner's zone instead. Fixtures use
-// an explicit zone so every assertion holds under CI's UTC too.
-describe('calendar-day arithmetic across DST transitions', function () {
-  afterEach(function () {
-    moment.tz.setDefault(); // back to the machine's zone, or the rest of the suite inherits this
-  });
-
-  /** Start of a calendar day in `zone`, whatever wall clock that instant carries */
-  const dayStart = (zone: string, iso: string) => moment.tz(iso, zone).unix();
-  /** Fixture shift. Must be moment-based: setDefault only reaches moment, so a Date-based
-   *  shift would build the fixture in the host zone while the code under test is in ZONE. */
-  const shiftFixture = (unix: number, days: number) =>
-    moment.unix(unix).add(days, 'days').startOf('day').unix();
-
-  describe('where the transition is at 2am', function () {
-    const ZONE = 'America/Chicago';
-
-    it('advances to the next day-start across spring-forward, where +86400 overshoots', function () {
-      moment.tz.setDefault(ZONE);
-      const mar8 = dayStart(ZONE, '2026-03-08');
-      expect(shiftFixture(mar8, 1)).toBe(dayStart(ZONE, '2026-03-09'));
-      expect(shiftFixture(mar8, 1) - mar8).toBe(23 * 3600);
-    });
-
-    it('advances to the next day-start across fall-back, where +86400 undershoots', function () {
-      moment.tz.setDefault(ZONE);
-      const nov1 = dayStart(ZONE, '2026-11-01');
-      expect(shiftFixture(nov1, 1)).toBe(dayStart(ZONE, '2026-11-02'));
-      expect(shiftFixture(nov1, 1) - nov1).toBe(25 * 3600);
-    });
-
-    it('gives a 23-hour day a full exclusive end', function () {
-      moment.tz.setDefault(ZONE);
-      expect(exclusiveAllDayEnd(dayStart(ZONE, '2026-03-08'))).toBe(dayStart(ZONE, '2026-03-09'));
-      expect(inclusiveAllDayEnd(dayStart(ZONE, '2026-03-09'))).toBe(dayStart(ZONE, '2026-03-08'));
-    });
-
-    it('floors an all-day end to a whole calendar day, not 86400 seconds', function () {
-      moment.tz.setDefault(ZONE);
-      const mar8 = dayStart(ZONE, '2026-03-08');
-      expect(clampEnd(mar8, mar8, true)).toBe(dayStart(ZONE, '2026-03-09'));
-    });
-  });
-
-  describe('where the transition is at midnight', function () {
-    // Santiago springs forward at 24:00, so 2026-09-06 has no 00:00 and startOf('day')
-    // normalizes to 01:00 — the case that leaves a fractional day-diff.
-    const ZONE = 'America/Santiago';
-
-    it('returns whole days when an endpoint is the transition day', function () {
-      moment.tz.setDefault(ZONE);
-      const sep6 = dayStart(ZONE, '2026-09-06');
-      expect(
-        calendarDaysBetween(calendarDateFromUnix(sep6), calendarDateFromUnix(shiftFixture(sep6, 5)))
-      ).toBe(5);
-      expect(
-        calendarDaysBetween(
-          calendarDateFromUnix(sep6),
-          calendarDateFromUnix(shiftFixture(sep6, -5))
-        )
-      ).toBe(-5);
-      expect(
-        calendarDaysBetween(calendarDateFromUnix(sep6), calendarDateFromUnix(shiftFixture(sep6, 1)))
-      ).toBe(1);
-    });
-
-    // These compare calendar days, not instants. Where midnight doesn't exist the day starts
-    // at 01:00, and the shift carries that wall clock, so a round trip can shift by an
-    // hour within the same day. Both encode the same DATE, so only the day is contractual.
-    it('round-trips inclusive and exclusive ends onto the same day', function () {
-      moment.tz.setDefault(ZONE);
-      const sep6 = dayStart(ZONE, '2026-09-06');
-      [-1, 0, 1].forEach((offset) => {
-        const start = shiftFixture(sep6, offset);
-        const roundTripped = inclusiveAllDayEnd(exclusiveAllDayEnd(start));
-        expect(
-          calendarDaysBetween(calendarDateFromUnix(start), calendarDateFromUnix(roundTripped))
-        ).toBe(0);
-      });
-    });
-
-    // The only input shape where `add` before `startOf` differs from the reverse: the day
-    // BEFORE a missing midnight. Truncating first lands on the transition day at 23:00,
-    // still inside the previous day, which collapses a one-day event to zero length.
-    it('takes the next day-start when the following midnight does not exist', function () {
-      moment.tz.setDefault(ZONE);
-      expect(exclusiveAllDayEnd(dayStart(ZONE, '2026-09-05'))).toBe(dayStart(ZONE, '2026-09-06'));
-    });
-
-    it('spans the transition day itself without dropping it', function () {
-      moment.tz.setDefault(ZONE);
-      const start = dayStart(ZONE, '2026-09-05');
-      const end = exclusiveAllDayEnd(shiftFixture(start, 2)); // covers 5th, 6th, 7th
-      expect(
-        calendarDaysBetween(
-          calendarDateFromUnix(start),
-          calendarDateFromUnix(inclusiveAllDayEnd(end))
-        )
-      ).toBe(2);
-    });
-  });
-});
+// A moment.tz.setDefault-pinned DST block lived here. It's gone rather than patched: setDefault
+// only reaches code still computing through moment, and the day math it covered now runs on
+// epoch-day integers, which have no zone behaviour to pin. That coverage is in
+// calendar-date-spec.ts, zone-independent by construction.
+//
+// inclusiveAllDayEnd is the last moment holdout, and it needed no pinned coverage: for an exact
+// midnight its truncation is correct in every zone, transition days included. Its one bad input
+// is an end an hour past midnight, which it cannot tell from the all-day toggle wall-clock ends
+// - indistinguishable by construction, and unreachable while callers pass ical.js values.

--- a/app/src/calendar-date.ts
+++ b/app/src/calendar-date.ts
@@ -73,6 +73,16 @@ export function nextDayStartUnix(date: CalendarDate): number {
   return dayStartUnix(addCalendarDays(date, 1));
 }
 
+/**
+ * The start of the date `days` after the one this instant falls on.
+ *
+ * A migration bridge for callers that still hold instants. It goes away as they move to
+ * holding dates, at which point they compose the two functions above directly.
+ */
+export function shiftedDayStartUnix(unixSeconds: number, days: number): number {
+  return dayStartUnix(addCalendarDays(calendarDateFromUnix(unixSeconds), days));
+}
+
 /** Shift by whole days. Free and exact — epoch days have no transitions to cross. */
 export function addCalendarDays(date: CalendarDate, days: number): CalendarDate {
   return (date + days) as CalendarDate;

--- a/app/src/calendar-date.ts
+++ b/app/src/calendar-date.ts
@@ -65,9 +65,7 @@ export function dayStartUnix(date: CalendarDate): number {
 }
 
 /**
- * The first instant after a date — the exclusive boundary the day-overlap filters compare
- * against, so the day following a span doesn't light up. No caller yet; the filters still
- * compare timestamps.
+ * The first instant after a date — the exclusive end callers store or serialize.
  */
 export function nextDayStartUnix(date: CalendarDate): number {
   return dayStartUnix(addCalendarDays(date, 1));

--- a/app/src/calendar-date.ts
+++ b/app/src/calendar-date.ts
@@ -1,0 +1,125 @@
+/**
+ * A calendar date — no time, no timezone. Days since 1970-01-01.
+ *
+ * All-day events are dates in ICS (`DTSTART;VALUE=DATE:20260621`), but the app has always
+ * held them as unix seconds, so a date got encoded as local midnight and then had instant
+ * arithmetic done to it. That mismatch produced every all-day DST bug we've fixed.
+ *
+ * The brand keeps a CalendarDate from being passed where a unix timestamp is expected, and
+ * vice versa — the two are both `number` and were previously interchangeable to the compiler.
+ */
+export type CalendarDate = number & { readonly __calendarDate: unique symbol };
+
+const MS_PER_DAY = 86400000;
+
+/** Formatters are ~12x the cost of a Date component read, so build one per zone, not per call */
+const partFormatters = new Map<string, Intl.DateTimeFormat>();
+
+function partFormatterFor(zone: string | undefined): Intl.DateTimeFormat {
+  const key = zone ?? '';
+  let formatter = partFormatters.get(key);
+  if (!formatter) {
+    formatter = new Intl.DateTimeFormat('en-US', {
+      timeZone: zone, // undefined reads in the host's zone
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    });
+    partFormatters.set(key, formatter);
+  }
+  return formatter;
+}
+
+/**
+ * The calendar date an instant falls on.
+ *
+ * Reads the date components and discards the time. There is deliberately no arithmetic here:
+ * the instant may be any time of day — midnight, 01:00 where midnight doesn't exist, or 23:00
+ * from a seconds-based shift — and all of them name the same date.
+ *
+ * `zone` is read explicitly rather than taken from the host, so a caller can render a calendar
+ * in a chosen zone and so specs can exercise real zones without the suite running in one.
+ * Reads through `formatToParts` rather than a locale's date format, which isn't guaranteed.
+ *
+ * Costs ~2µs, so call it once per occurrence and keep the result; don't call it per render.
+ */
+export function calendarDateOf(unixSeconds: number, zone?: string): CalendarDate {
+  let year = 0;
+  let month = 0;
+  let day = 0;
+  for (const part of partFormatterFor(zone).formatToParts(new Date(unixSeconds * 1000))) {
+    if (part.type === 'year') year = Number(part.value);
+    else if (part.type === 'month') month = Number(part.value);
+    else if (part.type === 'day') day = Number(part.value);
+  }
+  // Assembled in UTC, which has no transitions, so the day count can't be skewed
+  return (Date.UTC(year, month - 1, day) / MS_PER_DAY) as CalendarDate;
+}
+
+/**
+ * The first instant of a date, in the local zone.
+ *
+ * Where local midnight doesn't exist (Santiago, Havana, Beirut on their transition day) this
+ * is 01:00 — the day's true first instant — because `new Date(y, m, d)` resolves the gap
+ * forward. Callers wanting "the start of this day" get exactly that, whatever it reads as.
+ */
+export function unixDayStart(date: CalendarDate): number {
+  const utc = new Date(date * MS_PER_DAY);
+  return new Date(utc.getUTCFullYear(), utc.getUTCMonth(), utc.getUTCDate()).getTime() / 1000;
+}
+
+/**
+ * The first instant after a date — RFC 5545's exclusive end.
+ *
+ * Layout and serialization both need this: `event.start < dayEnd && event.end > dayStart`
+ * relies on the exclusive boundary to keep the day after a span from lighting up, and ICS
+ * writes `DTEND` exclusively. Derived rather than stored, so a mistake here draws a wrong
+ * cell instead of persisting a wrong date.
+ */
+export function unixDayEndExclusive(date: CalendarDate): number {
+  return unixDayStart(addCalendarDays(date, 1));
+}
+
+/** Shift by whole days. Free and exact — epoch days have no transitions to cross. */
+export function addCalendarDays(date: CalendarDate, days: number): CalendarDate {
+  return (date + days) as CalendarDate;
+}
+
+/** Whole days from one date to another. Negative when `to` precedes `from`. */
+export function calendarDaysBetween(from: CalendarDate, to: CalendarDate): number {
+  return to - from;
+}
+
+/** Days covered by an inclusive range, so a single-day event is 1. */
+export function calendarDaySpan(start: CalendarDate, endInclusive: CalendarDate): number {
+  return endInclusive - start + 1;
+}
+
+/** Parses the ICS DATE form, `20260621`. */
+export function parseICSDate(value: string): CalendarDate {
+  const year = Number(value.slice(0, 4));
+  const month = Number(value.slice(4, 6));
+  const day = Number(value.slice(6, 8));
+  return (Date.UTC(year, month - 1, day) / MS_PER_DAY) as CalendarDate;
+}
+
+/** Formats for ICS, `20260621`. */
+export function formatICSDate(date: CalendarDate): string {
+  const d = new Date(date * MS_PER_DAY);
+  const month = String(d.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(d.getUTCDate()).padStart(2, '0');
+  return `${d.getUTCFullYear()}${month}${day}`;
+}
+
+/** ISO form, `2026-06-21`. For debugging, specs, and anywhere a human reads the value. */
+export function formatCalendarDate(date: CalendarDate): string {
+  const d = new Date(date * MS_PER_DAY);
+  const month = String(d.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(d.getUTCDate()).padStart(2, '0');
+  return `${d.getUTCFullYear()}-${month}-${day}`;
+}
+
+/** Builds a CalendarDate from `2026-06-21`. The inverse of `formatCalendarDate`. */
+export function parseCalendarDate(iso: string): CalendarDate {
+  return parseICSDate(iso.replace(/-/g, ''));
+}

--- a/app/src/calendar-date.ts
+++ b/app/src/calendar-date.ts
@@ -1,83 +1,75 @@
 /**
  * A calendar date — no time, no timezone. Days since 1970-01-01.
  *
- * All-day events are dates in ICS (`DTSTART;VALUE=DATE:20260621`), but the app has always
- * held them as unix seconds, so a date got encoded as local midnight and then had instant
- * arithmetic done to it. That mismatch produced every all-day DST bug we've fixed.
- *
- * The brand keeps a CalendarDate from being passed where a unix timestamp is expected, and
- * vice versa — the two are both `number` and were previously interchangeable to the compiler.
+ * The brand blocks a unix timestamp being passed as a date. It does not block the reverse:
+ * an intersection is assignable to `number`, so a date still flows into a seconds parameter.
  */
 export type CalendarDate = number & { readonly __calendarDate: unique symbol };
 
 const MS_PER_DAY = 86400000;
 
-/** Formatters are ~12x the cost of a Date component read, so build one per zone, not per call */
+/** ~12x the cost of a Date component read, so build one per zone, not per call */
 const partFormatters = new Map<string, Intl.DateTimeFormat>();
 
-function partFormatterFor(zone: string | undefined): Intl.DateTimeFormat {
-  const key = zone ?? '';
-  let formatter = partFormatters.get(key);
+function partFormatterFor(zone: string): Intl.DateTimeFormat {
+  let formatter = partFormatters.get(zone);
   if (!formatter) {
     formatter = new Intl.DateTimeFormat('en-US', {
-      timeZone: zone, // undefined reads in the host's zone
+      timeZone: zone,
       year: 'numeric',
       month: '2-digit',
       day: '2-digit',
     });
-    partFormatters.set(key, formatter);
+    partFormatters.set(zone, formatter);
   }
   return formatter;
 }
 
 /**
- * The calendar date an instant falls on.
+ * The calendar date an instant falls on, in `zone` or the host's zone.
  *
- * Reads the date components and discards the time. There is deliberately no arithmetic here:
- * the instant may be any time of day — midnight, 01:00 where midnight doesn't exist, or 23:00
- * from a seconds-based shift — and all of them name the same date.
+ * No arithmetic: any time of day on a date yields that date, including the 01:00 the sync
+ * engine writes and the 23:00 a seconds shift lands on.
  *
- * `zone` is read explicitly rather than taken from the host, so a caller can render a calendar
- * in a chosen zone and so specs can exercise real zones without the suite running in one.
- * Reads through `formatToParts` rather than a locale's date format, which isn't guaranteed.
- *
- * Costs ~2µs, so call it once per occurrence and keep the result; don't call it per render.
+ * The host-zone path reads `Date` components live. It must not go through a cached formatter:
+ * `Intl` fixes its zone at construction, so after the host's zone changes — a laptop waking in
+ * a new one — a cached formatter keeps reporting the old date, and this module's callers write
+ * that date into ICS. Reading live also costs ~0.3µs against ~2µs through `Intl`.
  */
-export function calendarDateOf(unixSeconds: number, zone?: string): CalendarDate {
+export function calendarDateFromUnix(unixSeconds: number, zone?: string): CalendarDate {
+  const instant = new Date(unixSeconds * 1000);
+  if (!zone) {
+    return calendarDateFromParts(instant.getFullYear(), instant.getMonth() + 1, instant.getDate());
+  }
   let year = 0;
   let month = 0;
   let day = 0;
-  for (const part of partFormatterFor(zone).formatToParts(new Date(unixSeconds * 1000))) {
+  for (const part of partFormatterFor(zone).formatToParts(instant)) {
     if (part.type === 'year') year = Number(part.value);
     else if (part.type === 'month') month = Number(part.value);
     else if (part.type === 'day') day = Number(part.value);
   }
-  // Assembled in UTC, which has no transitions, so the day count can't be skewed
-  return (Date.UTC(year, month - 1, day) / MS_PER_DAY) as CalendarDate;
+  return calendarDateFromParts(year, month, day);
 }
 
 /**
  * The first instant of a date, in the local zone.
  *
  * Where local midnight doesn't exist (Santiago, Havana, Beirut on their transition day) this
- * is 01:00 — the day's true first instant — because `new Date(y, m, d)` resolves the gap
- * forward. Callers wanting "the start of this day" get exactly that, whatever it reads as.
+ * is 01:00 — the day's true first instant, since `new Date(y, m, d)` resolves the gap forward.
  */
-export function unixDayStart(date: CalendarDate): number {
+export function dayStartUnix(date: CalendarDate): number {
   const utc = new Date(date * MS_PER_DAY);
   return new Date(utc.getUTCFullYear(), utc.getUTCMonth(), utc.getUTCDate()).getTime() / 1000;
 }
 
 /**
- * The first instant after a date — RFC 5545's exclusive end.
- *
- * Layout and serialization both need this: `event.start < dayEnd && event.end > dayStart`
- * relies on the exclusive boundary to keep the day after a span from lighting up, and ICS
- * writes `DTEND` exclusively. Derived rather than stored, so a mistake here draws a wrong
- * cell instead of persisting a wrong date.
+ * The first instant after a date — the exclusive boundary the day-overlap filters compare
+ * against, so the day following a span doesn't light up. No caller yet; the filters still
+ * compare timestamps.
  */
-export function unixDayEndExclusive(date: CalendarDate): number {
-  return unixDayStart(addCalendarDays(date, 1));
+export function nextDayStartUnix(date: CalendarDate): number {
+  return dayStartUnix(addCalendarDays(date, 1));
 }
 
 /** Shift by whole days. Free and exact — epoch days have no transitions to cross. */
@@ -90,25 +82,9 @@ export function calendarDaysBetween(from: CalendarDate, to: CalendarDate): numbe
   return to - from;
 }
 
-/** Days covered by an inclusive range, so a single-day event is 1. */
-export function calendarDaySpan(start: CalendarDate, endInclusive: CalendarDate): number {
-  return endInclusive - start + 1;
-}
-
-/** Parses the ICS DATE form, `20260621`. */
-export function parseICSDate(value: string): CalendarDate {
-  const year = Number(value.slice(0, 4));
-  const month = Number(value.slice(4, 6));
-  const day = Number(value.slice(6, 8));
+/** From y/m/d directly, so no timezone is applied on the way. `month` is 1-based, as in ICS. */
+export function calendarDateFromParts(year: number, month: number, day: number): CalendarDate {
   return (Date.UTC(year, month - 1, day) / MS_PER_DAY) as CalendarDate;
-}
-
-/** Formats for ICS, `20260621`. */
-export function formatICSDate(date: CalendarDate): string {
-  const d = new Date(date * MS_PER_DAY);
-  const month = String(d.getUTCMonth() + 1).padStart(2, '0');
-  const day = String(d.getUTCDate()).padStart(2, '0');
-  return `${d.getUTCFullYear()}${month}${day}`;
 }
 
 /** ISO form, `2026-06-21`. For debugging, specs, and anywhere a human reads the value. */
@@ -116,10 +92,14 @@ export function formatCalendarDate(date: CalendarDate): string {
   const d = new Date(date * MS_PER_DAY);
   const month = String(d.getUTCMonth() + 1).padStart(2, '0');
   const day = String(d.getUTCDate()).padStart(2, '0');
-  return `${d.getUTCFullYear()}-${month}-${day}`;
+  return `${String(d.getUTCFullYear()).padStart(4, '0')}-${month}-${day}`;
 }
 
 /** Builds a CalendarDate from `2026-06-21`. The inverse of `formatCalendarDate`. */
 export function parseCalendarDate(iso: string): CalendarDate {
-  return parseICSDate(iso.replace(/-/g, ''));
+  return calendarDateFromParts(
+    Number(iso.slice(0, 4)),
+    Number(iso.slice(5, 7)),
+    Number(iso.slice(8, 10))
+  );
 }

--- a/app/src/calendar-date.ts
+++ b/app/src/calendar-date.ts
@@ -26,7 +26,8 @@ function partFormatterFor(zone: string): Intl.DateTimeFormat {
 }
 
 /**
- * The calendar date an instant falls on, in `zone` or the host's zone.
+ * The calendar date an instant falls on, in `zone` or the host's zone. No caller passes a zone
+ * yet; it's the seam a display-timezone setting needs, and what lets specs cover real zones.
  *
  * No arithmetic: any time of day on a date yields that date, including the 01:00 the sync
  * engine writes and the 23:00 a seconds shift lands on.

--- a/app/src/global/mailspring-exports.d.ts
+++ b/app/src/global/mailspring-exports.d.ts
@@ -191,6 +191,10 @@ export type CalendarUtils = typeof import('../calendar-utils');
 export const CalendarUtils: CalendarUtils;
 export { ICSParticipantStatus, ICSParticipant } from '../calendar-utils';
 
+export type CalendarDateUtils = typeof import('../calendar-date');
+export const CalendarDateUtils: CalendarDateUtils;
+export { CalendarDate } from '../calendar-date';
+
 export type ICSEventHelpers = typeof import('../ics-event-helpers');
 export const ICSEventHelpers: ICSEventHelpers;
 export {

--- a/app/src/global/mailspring-exports.js
+++ b/app/src/global/mailspring-exports.js
@@ -184,6 +184,7 @@ lazyLoad(`DOMUtils`, 'dom-utils');
 lazyLoad(`DateUtils`, 'date-utils');
 lazyLoadWithGetter(`imapUtf7`, () => require('../utils/imap-utf7').imapUtf7);
 lazyLoad(`CalendarUtils`, 'calendar-utils');
+lazyLoad(`CalendarDateUtils`, 'calendar-date');
 lazyLoad(`ICSEventHelpers`, 'ics-event-helpers');
 lazyLoad(`FsUtils`, 'fs-utils');
 lazyLoad(`CanvasUtils`, 'canvas-utils');

--- a/app/src/ics-event-helpers.ts
+++ b/app/src/ics-event-helpers.ts
@@ -1,10 +1,5 @@
 import { parseICSString } from './calendar-utils';
-import {
-  calendarDateFromUnix,
-  dayStartUnix,
-  addCalendarDays,
-  calendarDaysBetween,
-} from './calendar-date';
+import { calendarDateFromUnix, shiftedDayStartUnix, calendarDaysBetween } from './calendar-date';
 
 type ICAL = typeof import('ical.js').default;
 type ICALComponent = InstanceType<ICAL['Component']>;
@@ -732,17 +727,6 @@ export function applyEditsToException(
 }
 
 /**
- * The start of the date `days` after the one this instant falls on.
- *
- * All-day values reach this module as instants, so converting to a date and back is the only
- * way to shift them by whole days. Note the brand can't protect these call sites: ical.js
- * values arrive as `any`, so a raw millisecond count would type-check silently.
- */
-function shiftedDayStart(unixSeconds: number, days: number): number {
-  return dayStartUnix(addCalendarDays(calendarDateFromUnix(unixSeconds), days));
-}
-
-/**
  * Shifts the RECURRENCE-ID of all inline exception VEVENTs within a master VCALENDAR
  * by the given time delta (in milliseconds). This keeps inline exceptions correctly
  * mapped to their corresponding RRULE-generated slots after the master series is shifted.
@@ -784,7 +768,7 @@ export function shiftInlineExceptions(ics: string, deltaMs: number): string {
     const newRidTime = (ridValue.isDate as boolean)
       ? createAllDayTime(
           new Date(
-            shiftedDayStart(ridDate.getTime() / 1000, Math.round(deltaMs / 86400000)) * 1000
+            shiftedDayStartUnix(ridDate.getTime() / 1000, Math.round(deltaMs / 86400000)) * 1000
           ),
           ical
         )
@@ -830,8 +814,8 @@ export function updateRecurringEventTimes(
       calendarDateFromUnix(newStart)
     );
     return updateEventTimes(ics, {
-      start: shiftedDayStart(currentStart / 1000, days),
-      end: shiftedDayStart(currentEnd / 1000, days),
+      start: shiftedDayStartUnix(currentStart / 1000, days),
+      end: shiftedDayStartUnix(currentEnd / 1000, days),
       isAllDay,
     });
   }

--- a/app/src/ics-event-helpers.ts
+++ b/app/src/ics-event-helpers.ts
@@ -1,4 +1,10 @@
 import { parseICSString } from './calendar-utils';
+import {
+  calendarDateOf,
+  unixDayStart,
+  addCalendarDays,
+  calendarDaysBetween,
+} from './calendar-date';
 
 type ICAL = typeof import('ical.js').default;
 type ICALComponent = InstanceType<ICAL['Component']>;
@@ -726,6 +732,17 @@ export function applyEditsToException(
 }
 
 /**
+ * The start of the date `days` after the one this instant falls on.
+ *
+ * All-day values reach this module as instants, so converting to a date and back is the only
+ * way to shift them by whole days. Note the brand can't protect these call sites: ical.js
+ * values arrive as `any`, so a raw millisecond count would type-check silently.
+ */
+function shiftedDayStart(unixSeconds: number, days: number): number {
+  return unixDayStart(addCalendarDays(calendarDateOf(unixSeconds), days));
+}
+
+/**
  * Shifts the RECURRENCE-ID of all inline exception VEVENTs within a master VCALENDAR
  * by the given time delta (in milliseconds). This keeps inline exceptions correctly
  * mapped to their corresponding RRULE-generated slots after the master series is shifted.
@@ -766,7 +783,9 @@ export function shiftInlineExceptions(ics: string, deltaMs: number): string {
     // An all-day delta is always whole days give or take the transition hour, so round it.
     const newRidTime = (ridValue.isDate as boolean)
       ? createAllDayTime(
-          new Date(addCalendarDays(ridDate.getTime(), Math.round(deltaMs / 86400000)) * 1000),
+          new Date(
+            shiftedDayStart(ridDate.getTime() / 1000, Math.round(deltaMs / 86400000)) * 1000
+          ),
           ical
         )
       : // Keep as UTC (same format as createRecurrenceException)
@@ -806,10 +825,13 @@ export function updateRecurringEventTimes(
     // A raw millisecond delta is wrong here: moving an occurrence across a spring-forward
     // day yields 23h, and shifting the master by 23h leaves its date unchanged, so the
     // series silently doesn't move. Shift the dates themselves instead.
-    const days = calendarDaysBetween(originalOccurrenceStart, newStart);
+    const days = calendarDaysBetween(
+      calendarDateOf(originalOccurrenceStart),
+      calendarDateOf(newStart)
+    );
     return updateEventTimes(ics, {
-      start: addCalendarDays(currentStart, days),
-      end: addCalendarDays(currentEnd, days),
+      start: shiftedDayStart(currentStart / 1000, days),
+      end: shiftedDayStart(currentEnd / 1000, days),
       isAllDay,
     });
   }
@@ -821,27 +843,6 @@ export function updateRecurringEventTimes(
     end: (currentEnd + deltaMs) / 1000,
     isAllDay,
   });
-}
-
-/**
- * Whole calendar days from one timestamp's local date to another's. Compared in UTC, which
- * has no transitions, so a DST change between the two can't skew the count.
- *
- * Duplicated from calendar-helpers.ts because that module lives in an internal package and
- * this one can't import upwards. Both go away once all-day events are modelled as dates.
- */
-function calendarDaysBetween(fromUnix: number, toUnix: number): number {
-  const utcMidnight = (unix: number) => {
-    const d = new Date(unix * 1000);
-    return Date.UTC(d.getFullYear(), d.getMonth(), d.getDate());
-  };
-  return Math.round((utcMidnight(toUnix) - utcMidnight(fromUnix)) / 86400000);
-}
-
-/** Shifts a timestamp's local date by whole days, landing on that date's local midnight. */
-function addCalendarDays(ms: number, days: number): number {
-  const d = new Date(ms);
-  return new Date(d.getFullYear(), d.getMonth(), d.getDate() + days).getTime() / 1000;
 }
 
 /**

--- a/app/src/ics-event-helpers.ts
+++ b/app/src/ics-event-helpers.ts
@@ -1,7 +1,7 @@
 import { parseICSString } from './calendar-utils';
 import {
-  calendarDateOf,
-  unixDayStart,
+  calendarDateFromUnix,
+  dayStartUnix,
   addCalendarDays,
   calendarDaysBetween,
 } from './calendar-date';
@@ -739,7 +739,7 @@ export function applyEditsToException(
  * values arrive as `any`, so a raw millisecond count would type-check silently.
  */
 function shiftedDayStart(unixSeconds: number, days: number): number {
-  return unixDayStart(addCalendarDays(calendarDateOf(unixSeconds), days));
+  return dayStartUnix(addCalendarDays(calendarDateFromUnix(unixSeconds), days));
 }
 
 /**
@@ -826,8 +826,8 @@ export function updateRecurringEventTimes(
     // day yields 23h, and shifting the master by 23h leaves its date unchanged, so the
     // series silently doesn't move. Shift the dates themselves instead.
     const days = calendarDaysBetween(
-      calendarDateOf(originalOccurrenceStart),
-      calendarDateOf(newStart)
+      calendarDateFromUnix(originalOccurrenceStart),
+      calendarDateFromUnix(newStart)
     );
     return updateEventTimes(ics, {
       start: shiftedDayStart(currentStart / 1000, days),

--- a/package.json
+++ b/package.json
@@ -78,8 +78,8 @@
     "lint": "eslint --fix -c .eslintrc \"app/src/**/*.{ts,tsx}\" \"app/internal_packages/**/*.{ts,tsx}\"",
     "lint:check": "eslint -c .eslintrc \"app/src/**/*.{ts,tsx}\" \"app/internal_packages/**/*.{ts,tsx}\"",
     "typecheck": "./node_modules/.bin/tsc -p app/tsconfig.json --noEmit",
-    "test": "electron ./app --enable-logging --test",
-    "test-window": "electron ./app --enable-logging --test=window",
+    "test": "node scripts/test.js --test",
+    "test-window": "node scripts/test.js --test=window",
     "test:e2e": "npx playwright test --config playwright/playwright.config.ts",
     "tsc-watch": "tsc -w -p ./app --noEmit",
     "build": "node app/build/build.js"

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+const { spawn } = require('child_process');
+const electron = require('electron');
+
+// Pinned so the suite doesn't run in whatever zone the machine happens to be in. CI has no TZ
+// of its own, i.e. UTC, where a local date component read is indistinguishable from a UTC one —
+// so the calendar's zone handling would go unverified there. Set as a default rather than an
+// override, so `TZ=America/Santiago npm test` still works for chasing a zone-specific bug.
+const DEFAULT_TZ = 'America/Chicago';
+
+const child = spawn(electron, ['./app', '--enable-logging', ...process.argv.slice(2)], {
+  stdio: 'inherit',
+  env: Object.assign({ TZ: DEFAULT_TZ }, process.env),
+});
+
+child.on('exit', (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+  } else {
+    process.exit(code);
+  }
+});


### PR DESCRIPTION
## What

Introduces a `CalendarDate` type (branded epoch-days, timezone-explicit) and routes
all-day calendar events through it, so an all-day event is represented by the *dates*
it covers rather than by a pair of Unix instants. Occurrences now carry inclusive
`startDate`/`endDate`, and the month- and agenda-view day filters decide membership
from those dates instead of re-deriving a day from `start`/`end` seconds.

This is a follow-on to #2799, which fixed the acute all-day DST symptoms. That PR
patched the arithmetic; this one removes the representation that made the arithmetic
fragile in the first place.

## Why

All-day events arrive as `DTSTART;VALUE=DATE:20260621` — a date with no time and no
zone. We were encoding that as a local-midnight Unix timestamp and then doing instant
arithmetic on it, which breaks in every zone that observes DST:

- `+86400` seconds isn't a calendar day on a 23- or 25-hour day.
- Local midnight doesn't *exist* on the spring-forward day in Santiago, Havana, and
  Beirut, so `startOf('day')` after an add lands on the previous day at 23:00.
- Exclusive-vs-inclusive end drifted between code paths.

Reading a date off an instant *inside* the event (`dateOf(instant)`, no arithmetic)
can't cross a boundary, so it's correct for local midnight, for the sync engine's
hour-late `mktime` slop, and for moment's gap resolution alike. Six helpers that
existed only to maintain a "this is a whole calendar day" invariant collapse into the
type — the diff deletes more of that machinery than it adds.

## Scope

This PR is the foundation: the type, the inclusive covered-date model, the
load-bearing day filters, and the deletion of the redundant day-arithmetic helpers.
It is intentionally correctness-preserving — it makes a class of DST bugs
unrepresentable rather than fixing a single reported bug. Narrowing `EventOccurrence`
to drop `start`/`end` for all-day events (which takes the line count net-negative) and
the remaining drag/keyboard bugs are tracked as separate follow-ups.

Two conversions survive on purpose, at boundaries we don't own: reading the C++ sync
engine's INTEGER `recurrenceStart/End` columns for the SQL range query, and converting
a date to an instant for that same query. Timed events keep instants throughout.

## Testing

Adds a default `TZ` (`America/Chicago`) to the test runner (`scripts/test.js`) so DST
behavior is exercised in CI, which otherwise runs in UTC where a local date read is
indistinguishable from a UTC one. New specs pin the transition behavior and fail on a
`+86400`-style regression. Full suite green.

## ⚠️ Needs a Windows check

The test runner pins `TZ` by setting the env var as a default. **Whether V8 on Windows
honours an IANA name like `America/Chicago` is unverified** — could a Windows
contributor confirm `npm test` picks up the zone? If it doesn't, the effect is benign
(those contributors get their host zone, as today) but the pinning silently won't apply
for them, so I'd rather not claim it works everywhere. This exposure is identical to
what `cross-env` would have — both only set the variable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)