### PR TITLE
Model all-day as a discriminated union

### DIFF
--- a/app/internal_packages/main-calendar/lib/core/agenda-view.tsx
+++ b/app/internal_packages/main-calendar/lib/core/agenda-view.tsx
@@ -6,7 +6,12 @@ import { MailspringCalendarViewProps } from './mailspring-calendar';
 import { CalendarView } from './calendar-constants';
 import { HeaderControls } from './header-controls';
 import { CalendarEventPopover } from './calendar-event-popover';
-import { EventOccurrence, eventCoversDate } from './calendar-data-source';
+import {
+  EventOccurrence,
+  eventCoversDate,
+  isTimed,
+  occurrenceStartUnix,
+} from './calendar-data-source';
 import { Disposable } from 'rx-core';
 import { calcEventColors, extractMeetingDomain } from './calendar-helpers';
 
@@ -94,7 +99,7 @@ export class AgendaView extends React.Component<MailspringCalendarViewProps, Age
           // All-day events first, then sort by start time
           if (a.isAllDay && !b.isAllDay) return -1;
           if (!a.isAllDay && b.isAllDay) return 1;
-          return a.start - b.start;
+          return occurrenceStartUnix(a) - occurrenceStartUnix(b);
         });
 
       days.push({ day, events });
@@ -122,12 +127,12 @@ export class AgendaView extends React.Component<MailspringCalendarViewProps, Age
   };
 
   _formatEventTime(event: EventOccurrence): string {
-    if (event.isAllDay) {
-      return localized('All day');
+    if (isTimed(event)) {
+      const start = moment.unix(event.start);
+      const end = moment.unix(event.end);
+      return `${start.format('LT')} – ${end.format('LT')}`;
     }
-    const start = moment.unix(event.start);
-    const end = moment.unix(event.end);
-    return `${start.format('LT')} – ${end.format('LT')}`;
+    return localized('All day');
   }
 
   _renderDayHeader(day: Moment) {

--- a/app/internal_packages/main-calendar/lib/core/calendar-data-source.ts
+++ b/app/internal_packages/main-calendar/lib/core/calendar-data-source.ts
@@ -41,6 +41,32 @@ export function eventCoversDate(event: EventOccurrence, date: CalendarDate): boo
 }
 
 /**
+ * Narrowing guard. The app tsconfig omits `strictNullChecks`, so `if (e.isAllDay)` does NOT
+ * narrow the union — only `=== true`/`=== false` and a guard like this do. Use it to reach
+ * `start`/`end`, which exist on timed occurrences only.
+ */
+export function isTimed(e: EventOccurrence): e is TimedOccurrence {
+  return e.isAllDay === false;
+}
+
+/**
+ * An occurrence's start as an instant — its real start if timed, its first day's start if
+ * all-day. For sort keys, the focus scroll target, and day-snap drag references; never stored.
+ */
+export function occurrenceStartUnix(e: EventOccurrence): number {
+  return isTimed(e) ? e.start : CalendarDateUtils.dayStartUnix(e.startDate);
+}
+
+/**
+ * An occurrence's end as an exclusive instant — its real end if timed, the midnight after its
+ * last covered day if all-day. For drag hit-testing and time formatting; never stored, and not
+ * for layout positioning (that stays in date space).
+ */
+export function occurrenceEndUnix(e: EventOccurrence): number {
+  return isTimed(e) ? e.end : CalendarDateUtils.nextDayStartUnix(e.endDate);
+}
+
+/**
  * The dates an event covers, inclusive, from its start and exclusive end instants.
  *
  * All-day ends land on a day boundary, so the last covered date is one date back; timed ends
@@ -73,14 +99,13 @@ function lastCoveredDate(exclusiveEnd: CalendarDate, startDate: CalendarDate): C
   return Math.max(CalendarDateUtils.addCalendarDays(exclusiveEnd, -1), startDate) as CalendarDate;
 }
 
-export interface EventOccurrence {
-  start: number; // unix
-  end: number; // unix
+/** Fields common to all occurrences, all-day or timed. */
+interface OccurrenceBase {
   /**
    * The days covered, inclusive both ends — a one-day event has `startDate === endDate`.
    *
-   * Stored rather than derived per render: the day-cell filters read them per event per cell,
-   * via eventCoversDate.
+   * The authoritative span for all-day events, and what the day-cell filters read per event
+   * per cell via eventCoversDate.
    */
   startDate: CalendarDate;
   endDate: CalendarDate;
@@ -90,7 +115,6 @@ export interface EventOccurrence {
   title: string;
   location: string;
   description: string;
-  isAllDay: boolean;
   isCancelled: boolean;
   /**
    * True if this event should display with "pending" styling (hatched pattern).
@@ -118,8 +142,27 @@ export interface EventOccurrence {
   originalEventId?: string;
 }
 
+/** An all-day occurrence: covered dates only, no instants. `isAllDay` discriminates the union. */
+export interface AllDayOccurrence extends OccurrenceBase {
+  isAllDay: true;
+}
+
+/** A timed occurrence: keeps its start/end instants. */
+export interface TimedOccurrence extends OccurrenceBase {
+  isAllDay: false;
+  start: number; // unix
+  end: number; // unix
+}
+
+export type EventOccurrence = AllDayOccurrence | TimedOccurrence;
+
 // Minimal type for focusing/highlighting an event on the calendar
-export type FocusedEventInfo = Pick<EventOccurrence, 'start' | 'id'>;
+/**
+ * What the calendar keeps to hold an event focused: its id and a scroll-to instant. `start`
+ * is that instant — a timed event's real start, an all-day event's day start — so an all-day
+ * occurrence (which has no start of its own) still scrolls the view somewhere sensible.
+ */
+export type FocusedEventInfo = { id: string; start: number };
 
 /** Strip mailto: prefix from email addresses (common in iCalendar data) */
 function normalizeEmail(email: string): string {
@@ -202,16 +245,13 @@ function occurrenceFromICS(args: {
 
   const rid = item.component?.getFirstPropertyValue('recurrence-id');
 
-  return {
-    start: startUnix,
-    end: endUnix,
+  const base: OccurrenceBase = {
     id,
     accountId: event.accountId,
     calendarId: event.calendarId,
     title: item.summary || '',
     location: item.location || '',
     description: item.description || '',
-    isAllDay,
     startDate,
     endDate,
     isCancelled: status === 'CANCELLED',
@@ -222,6 +262,10 @@ function occurrenceFromICS(args: {
     organizer: item.organizer ? { email: item.organizer } : null,
     attendees,
   };
+
+  return isAllDay
+    ? { ...base, isAllDay: true }
+    : { ...base, isAllDay: false, start: startUnix, end: endUnix };
 }
 
 export function occurrencesForEvents(
@@ -290,19 +334,16 @@ export function occurrencesForEvents(
             isAllDay
           );
 
-          occurrences.push({
-            start: master.recurrenceStart,
-            end: master.recurrenceEnd,
+          // Expansion failed, so there's no DATE flag to read — isAllDay fell back on
+          // duration above. A recurring master's columns can hold one occurrence's span, so
+          // a series can misread as all-day here.
+          const errorBase: OccurrenceBase = {
             id: `${master.id}-e0`,
             accountId: master.accountId,
             calendarId: master.calendarId,
             title: '(Error expanding event)',
             location: '',
             description: '',
-            // Expansion failed, so there's no DATE flag to read — fall back on duration. A
-            // recurring master's columns can hold one occurrence's span, so a series can
-            // misread as all-day here.
-            isAllDay,
             startDate,
             endDate,
             isCancelled: false,
@@ -311,7 +352,17 @@ export function occurrencesForEvents(
             isRecurring: false,
             organizer: null,
             attendees: [],
-          });
+          };
+          occurrences.push(
+            isAllDay
+              ? { ...errorBase, isAllDay: true }
+              : {
+                  ...errorBase,
+                  isAllDay: false,
+                  start: master.recurrenceStart,
+                  end: master.recurrenceEnd,
+                }
+          );
         }
       }
     }

--- a/app/internal_packages/main-calendar/lib/core/calendar-drag-utils.ts
+++ b/app/internal_packages/main-calendar/lib/core/calendar-drag-utils.ts
@@ -186,29 +186,33 @@ export function createDragState(
   mouseY: number,
   config: DragConfig
 ): DragState {
+  // The drag pipeline is unix; derive the event's instants once (all-day carries dates only).
+  const start = occurrenceStartUnix(event);
+  const end = occurrenceEndUnix(event);
+
   // Calculate click offset for 'move' mode - this is the time difference between
   // where the user clicked and the event's start time. We'll preserve this offset
   // so the event doesn't jump when dragging starts.
   let clickOffset = 0;
   if (hitZone.mode === 'move') {
-    clickOffset = mouseTime - occurrenceStartUnix(event);
+    clickOffset = mouseTime - start;
   } else if (hitZone.mode === 'resize-end') {
     // For resize-end, offset is from the end of the event
-    clickOffset = mouseTime - occurrenceEndUnix(event);
+    clickOffset = mouseTime - end;
   }
   // For resize-start, no offset needed (we resize from start time)
 
   return {
     mode: hitZone.mode,
     event,
-    originalStart: occurrenceStartUnix(event),
-    originalEnd: occurrenceEndUnix(event),
+    originalStart: start,
+    originalEnd: end,
     initialMouseTime: mouseTime,
     clickOffset,
     initialMouseX: mouseX,
     initialMouseY: mouseY,
-    previewStart: occurrenceStartUnix(event),
-    previewEnd: occurrenceEndUnix(event),
+    previewStart: start,
+    previewEnd: end,
     snapIntervalSeconds: config.snapInterval,
     isDragging: false,
   };

--- a/app/internal_packages/main-calendar/lib/core/calendar-drag-utils.ts
+++ b/app/internal_packages/main-calendar/lib/core/calendar-drag-utils.ts
@@ -6,7 +6,12 @@ import {
   HitZone,
   ViewDirection,
 } from './calendar-drag-types';
-import { EventOccurrence, coveredDates } from './calendar-data-source';
+import {
+  EventOccurrence,
+  coveredDates,
+  occurrenceStartUnix,
+  occurrenceEndUnix,
+} from './calendar-data-source';
 import { CalendarDateUtils } from 'mailspring-exports';
 import { inclusiveAllDayEnd } from './calendar-helpers';
 
@@ -56,16 +61,18 @@ function exclusiveDayEnd(end: number, floor: number): number {
  */
 export function createDragPreviewEvent(dragState: DragState): EventOccurrence {
   const { event, previewStart, previewEnd } = dragState;
-  return {
+  // coveredDates replaces the spread's pre-drag dates. Timed previews also carry the preview
+  // instants; all-day previews carry only the shifted dates.
+  const shared = {
     ...event,
-    id: `${event.id}-drag-preview`,
-    start: previewStart,
-    end: previewEnd,
-    // The spread carries the pre-drag dates, which no longer agree with the preview instants
     ...coveredDates(previewStart, previewEnd, event.isAllDay),
+    id: `${event.id}-drag-preview`,
     isDragPreview: true,
     originalEventId: event.id,
   };
+  return event.isAllDay
+    ? { ...shared, isAllDay: true }
+    : { ...shared, isAllDay: false, start: previewStart, end: previewEnd };
 }
 
 /**
@@ -184,24 +191,24 @@ export function createDragState(
   // so the event doesn't jump when dragging starts.
   let clickOffset = 0;
   if (hitZone.mode === 'move') {
-    clickOffset = mouseTime - event.start;
+    clickOffset = mouseTime - occurrenceStartUnix(event);
   } else if (hitZone.mode === 'resize-end') {
     // For resize-end, offset is from the end of the event
-    clickOffset = mouseTime - event.end;
+    clickOffset = mouseTime - occurrenceEndUnix(event);
   }
   // For resize-start, no offset needed (we resize from start time)
 
   return {
     mode: hitZone.mode,
     event,
-    originalStart: event.start,
-    originalEnd: event.end,
+    originalStart: occurrenceStartUnix(event),
+    originalEnd: occurrenceEndUnix(event),
     initialMouseTime: mouseTime,
     clickOffset,
     initialMouseX: mouseX,
     initialMouseY: mouseY,
-    previewStart: event.start,
-    previewEnd: event.end,
+    previewStart: occurrenceStartUnix(event),
+    previewEnd: occurrenceEndUnix(event),
     snapIntervalSeconds: config.snapInterval,
     isDragging: false,
   };
@@ -361,7 +368,7 @@ export function canMoveEvent(event: EventOccurrence, isCalendarReadOnly = false)
   }
 
   // An in-progress event can still be moved — only a past end time locks it
-  if (isPastDate(event.end)) {
+  if (isPastDate(occurrenceEndUnix(event))) {
     return false;
   }
 

--- a/app/internal_packages/main-calendar/lib/core/calendar-event-popover.tsx
+++ b/app/internal_packages/main-calendar/lib/core/calendar-event-popover.tsx
@@ -22,7 +22,12 @@ import {
   TimePicker,
 } from 'mailspring-component-kit';
 import { EventAttendeesInput } from './event-attendees-input';
-import { EventOccurrence, EventAttendee } from './calendar-data-source';
+import {
+  EventOccurrence,
+  EventAttendee,
+  occurrenceStartUnix,
+  occurrenceEndUnix,
+} from './calendar-data-source';
 import { EventPropertyRow } from './event-property-row';
 import {
   createCalendarEvent,
@@ -123,7 +128,10 @@ export class CalendarEventPopover extends React.Component<
 
   constructor(props: CalendarEventPopoverProps) {
     super(props);
-    const { description, start, end, location, attendees, title, isAllDay } = this.props.event;
+    const { description, location, attendees, title, isAllDay } = this.props.event;
+    // The popover edits in instants; seed all-day events from their derived day boundaries.
+    const start = occurrenceStartUnix(this.props.event);
+    const end = occurrenceEndUnix(this.props.event);
 
     this.state = {
       description,
@@ -150,7 +158,9 @@ export class CalendarEventPopover extends React.Component<
   componentDidUpdate(prevProps: CalendarEventPopoverProps, prevState: CalendarEventPopoverState) {
     // Update state when event prop changes
     if (prevProps.event !== this.props.event) {
-      const { description, start, end, location, attendees, title } = this.props.event;
+      const { description, location, attendees, title } = this.props.event;
+      const start = occurrenceStartUnix(this.props.event);
+      const end = occurrenceEndUnix(this.props.event);
       this.setState({ description, start, end, location, attendees, title });
     }
 
@@ -293,7 +303,7 @@ export class CalendarEventPopover extends React.Component<
       // the same delta to the master DTSTART. This preserves all occurrences relative
       // to the new master start (unlike absolute updateEventTimes which would drop
       // occurrences scheduled before the selected occurrence's date).
-      const originalOccurrenceStart = this.props.event.start;
+      const originalOccurrenceStart = occurrenceStartUnix(this.props.event);
       ics = ICSEventHelpers.updateRecurringEventTimes(
         ics,
         originalOccurrenceStart,
@@ -350,7 +360,8 @@ export class CalendarEventPopover extends React.Component<
     // recurrenceIdStart instead (the RECURRENCE-ID value = the original unmodified time).
     // This ensures the upsert in createRecurrenceException finds and replaces the existing
     // inline exception VEVENT rather than creating a duplicate.
-    const originalOccurrenceStart = this.props.event.recurrenceIdStart ?? this.props.event.start;
+    const originalOccurrenceStart =
+      this.props.event.recurrenceIdStart ?? occurrenceStartUnix(this.props.event);
 
     // Embed the exception VEVENT inline in the master VCALENDAR with new times
     const { masterIcs, recurrenceId } = ICSEventHelpers.createRecurrenceException(
@@ -615,20 +626,22 @@ class CalendarEventPopoverUnenditable extends React.Component<
 
   renderTime() {
     const { event } = this.props;
-    const startMoment = moment(event.start * 1000);
-    const date = startMoment.format('dddd, MMMM D'); // e.g. Tuesday, February 22
 
-    if (event.isAllDay) {
-      const lastDay = moment(inclusiveAllDayEnd(event.end) * 1000);
+    if (event.isAllDay === true) {
+      const startMoment = moment(CalendarDateUtils.dayStartUnix(event.startDate) * 1000);
+      const date = startMoment.format('dddd, MMMM D'); // e.g. Tuesday, February 22
+      const lastDay = moment(CalendarDateUtils.dayStartUnix(event.endDate) * 1000);
       return (
         <div>
-          {lastDay.isSame(startMoment, 'day') ? date : `${date} – ${lastDay.format('MMMM D')}`}
+          {event.startDate === event.endDate ? date : `${date} – ${lastDay.format('MMMM D')}`}
           <br />
           {localized('All day')}
         </div>
       );
     }
 
+    const startMoment = moment(event.start * 1000);
+    const date = startMoment.format('dddd, MMMM D'); // e.g. Tuesday, February 22
     const endMoment = moment(event.end * 1000);
     const timeRange = `${formatTime(startMoment)} - ${formatTime(endMoment)}`;
     return (

--- a/app/internal_packages/main-calendar/lib/core/calendar-event.tsx
+++ b/app/internal_packages/main-calendar/lib/core/calendar-event.tsx
@@ -1,7 +1,13 @@
 import React, { CSSProperties } from 'react';
 import ReactDOM from 'react-dom';
 import { InjectedComponentSet } from 'mailspring-component-kit';
-import { EventOccurrence } from './calendar-data-source';
+import { CalendarDateUtils } from 'mailspring-exports';
+import {
+  EventOccurrence,
+  isTimed,
+  occurrenceStartUnix,
+  occurrenceEndUnix,
+} from './calendar-data-source';
 import { calcEventColors, extractMeetingDomain, formatEventTimeRange } from './calendar-helpers';
 import { RecurringIcon } from './calendar-icons';
 import { HitZone, ViewDirection } from './calendar-drag-types';
@@ -87,14 +93,24 @@ export class CalendarEvent extends React.Component<CalendarEventProps, CalendarE
   }
 
   _getDimensions() {
-    const scopeLen = this.props.scopeEnd - this.props.scopeStart;
-    const duration = this.props.event.end - this.props.event.start;
+    const event = this.props.event;
 
-    let top: number | string = Math.max(
-      (this.props.event.start - this.props.scopeStart) / scopeLen,
-      0
-    );
-    let height: number | string = Math.min((duration - this._overflowBefore()) / scopeLen, 1);
+    // top/height are fractions of the scope. Timed events fill a day vertically by instant;
+    // all-day events fill the week horizontally (remapped in _getStyles) by whole days, so their
+    // fraction is computed in date space — DST-immune, unlike a seconds-based fraction would be.
+    let top: number | string;
+    let height: number | string;
+    if (isTimed(event)) {
+      const scopeLen = this.props.scopeEnd - this.props.scopeStart;
+      const duration = event.end - event.start;
+      top = Math.max((event.start - this.props.scopeStart) / scopeLen, 0);
+      height = Math.min((duration - this._overflowBefore()) / scopeLen, 1);
+    } else {
+      const scopeStartDate = CalendarDateUtils.calendarDateFromUnix(this.props.scopeStart);
+      const scopeDays = Math.round((this.props.scopeEnd - this.props.scopeStart) / 86400);
+      top = Math.max((event.startDate - scopeStartDate) / scopeDays, 0);
+      height = Math.min((event.endDate + 1 - event.startDate) / scopeDays, 1);
+    }
 
     let width: number | string = 1;
     let left: number | string;
@@ -150,7 +166,8 @@ export class CalendarEvent extends React.Component<CalendarEventProps, CalendarE
   }
 
   _overflowBefore() {
-    return Math.max(this.props.scopeStart - this.props.event.start, 0);
+    const event = this.props.event;
+    return isTimed(event) ? Math.max(this.props.scopeStart - event.start, 0) : 0;
   }
 
   /**
@@ -217,8 +234,10 @@ export class CalendarEvent extends React.Component<CalendarEventProps, CalendarE
 
     // Clamp to [0, 1] and calculate time
     percent = Math.max(0, Math.min(1, percent));
-    const eventDuration = this.props.event.end - this.props.event.start;
-    return this.props.event.start + percent * eventDuration;
+    // Drag works in unix throughout, so hand it an instant even for all-day events.
+    const start = occurrenceStartUnix(this.props.event);
+    const eventDuration = occurrenceEndUnix(this.props.event) - start;
+    return start + percent * eventDuration;
   }
 
   /**
@@ -264,7 +283,11 @@ export class CalendarEvent extends React.Component<CalendarEventProps, CalendarE
     if (!event.isDragPreview) {
       return null;
     }
-    const timeString = formatDragPreviewTime(event.start, event.end, event.isAllDay);
+    const timeString = formatDragPreviewTime(
+      occurrenceStartUnix(event),
+      occurrenceEndUnix(event),
+      event.isAllDay
+    );
     return <div className="drag-preview-time-tooltip">{timeString}</div>;
   }
 
@@ -282,7 +305,11 @@ export class CalendarEvent extends React.Component<CalendarEventProps, CalendarE
     }
 
     const meetingDomain = extractMeetingDomain(event.location, event.description);
-    const timeRange = formatEventTimeRange(event.start, event.end, event.isAllDay);
+    const timeRange = formatEventTimeRange(
+      occurrenceStartUnix(event),
+      occurrenceEndUnix(event),
+      event.isAllDay
+    );
     const hasPhysicalLocation = !meetingDomain && !!event.location;
 
     if (!meetingDomain && !hasPhysicalLocation && !timeRange) {

--- a/app/internal_packages/main-calendar/lib/core/calendar-event.tsx
+++ b/app/internal_packages/main-calendar/lib/core/calendar-event.tsx
@@ -108,8 +108,13 @@ export class CalendarEvent extends React.Component<CalendarEventProps, CalendarE
     } else {
       const scopeStartDate = CalendarDateUtils.calendarDateFromUnix(this.props.scopeStart);
       const scopeDays = Math.round((this.props.scopeEnd - this.props.scopeStart) / 86400);
-      top = Math.max((event.startDate - scopeStartDate) / scopeDays, 0);
-      height = Math.min((event.endDate + 1 - event.startDate) / scopeDays, 1);
+      const startOffset = CalendarDateUtils.calendarDaysBetween(scopeStartDate, event.startDate);
+      const spanDays = CalendarDateUtils.calendarDaysBetween(event.startDate, event.endDate) + 1;
+      // Mirror the timed branch: clamp the start into scope and drop the pre-scope days from the
+      // span, so an all-day event beginning before the visible week isn't drawn too wide.
+      const overflowDays = Math.max(-startOffset, 0);
+      top = Math.max(startOffset / scopeDays, 0);
+      height = Math.min((spanDays - overflowDays) / scopeDays, 1);
     }
 
     let width: number | string = 1;

--- a/app/internal_packages/main-calendar/lib/core/event-search-bar.tsx
+++ b/app/internal_packages/main-calendar/lib/core/event-search-bar.tsx
@@ -1,9 +1,16 @@
 import React, { Component } from 'react';
 import moment from 'moment-timezone';
-import { Rx, Event, DatabaseStore, localized, Calendar, Actions } from 'mailspring-exports';
+import {
+  Rx,
+  Event,
+  DatabaseStore,
+  localized,
+  Calendar,
+  Actions,
+  CalendarDateUtils,
+} from 'mailspring-exports';
 import { RetinaImg, KeyCommandsRegion, BindGlobalCommands } from 'mailspring-component-kit';
-import { EventOccurrence, occurrencesForEvents } from './calendar-data-source';
-import { inclusiveAllDayEnd } from './calendar-helpers';
+import { EventOccurrence, occurrencesForEvents, occurrenceStartUnix } from './calendar-data-source';
 import { Disposable } from 'rx-core';
 
 const DISABLED_CALENDARS = 'mailspring.disabledCalendars';
@@ -107,8 +114,8 @@ export class EventSearchBar extends Component<Record<string, unknown>, EventSear
       // Sort by start date, closest to now first
       const now = moment().unix();
       suggestions.sort((a, b) => {
-        const aDiff = Math.abs(a.start - now);
-        const bDiff = Math.abs(b.start - now);
+        const aDiff = Math.abs(occurrenceStartUnix(a) - now);
+        const bDiff = Math.abs(occurrenceStartUnix(b) - now);
         return aDiff - bDiff;
       });
 
@@ -131,7 +138,7 @@ export class EventSearchBar extends Component<Record<string, unknown>, EventSear
 
   _onSelectEvent = (event: EventOccurrence) => {
     this.setState({ query: '', suggestions: [], focused: false, selectedIdx: -1 });
-    Actions.focusCalendarEvent(event);
+    Actions.focusCalendarEvent({ id: event.id, start: occurrenceStartUnix(event) });
   };
 
   _focusSearch = () => {
@@ -186,16 +193,17 @@ export class EventSearchBar extends Component<Record<string, unknown>, EventSear
   };
 
   _formatEventTime = (event: EventOccurrence) => {
+    if (event.isAllDay === true) {
+      const first = moment(CalendarDateUtils.dayStartUnix(event.startDate) * 1000);
+      if (event.startDate === event.endDate) {
+        return first.format('ddd, MMM D, YYYY');
+      }
+      const last = moment(CalendarDateUtils.dayStartUnix(event.endDate) * 1000);
+      return `${first.format('MMM D')} - ${last.format('MMM D, YYYY')}`;
+    }
+
     const start = moment(event.start * 1000);
     const end = moment(event.end * 1000);
-
-    if (event.isAllDay) {
-      const lastDay = moment(inclusiveAllDayEnd(event.end) * 1000);
-      if (lastDay.isSame(start, 'day')) {
-        return start.format('ddd, MMM D, YYYY');
-      }
-      return `${start.format('MMM D')} - ${lastDay.format('MMM D, YYYY')}`;
-    }
 
     if (start.isSame(end, 'day')) {
       return `${start.format('ddd, MMM D')} \u00B7 ${start.format('h:mm A')} - ${end.format(

--- a/app/internal_packages/main-calendar/lib/core/mailspring-calendar.tsx
+++ b/app/internal_packages/main-calendar/lib/core/mailspring-calendar.tsx
@@ -31,6 +31,8 @@ import {
   EventOccurrence,
   FocusedEventInfo,
   coveredDates,
+  occurrenceStartUnix,
+  occurrenceEndUnix,
 } from './calendar-data-source';
 import { CalendarView } from './calendar-constants';
 import { CalendarEmptyState } from './calendar-empty-state';
@@ -485,7 +487,7 @@ export class MailspringCalendar extends React.Component<
     // Add EXDATE to exclude this occurrence
     masterEvent.ics = ICSEventHelpers.addExclusionDate(
       masterEvent.ics,
-      occurrence.start,
+      occurrenceStartUnix(occurrence),
       occurrence.isAllDay
     );
 
@@ -675,7 +677,9 @@ export class MailspringCalendar extends React.Component<
         return;
       }
 
-      // Calculate new times
+      // The keyboard pipeline is unix, so derive instants for all-day occurrences (dates only).
+      const occStart = occurrenceStartUnix(occurrence);
+      const occEnd = occurrenceEndUnix(occurrence);
       let newStart: number;
       let newEnd: number;
 
@@ -684,29 +688,27 @@ export class MailspringCalendar extends React.Component<
         // by calendar days rather than 86400 seconds keeps the times on midnight across a
         // DST transition, where a seconds shift overshoots and snaps up an extra day.
         const days = Math.sign(timeDelta);
-        newStart = isResize
-          ? occurrence.start
-          : CalendarDateUtils.shiftedDayStartUnix(occurrence.start, days);
+        newStart = isResize ? occStart : CalendarDateUtils.shiftedDayStartUnix(occStart, days);
         newEnd = isResize
-          ? clampEnd(newStart, CalendarDateUtils.shiftedDayStartUnix(occurrence.end, days), true)
-          : shiftEndWithStart(occurrence.start, occurrence.end, newStart, true);
+          ? clampEnd(newStart, CalendarDateUtils.shiftedDayStartUnix(occEnd, days), true)
+          : shiftEndWithStart(occStart, occEnd, newStart, true);
         const snapped = snapAllDayTimes(newStart, newEnd);
         newStart = snapped.start;
         newEnd = snapped.end;
       } else if (isResize) {
         // Shift+Arrow: resize the event (change end time only)
-        newStart = occurrence.start;
-        newEnd = clampEnd(newStart, occurrence.end + timeDelta, false);
+        newStart = occStart;
+        newEnd = clampEnd(newStart, occEnd + timeDelta, false);
       } else {
         // Arrow: move the event (change both start and end)
-        newStart = occurrence.start + timeDelta;
-        newEnd = occurrence.end + timeDelta;
+        newStart = occStart + timeDelta;
+        newEnd = occEnd + timeDelta;
       }
 
       // Resizing at the minimum duration clamps back to the current end, so the change can
       // be a no-op. Bail like the mouse-up path does, rather than queueing a syncback and an
       // undo toast for an identical event — or prompting for a recurring series that won't move.
-      if (newStart === occurrence.start && newEnd === occurrence.end) {
+      if (newStart === occStart && newEnd === occEnd) {
         return;
       }
 
@@ -716,7 +718,7 @@ export class MailspringCalendar extends React.Component<
         // For inline exceptions, use the RECURRENCE-ID value (recurrenceIdStart), NOT the
         // exception's moved DTSTART (start). Using start would produce the wrong RECURRENCE-ID
         // in the new exception, causing the upsert to miss the existing one and leave a duplicate.
-        originalOccurrenceStart: occurrence.recurrenceIdStart ?? occurrence.start,
+        originalOccurrenceStart: occurrence.recurrenceIdStart ?? occStart,
         newStart,
         newEnd,
         isAllDay: occurrence.isAllDay,
@@ -777,7 +779,8 @@ export class MailspringCalendar extends React.Component<
         // For inline exceptions, use the RECURRENCE-ID value (recurrenceIdStart), NOT the
         // exception's moved DTSTART (start). Using start would produce the wrong RECURRENCE-ID
         // in the new exception, causing the upsert to miss the existing one and leave a duplicate.
-        originalOccurrenceStart: dragState.event.recurrenceIdStart ?? dragState.event.start,
+        originalOccurrenceStart:
+          dragState.event.recurrenceIdStart ?? occurrenceStartUnix(dragState.event),
         newStart,
         newEnd,
         isAllDay: dragState.event.isAllDay,

--- a/app/internal_packages/main-calendar/lib/core/mailspring-calendar.tsx
+++ b/app/internal_packages/main-calendar/lib/core/mailspring-calendar.tsx
@@ -343,16 +343,14 @@ export class MailspringCalendar extends React.Component<
       ? CalendarDateUtils.nextDayStartUnix(CalendarDateUtils.calendarDateFromUnix(startUnix))
       : startUnix + 3600;
 
-    // Build a temporary EventOccurrence to open the popover in "new event" mode
-    const newEventOccurrence: EventOccurrence = {
+    // Build a temporary EventOccurrence to open the popover in "new event" mode. Build the
+    // right variant — an all-day new event carries dates only, like every other occurrence.
+    const base = {
       id: `__new_event_${Date.now()}`,
-      start: startUnix,
-      end: endUnix,
       ...coveredDates(startUnix, endUnix, isAllDay),
       title: '',
       description: '',
       location: '',
-      isAllDay,
       isRecurring: false,
       isCancelled: false,
       isPending: false,
@@ -362,6 +360,9 @@ export class MailspringCalendar extends React.Component<
       accountId: editableCalendars[0].accountId,
       calendarId: editableCalendars[0].id,
     };
+    const newEventOccurrence: EventOccurrence = isAllDay
+      ? { ...base, isAllDay: true }
+      : { ...base, isAllDay: false, start: startUnix, end: endUnix };
 
     // Open the popover anchored near the mouse position
     const originRect = new DOMRect(args.mouseEvent.clientX - 1, args.mouseEvent.clientY - 1, 2, 2);

--- a/app/internal_packages/main-calendar/lib/core/month-view-day-cell.tsx
+++ b/app/internal_packages/main-calendar/lib/core/month-view-day-cell.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Moment } from 'moment-timezone';
 import classnames from 'classnames';
-import { EventOccurrence, FocusedEventInfo } from './calendar-data-source';
+import { EventOccurrence, FocusedEventInfo, occurrenceStartUnix } from './calendar-data-source';
 import { MonthViewEvent } from './month-view-event';
 import { localized } from 'mailspring-exports';
 import { DragState, HitZone } from './calendar-drag-types';
@@ -49,7 +49,7 @@ export class MonthViewDayCell extends React.Component<MonthViewDayCellProps> {
       if (!a.isDragPreview && b.isDragPreview) return -1;
       if (a.isAllDay && !b.isAllDay) return -1;
       if (!a.isAllDay && b.isAllDay) return 1;
-      return a.start - b.start;
+      return occurrenceStartUnix(a) - occurrenceStartUnix(b);
     });
   }
 

--- a/app/internal_packages/main-calendar/lib/core/month-view-event.tsx
+++ b/app/internal_packages/main-calendar/lib/core/month-view-event.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import classnames from 'classnames';
-import { EventOccurrence } from './calendar-data-source';
+import { EventOccurrence, occurrenceStartUnix, occurrenceEndUnix } from './calendar-data-source';
 import { calcEventColors } from './calendar-helpers';
 import { RecurringIcon } from './calendar-icons';
 import { HitZone } from './calendar-drag-types';
@@ -139,7 +139,7 @@ export class MonthViewEvent extends React.Component<MonthViewEventProps, MonthVi
 
     // For month view events, use the event's start time as the mouse time
     // since day-level snapping doesn't require precise time positioning
-    const mouseTime = this.props.event.start;
+    const mouseTime = occurrenceStartUnix(this.props.event);
 
     // Notify parent of drag start
     if (this.props.onDragStart) {
@@ -185,7 +185,11 @@ export class MonthViewEvent extends React.Component<MonthViewEventProps, MonthVi
 
     // Drag preview events render differently - non-interactive with time tooltip
     if (event.isDragPreview) {
-      const timeString = formatDragPreviewTime(event.start, event.end, event.isAllDay);
+      const timeString = formatDragPreviewTime(
+        occurrenceStartUnix(event),
+        occurrenceEndUnix(event),
+        event.isAllDay
+      );
       return (
         <div className={className} style={style}>
           <span className="month-view-event-title">{event.title}</span>

--- a/app/internal_packages/main-calendar/lib/core/week-view-helpers.ts
+++ b/app/internal_packages/main-calendar/lib/core/week-view-helpers.ts
@@ -1,6 +1,6 @@
 import { EventOccurrence, isTimed } from './calendar-data-source';
 import moment, { Moment } from 'moment';
-import { Utils } from 'mailspring-exports';
+import { Utils, CalendarDateUtils } from 'mailspring-exports';
 
 // This pre-fetches from Utils to prevent constant disc access
 const overlapsBounds = Utils.overlapsBounds;
@@ -19,19 +19,19 @@ export interface OverlapByEventId {
 /**
  * Sweep-line bounds for an occurrence, as a half-open `[lo, hi)`. Each call is homogeneous —
  * the all-day bar passes only all-day events, day columns only timed — so all-day stacks in
- * date space (`endDate + 1` exclusive) and timed in instants, and the two never mix in one call.
+ * date space (`addCalendarDays(endDate, 1)` exclusive) and timed in instants, and the two never mix in one call.
  */
 function sweepBounds(e: EventOccurrence): { lo: number; hi: number } {
-  return isTimed(e) ? { lo: e.start, hi: e.end } : { lo: e.startDate, hi: e.endDate + 1 };
+  return isTimed(e)
+    ? { lo: e.start, hi: e.end }
+    : { lo: e.startDate, hi: CalendarDateUtils.addCalendarDays(e.endDate, 1) };
 }
 
 export function overlapForEvents(events: EventOccurrence[]) {
   const eventsByTime: { [unix: number]: EventOccurrence[] } = {};
-  const boundsById: { [id: string]: { lo: number; hi: number } } = {};
 
   for (const event of events) {
     const b = sweepBounds(event);
-    boundsById[event.id] = b;
     if (!eventsByTime[b.lo]) {
       eventsByTime[b.lo] = [];
     }
@@ -53,12 +53,13 @@ export function overlapForEvents(events: EventOccurrence[]) {
     // Process all event start/ends during this time to keep our
     // "ongoingEvents" set correct.
     for (const e of eventsByTime[t]) {
-      if (boundsById[e.id].lo === t) {
+      const b = sweepBounds(e);
+      if (b.lo === t) {
         overlapById[e.id] = { concurrentEvents: 1, order: null };
         ongoingEvents.push(e);
         ongoingIds.add(e.id);
       }
-      if (boundsById[e.id].hi === t) {
+      if (b.hi === t) {
         ongoingIds.delete(e.id);
       }
     }

--- a/app/internal_packages/main-calendar/lib/core/week-view-helpers.ts
+++ b/app/internal_packages/main-calendar/lib/core/week-view-helpers.ts
@@ -1,4 +1,4 @@
-import { EventOccurrence } from './calendar-data-source';
+import { EventOccurrence, isTimed } from './calendar-data-source';
 import moment, { Moment } from 'moment';
 import { Utils } from 'mailspring-exports';
 
@@ -16,18 +16,30 @@ export interface OverlapByEventId {
  *   - concurrentEvents: number of concurrent events
  *   - order: the order in that series of concurrent events
  */
+/**
+ * Sweep-line bounds for an occurrence, as a half-open `[lo, hi)`. Each call is homogeneous —
+ * the all-day bar passes only all-day events, day columns only timed — so all-day stacks in
+ * date space (`endDate + 1` exclusive) and timed in instants, and the two never mix in one call.
+ */
+function sweepBounds(e: EventOccurrence): { lo: number; hi: number } {
+  return isTimed(e) ? { lo: e.start, hi: e.end } : { lo: e.startDate, hi: e.endDate + 1 };
+}
+
 export function overlapForEvents(events: EventOccurrence[]) {
   const eventsByTime: { [unix: number]: EventOccurrence[] } = {};
+  const boundsById: { [id: string]: { lo: number; hi: number } } = {};
 
   for (const event of events) {
-    if (!eventsByTime[event.start]) {
-      eventsByTime[event.start] = [];
+    const b = sweepBounds(event);
+    boundsById[event.id] = b;
+    if (!eventsByTime[b.lo]) {
+      eventsByTime[b.lo] = [];
     }
-    if (!eventsByTime[event.end]) {
-      eventsByTime[event.end] = [];
+    if (!eventsByTime[b.hi]) {
+      eventsByTime[b.hi] = [];
     }
-    eventsByTime[event.start].push(event);
-    eventsByTime[event.end].push(event);
+    eventsByTime[b.lo].push(event);
+    eventsByTime[b.hi].push(event);
   }
   const sortedTimes = Object.keys(eventsByTime)
     .map(Number)
@@ -41,12 +53,12 @@ export function overlapForEvents(events: EventOccurrence[]) {
     // Process all event start/ends during this time to keep our
     // "ongoingEvents" set correct.
     for (const e of eventsByTime[t]) {
-      if (e.start === t) {
+      if (boundsById[e.id].lo === t) {
         overlapById[e.id] = { concurrentEvents: 1, order: null };
         ongoingEvents.push(e);
         ongoingIds.add(e.id);
       }
-      if (e.end === t) {
+      if (boundsById[e.id].hi === t) {
         ongoingIds.delete(e.id);
       }
     }
@@ -118,9 +130,7 @@ export function eventsGroupedByDay(events: EventOccurrence[], days: Moment[]) {
   });
 
   events.forEach((event) => {
-    if (event.isAllDay) {
-      map.allDay.push(event);
-    } else {
+    if (isTimed(event)) {
       for (const day of unixDays) {
         const bounds = {
           start: day,
@@ -130,6 +140,8 @@ export function eventsGroupedByDay(events: EventOccurrence[], days: Moment[]) {
           map[`${day}`].push(event);
         }
       }
+    } else {
+      map.allDay.push(event);
     }
   });
 

--- a/app/spec/calendar-data-source-spec.ts
+++ b/app/spec/calendar-data-source-spec.ts
@@ -4,6 +4,8 @@ import { Event as MailspringEvent } from '../src/flux/models/event';
 import {
   occurrencesForEvents,
   eventCoversDate,
+  occurrenceStartUnix,
+  occurrenceEndUnix,
 } from '../internal_packages/main-calendar/lib/core/calendar-data-source';
 import { formatCalendarDate, parseCalendarDate } from '../src/calendar-date';
 
@@ -56,7 +58,7 @@ describe('occurrencesForEvents isAllDay classification', function () {
 
   it('does not treat a long timed event as all-day', function () {
     const [occ] = expand(makeEvent(icsFor('DTSTART:20260622T090000Z', 'DTEND:20260623T170000Z')));
-    expect(occ.end - occ.start).toBeGreaterThan(86400);
+    expect(occurrenceEndUnix(occ) - occurrenceStartUnix(occ)).toBeGreaterThan(86400);
     expect(occ.isAllDay).toBe(false);
   });
 

--- a/app/spec/calendar-drag-utils-spec.ts
+++ b/app/spec/calendar-drag-utils-spec.ts
@@ -12,13 +12,19 @@ import {
 import { MONTH_VIEW_DRAG_CONFIG } from '../internal_packages/main-calendar/lib/core/calendar-drag-types';
 import {
   EventOccurrence,
+  TimedOccurrence,
   coveredDates,
 } from '../internal_packages/main-calendar/lib/core/calendar-data-source';
 
 const HOUR = 60 * 60;
 
-function makeOccurrence(overrides: Partial<EventOccurrence> = {}): EventOccurrence {
+// Fixtures still specify all-day events by the instants they span; makeOccurrence derives the
+// dates and emits the right variant, so callers can't encode a shape production never emits.
+type OccurrenceOverrides = Partial<Omit<TimedOccurrence, 'isAllDay'>> & { isAllDay?: boolean };
+
+function makeOccurrence(overrides: OccurrenceOverrides = {}): EventOccurrence {
   const nowUnix = Date.now() / 1000;
+  const { start = nowUnix + HOUR, end = nowUnix + 2 * HOUR, isAllDay = false, ...rest } = overrides;
   const base = {
     id: 'event-1-e0',
     accountId: 'acct-1',
@@ -26,20 +32,16 @@ function makeOccurrence(overrides: Partial<EventOccurrence> = {}): EventOccurren
     title: 'Standup',
     location: '',
     description: '',
-    start: nowUnix + HOUR,
-    end: nowUnix + 2 * HOUR,
-    isAllDay: false,
     isCancelled: false,
     isPending: false,
     isException: false,
     isRecurring: false,
     organizer: null,
     attendees: [],
-    ...overrides,
+    ...rest,
+    ...coveredDates(start, end, isAllDay),
   };
-  // Through the same derivation production uses, so fixtures can't encode a shape
-  // occurrencesForEvents would never emit
-  return { ...base, ...coveredDates(base.start, base.end, base.isAllDay) };
+  return isAllDay ? { ...base, isAllDay: true } : { ...base, isAllDay: false, start, end };
 }
 
 describe('isPastDate', function () {

--- a/app/spec/calendar-event-spec.ts
+++ b/app/spec/calendar-event-spec.ts
@@ -1,0 +1,54 @@
+import { CalendarEvent } from '../internal_packages/main-calendar/lib/core/calendar-event';
+import { AllDayOccurrence } from '../internal_packages/main-calendar/lib/core/calendar-data-source';
+import { CalendarDateUtils } from 'mailspring-exports';
+import { parseCalendarDate } from '../src/calendar-date';
+
+// _getDimensions reads only this.props, so we can exercise it without rendering.
+function allDayDimensions(startISO: string, endISO: string) {
+  const weekStart = parseCalendarDate('2026-06-21'); // Sun; June has no DST transition
+  const event = {
+    isAllDay: true,
+    startDate: parseCalendarDate(startISO),
+    endDate: parseCalendarDate(endISO),
+    id: 'e0',
+    accountId: 'a',
+    calendarId: 'c',
+    title: '',
+    location: '',
+    description: '',
+    isCancelled: false,
+    isPending: false,
+    isException: false,
+    isRecurring: false,
+    organizer: null,
+    attendees: [],
+  } as AllDayOccurrence;
+  const instance = new CalendarEvent({
+    event,
+    order: 1,
+    concurrentEvents: 1,
+    fixedSize: -1,
+    direction: 'horizontal',
+    scopeStart: CalendarDateUtils.dayStartUnix(weekStart),
+    scopeEnd: CalendarDateUtils.dayStartUnix((weekStart + 7) as any),
+  } as any);
+  const d = (instance as any)._getDimensions();
+  return { topPct: parseFloat(d.top), heightPct: parseFloat(d.height) };
+}
+
+describe('CalendarEvent all-day dimensions', function () {
+  it('sizes a fully-visible multi-day span by its covered days', function () {
+    // Jun 22-24 inclusive = 3 of the 7 week days
+    const { topPct, heightPct } = allDayDimensions('2026-06-22', '2026-06-24');
+    expect(topPct).toBeCloseTo((1 / 7) * 100, 4); // starts 1 day into the week
+    expect(heightPct).toBeCloseTo((3 / 7) * 100, 4);
+  });
+
+  it('clips the pre-week portion of a span that starts before the visible week', function () {
+    // Covers Jun 19-22; only Jun 21-22 (2 days) are visible. Regression: the dropped
+    // overflow clamp drew the full 4-day span (57%) pinned at day 0 instead of 2 days (29%).
+    const { topPct, heightPct } = allDayDimensions('2026-06-19', '2026-06-22');
+    expect(topPct).toBe(0);
+    expect(heightPct).toBeCloseTo((2 / 7) * 100, 4);
+  });
+});


### PR DESCRIPTION
## What

Makes `EventOccurrence` a discriminated union on `isAllDay`:
`AllDayOccurrence` carries covered dates only (`startDate`/`endDate`), and
`TimedOccurrence` carries those plus `start`/`end` instants. Follow-on to #2805,
which modeled all-day events as dates but left `start`/`end` on every occurrence.

## Why

#2805 stored the right dates but the type still let an all-day occurrence carry
instant fields, so nothing stopped code from reading `event.start` on an all-day
event and doing seconds-arithmetic on it — the exact shape of the DST bug class.
Narrowing the type makes that unrepresentable: an all-day occurrence has no
`start`, so every reader that assumed one is now a compile error. That surfaced
~75 such readers across 12 files, each handled explicitly.

## Notable for review

- **`isTimed()` instead of `if (event.isAllDay)`.** The app tsconfig has no
  `strictNullChecks`, and without it a truthiness check does not narrow a
  discriminated union (verified: `if (e.isAllDay)` narrows the positive branch
  but not the fall-through; `if (!e.isAllDay)` narrows neither). `=== true/false`
  and type guards do. So timed paths lead with `if (isTimed(event))`, backed by a
  one-line `isTimed(e): e is TimedOccurrence` guard. The union still flags every
  unguarded read — that's the point — you just clear the flag with a guard.

- **All-day layout now computes in date space.** All-day events are positioned in
  the week bar by `CalendarEvent._getDimensions` and stacked by `overlapForEvents`
  — both previously keyed off `start`/`end` instants across the week scope. They
  now use `startDate`/`endDate` against a day-count scope (`(startDate -
  weekStartDate) / scopeDays`), which is DST-immune. Timed positioning is
  unchanged (still instants against a within-day scope).

- **Derived instants survive at interaction/formatting boundaries only.**
  `occurrenceStartUnix`/`occurrenceEndUnix` (real instant if timed;
  `dayStartUnix(startDate)`/`nextDayStartUnix(endDate)` if all-day) feed sort
  keys, the focus scroll target, drag hit-testing, and date-range text — all of
  which are unix pipelines. Not used for layout (that's date space, above).

## Scope

Deliberately not here: the drag hit-test still turns a mouse position into a
unix time and round-trips all-day drags through it (`startTime + dayIndex *
86400` in `calendar-event-container.tsx`). That's a separate follow-up — a
date-space all-day drag path — which will retire the remaining unix day-snap
helpers. This PR bridges it with derived instants that preserve today's behavior.

This narrows a type rather than deleting helpers, so it's net additive. The
unix day-snap helpers (`inclusiveAllDayEnd`, `snapAllDayTimes`) stay — they're
load-bearing for the editing pickers and drag, which legitimately work in unix.

## Testing

Full suite green, typecheck and lint clean. The all-day week-bar geometry
(date-space `_getDimensions`) is covered by `calendar-event-spec.ts`, including
a multi-day all-day event that starts before the visible week.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
