### PR TITLE
Add an MCP get_attachment tool for viewing mail attachments

### DIFF
--- a/app/internal_packages/mcp-server/lib/mcp-http-server.ts
+++ b/app/internal_packages/mcp-server/lib/mcp-http-server.ts
@@ -3,7 +3,7 @@ import { randomUUID, createHash, timingSafeEqual } from 'crypto';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
-import { registerTools } from './mcp-tools';
+import { registerTools, registerResources } from './mcp-tools';
 
 export class McpHttpServer {
   private httpServer: http.Server | null = null;
@@ -15,6 +15,7 @@ export class McpHttpServer {
       version: '1.0.0',
     });
     registerTools(server);
+    registerResources(server);
     return server;
   }
 

--- a/app/internal_packages/mcp-server/lib/mcp-serializers.ts
+++ b/app/internal_packages/mcp-server/lib/mcp-serializers.ts
@@ -1,4 +1,4 @@
-import type { Thread, Message, Category, Contact } from 'mailspring-exports';
+import type { Thread, Message, Category, Contact, File } from 'mailspring-exports';
 import { isThreadAllowed, isMessageAllowed } from './mcp-access-control';
 
 // Authorization + output-shaping, combined. Every thread/message that leaves
@@ -16,6 +16,16 @@ function serializeContact(c: Pick<Contact, 'name' | 'email'>) {
   return { name: c.name, email: c.email };
 }
 
+function serializeFile(f: File) {
+  return {
+    id: f.id,
+    filename: f.displayName(),
+    contentType: f.contentType || null,
+    size: f.size,
+    isInline: !!f.contentId,
+  };
+}
+
 export function serializeThreadSummary(
   thread: Thread,
   opts: { includeMessageCount?: boolean } = {}
@@ -29,6 +39,7 @@ export function serializeThreadSummary(
     starred: thread.starred,
     lastMessageReceivedTimestamp: thread.lastMessageReceivedTimestamp,
     participantCount: thread.participants?.length || 0,
+    attachmentCount: thread.attachmentCount || 0,
     accountId: thread.accountId,
     categories: (thread.categories || []).map(serializeCategory),
   };
@@ -52,6 +63,7 @@ export function serializeMessageDetail(message: Message): Record<string, any> | 
     date: message.date,
     body: message.body,
     snippet: message.snippet,
+    files: (message.files || []).map(serializeFile),
     unread: message.unread,
     starred: message.starred,
     draft: message.draft,

--- a/app/internal_packages/mcp-server/lib/mcp-tools.ts
+++ b/app/internal_packages/mcp-server/lib/mcp-tools.ts
@@ -107,8 +107,8 @@ function messageTrackingSummary(message: Message) {
 // Upper bound on attachment bytes returned inline (as UTF-8 text or an MCP
 // image content block) in a tool result. Larger files — like all binary
 // files — are never inlined; the tool returns a resource_link plus the local
-// path instead, so tool results stay within what MCP clients will buffer.
-const MAX_INLINE_ATTACHMENT_BYTES = 10 * 1024 * 1024;
+// path instead, so tool results stay small enough to hand to a model.
+const MAX_INLINE_ATTACHMENT_BYTES = 200 * 1024;
 
 // URI scheme for the MCP resource that serves raw attachment bytes to
 // clients that explicitly read it (via resources/read). Tool results carry
@@ -560,7 +560,7 @@ export function registerTools(server: McpServer) {
   defineTool(
     server,
     'get_attachment',
-    "View the contents of an email attachment. Find the attachment's fileId in the `files` array returned by get_message or get_thread (use search_mail's has:attachment to find mail with attachments). Every result starts with a JSON metadata block (filename, contentType, size, plus the file's local `path` and its MCP `resourceUri` — this server only accepts connections from the same machine, so the path is directly readable by local tools). Text-based attachments (text/*, JSON, XML, SVG, ICS, EML) up to 10MB include their content in the JSON as UTF-8 `data`; images (PNG/JPEG/GIF/WebP) up to 10MB are additionally returned as an MCP image content block so they can be viewed directly; any other type or size returns no inline payload — instead the result ends with a resource_link content block whose URI can be fetched via resources/read, or the file can be read straight from `path`. If the attachment hasn't been downloaded from the mail server yet it is fetched first, which can take several seconds.",
+    "View the contents of an email attachment. Find the attachment's fileId in the `files` array returned by get_message or get_thread (use search_mail's has:attachment to find mail with attachments). Every result starts with a JSON metadata block (filename, contentType, size, plus the file's local `path` and its MCP `resourceUri` — this server only accepts connections from the same machine, so the path is directly readable by local tools). Text-based attachments (text/*, JSON, XML, SVG, ICS, EML) up to 200KB include their content in the JSON as UTF-8 `data`; images (PNG/JPEG/GIF/WebP) up to 200KB are additionally returned as an MCP image content block so they can be viewed directly; any other type or size returns no inline payload — instead the result ends with a resource_link content block whose URI can be fetched via resources/read, or the file can be read straight from `path`. If the attachment hasn't been downloaded from the mail server yet it is fetched first, which can take several seconds.",
     {
       messageId: z.string().describe('The ID of the message the attachment belongs to'),
       fileId: z.string().describe("The attachment's file ID (from the message's `files` array)"),

--- a/app/internal_packages/mcp-server/lib/mcp-tools.ts
+++ b/app/internal_packages/mcp-server/lib/mcp-tools.ts
@@ -1,12 +1,16 @@
+import fs from 'fs';
+import path from 'path';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import {
   AccountStore,
+  AttachmentStore,
   CategoryStore,
   DatabaseStore,
   Thread,
   Message,
   Contact,
+  File,
   Label,
   DraftFactory,
   SyncbackDraftTask,
@@ -98,6 +102,112 @@ function messageTrackingSummary(message: Message) {
   return { opens, links };
 }
 
+// ── Attachment viewing (get_attachment) ──────────────────────────────────
+
+// Upper bound on attachment bytes returned inline in a tool result. Base64
+// encoding inflates binary payloads by ~33%, so this keeps responses well
+// within what MCP clients will buffer, without truncating typical email
+// attachments (Mailspring caps outgoing attachments at 25MB).
+const MAX_INLINE_ATTACHMENT_BYTES = 10 * 1024 * 1024;
+
+// The sync engine writes attachment files to disk as part of fetching a
+// message's body. When the body hasn't been synced yet we request it and
+// poll for the file to appear; a large attachment on a slow connection
+// needs a generous deadline. When the body is already local, the file
+// should appear almost immediately (or never will), so give up quickly.
+const ATTACHMENT_DOWNLOAD_TIMEOUT_MS = 30 * 1000;
+const ATTACHMENT_RECHECK_TIMEOUT_MS = 5 * 1000;
+const ATTACHMENT_POLL_INTERVAL_MS = 500;
+
+// Fallback types for files without a usable contentType: files attached to
+// local drafts are created with `contentType: null`, and some providers
+// declare everything as application/octet-stream.
+const EXTENSION_MIME_TYPES: { [ext: string]: string } = {
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  gif: 'image/gif',
+  webp: 'image/webp',
+  svg: 'image/svg+xml',
+  txt: 'text/plain',
+  log: 'text/plain',
+  md: 'text/markdown',
+  csv: 'text/csv',
+  tsv: 'text/tab-separated-values',
+  html: 'text/html',
+  htm: 'text/html',
+  css: 'text/css',
+  js: 'application/javascript',
+  json: 'application/json',
+  xml: 'application/xml',
+  yml: 'text/yaml',
+  yaml: 'text/yaml',
+  ics: 'text/calendar',
+  eml: 'message/rfc822',
+  pdf: 'application/pdf',
+};
+
+// Formats MCP clients can render from an image content block. SVG is
+// deliberately absent — it's XML and is far more useful to a client as text.
+const VIEWABLE_IMAGE_MIME_TYPES = new Set(['image/png', 'image/jpeg', 'image/gif', 'image/webp']);
+
+const TEXT_MIME_TYPES = new Set([
+  'application/json',
+  'application/javascript',
+  'application/x-javascript',
+  'application/xml',
+  'application/xhtml+xml',
+  'image/svg+xml',
+  'message/rfc822',
+]);
+
+function mimeTypeForFile(file: File): string {
+  // contentType may carry parameters (e.g. "text/plain; charset=utf-8").
+  const declared = (file.contentType || '').split(';')[0].trim().toLowerCase();
+  if (declared && declared !== 'application/octet-stream') return declared;
+  return EXTENSION_MIME_TYPES[file.displayExtension()] || 'application/octet-stream';
+}
+
+function isTextMimeType(mimeType: string): boolean {
+  return (
+    mimeType.startsWith('text/') ||
+    mimeType.endsWith('+json') ||
+    mimeType.endsWith('+xml') ||
+    TEXT_MIME_TYPES.has(mimeType)
+  );
+}
+
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.promises.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// Where the sync engine saved this attachment on disk, or null if it hasn't
+// been downloaded yet. Mirrors AttachmentStore._prepareAndResolveFilePath:
+// when the exact path is missing but the file's directory holds exactly one
+// entry, the sync engine saved the file under an altered name — use it.
+async function attachmentPathOnDisk(file: File): Promise<string | null> {
+  const filePath = AttachmentStore.pathForFile(file);
+  if (!filePath) return null;
+  if (await fileExists(filePath)) return filePath;
+  try {
+    const dir = path.dirname(filePath);
+    const items = (await fs.promises.readdir(dir)).filter((i) => i !== '.DS_Store');
+    if (items.length === 1) return path.join(dir, items[0]);
+  } catch {
+    // The directory doesn't exist — the file hasn't been downloaded.
+  }
+  return null;
+}
+
+function delay(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 export interface AuditEntry {
   timestamp: number;
   toolName: string;
@@ -142,7 +252,10 @@ function errorResult(message: string) {
   };
 }
 
-type ToolResult = { content: { type: 'text'; text: string }[]; isError?: boolean };
+type ToolContent =
+  | { type: 'text'; text: string }
+  | { type: 'image'; data: string; mimeType: string };
+type ToolResult = { content: ToolContent[]; isError?: boolean };
 
 async function withAudit(
   toolName: string,
@@ -335,7 +448,7 @@ export function registerTools(server: McpServer) {
   defineTool(
     server,
     'get_thread',
-    'Get a thread with all its messages and full body content',
+    "Get a thread with all its messages, full body content, and attachment metadata (each message's `files` array; retrieve one with get_attachment)",
     { threadId: z.string().describe('The thread ID') },
     'read',
     async ({ threadId }) => {
@@ -358,7 +471,7 @@ export function registerTools(server: McpServer) {
   defineTool(
     server,
     'get_message',
-    'Get a single message with full body content',
+    'Get a single message with full body content and attachment metadata (`files` array; retrieve one with get_attachment)',
     { messageId: z.string().describe('The message ID') },
     'read',
     async ({ messageId }) => {
@@ -370,6 +483,93 @@ export function registerTools(server: McpServer) {
       const result = serializeMessageDetail(message);
       if (!result) return errorResult(`Message '${messageId}' not found`);
       return textResult(result);
+    }
+  );
+
+  defineTool(
+    server,
+    'get_attachment',
+    "View the contents of an email attachment. Find the attachment's fileId in the `files` array returned by get_message or get_thread (use search_mail's has:attachment to find mail with attachments). Returns a JSON object with the attachment's metadata and an `encoding` field describing the content: text-based attachments (text/*, JSON, XML, SVG, ICS, EML) carry their content in `data` as UTF-8 text, images (PNG/JPEG/GIF/WebP) are returned as a separate MCP image content block after the JSON so they can be viewed directly, and any other type carries `data` as base64. Attachments larger than 10MB return an error instead of content. If the attachment hasn't been downloaded from the mail server yet it is fetched first, which can take several seconds.",
+    {
+      messageId: z.string().describe('The ID of the message the attachment belongs to'),
+      fileId: z.string().describe("The attachment's file ID (from the message's `files` array)"),
+    },
+    'read',
+    async ({ messageId, fileId }) => {
+      // Body is included so the download wait below can distinguish
+      // "body never synced" from "body synced but file missing".
+      const message = await DatabaseStore.find<Message>(Message, messageId).include(
+        Message.attributes.body
+      );
+      if (!message || !isMessageAllowed(message)) {
+        return errorResult(`Message '${messageId}' not found`);
+      }
+
+      const file = (message.files || []).find((f) => f.id === fileId);
+      if (!file) {
+        return errorResult(`Message '${messageId}' has no attachment with id '${fileId}'`);
+      }
+      if (!AttachmentStore.pathForFile(file)) {
+        return errorResult(
+          `Attachment '${fileId}' has an unsafe filename and cannot be resolved on disk`
+        );
+      }
+
+      let filePath = await attachmentPathOnDisk(file);
+      if (!filePath) {
+        // Attachments are written to disk when the sync engine fetches the
+        // message body, so request the body and wait for the file to appear.
+        Actions.fetchBodies([message]);
+        const deadline =
+          Date.now() +
+          (message.body ? ATTACHMENT_RECHECK_TIMEOUT_MS : ATTACHMENT_DOWNLOAD_TIMEOUT_MS);
+        while (!filePath && Date.now() < deadline) {
+          await delay(ATTACHMENT_POLL_INTERVAL_MS);
+          filePath = await attachmentPathOnDisk(file);
+        }
+      }
+      if (!filePath) {
+        return errorResult(
+          `Attachment '${file.displayName()}' is not available locally and could not be downloaded. Open the message in Mailspring to download it, then try again.`
+        );
+      }
+
+      const { size } = await fs.promises.stat(filePath);
+      if (size > MAX_INLINE_ATTACHMENT_BYTES) {
+        return errorResult(
+          `Attachment '${file.displayName()}' is ${size} bytes, which exceeds the ${MAX_INLINE_ATTACHMENT_BYTES} byte limit for inline retrieval`
+        );
+      }
+
+      const mimeType = mimeTypeForFile(file);
+      const metadata = {
+        id: file.id,
+        filename: file.displayName(),
+        contentType: mimeType,
+        size,
+        isInline: !!file.contentId,
+        messageId: message.id,
+        threadId: message.threadId,
+        accountId: message.accountId,
+      };
+
+      const buffer = await fs.promises.readFile(filePath);
+
+      if (VIEWABLE_IMAGE_MIME_TYPES.has(mimeType)) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({ ...metadata, encoding: 'image' }, null, 2),
+            },
+            { type: 'image' as const, data: buffer.toString('base64'), mimeType },
+          ],
+        };
+      }
+      if (isTextMimeType(mimeType)) {
+        return textResult({ ...metadata, encoding: 'utf8', data: buffer.toString('utf8') });
+      }
+      return textResult({ ...metadata, encoding: 'base64', data: buffer.toString('base64') });
     }
   );
 

--- a/app/internal_packages/mcp-server/lib/mcp-tools.ts
+++ b/app/internal_packages/mcp-server/lib/mcp-tools.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { McpServer, ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import {
   AccountStore,
@@ -104,11 +104,20 @@ function messageTrackingSummary(message: Message) {
 
 // ── Attachment viewing (get_attachment) ──────────────────────────────────
 
-// Upper bound on attachment bytes returned inline in a tool result. Base64
-// encoding inflates binary payloads by ~33%, so this keeps responses well
-// within what MCP clients will buffer, without truncating typical email
-// attachments (Mailspring caps outgoing attachments at 25MB).
+// Upper bound on attachment bytes returned inline (as UTF-8 text or an MCP
+// image content block) in a tool result. Larger files — like all binary
+// files — are never inlined; the tool returns a resource_link plus the local
+// path instead, so tool results stay within what MCP clients will buffer.
 const MAX_INLINE_ATTACHMENT_BYTES = 10 * 1024 * 1024;
+
+// URI scheme for the MCP resource that serves raw attachment bytes to
+// clients that explicitly read it (via resources/read). Tool results carry
+// only a resource_link with one of these URIs — never base64 payloads.
+const ATTACHMENT_URI_SCHEME = 'attachment';
+
+function attachmentResourceUri(messageId: string, fileId: string): string {
+  return `${ATTACHMENT_URI_SCHEME}://${encodeURIComponent(messageId)}/${encodeURIComponent(fileId)}`;
+}
 
 // The sync engine writes attachment files to disk as part of fetching a
 // message's body. When the body hasn't been synced yet we request it and
@@ -254,7 +263,8 @@ function errorResult(message: string) {
 
 type ToolContent =
   | { type: 'text'; text: string }
-  | { type: 'image'; data: string; mimeType: string };
+  | { type: 'image'; data: string; mimeType: string }
+  | { type: 'resource_link'; uri: string; name: string; description?: string; mimeType?: string };
 type ToolResult = { content: ToolContent[]; isError?: boolean };
 
 async function withAudit(
@@ -306,6 +316,67 @@ function defineTool(
       if (err) return errorResult(err);
       return handler(args);
     })
+  );
+}
+
+// Serves raw attachment bytes to clients that explicitly dereference an
+// attachment:// resource_link returned by get_attachment. This is MCP's
+// mechanism for binary content: tool results stay payload-free (a link plus
+// metadata) and a client opts in to the bytes via resources/read, where the
+// spec carries them as a blob. The same account/folder authorization as
+// get_attachment applies, and reads land in the audit log.
+export function registerResources(server: McpServer) {
+  server.registerResource(
+    'attachment',
+    new ResourceTemplate(`${ATTACHMENT_URI_SCHEME}://{messageId}/{fileId}`, { list: undefined }),
+    {
+      title: 'Email attachment',
+      description: 'Raw bytes of an email attachment. Discover URIs via the get_attachment tool.',
+    },
+    async (uri, variables) => {
+      const start = Date.now();
+      const audit = (resultSummary: string) =>
+        addAuditEntry({
+          timestamp: Date.now(),
+          toolName: 'resources/read',
+          params: uri.href.slice(0, 200),
+          resultSummary,
+          durationMs: Date.now() - start,
+        });
+
+      try {
+        // Variables come from the SDK's template match on the raw URI, so
+        // they preserve the ids' case (unlike uri.host, which URL lowercases).
+        const messageId = decodeURIComponent(String(variables.messageId));
+        const fileId = decodeURIComponent(String(variables.fileId));
+
+        const message = await DatabaseStore.find<Message>(Message, messageId);
+        if (!message || !isMessageAllowed(message)) {
+          throw new Error(`Message '${messageId}' not found`);
+        }
+        const file = (message.files || []).find((f) => f.id === fileId);
+        if (!file) {
+          throw new Error(`Message '${messageId}' has no attachment with id '${fileId}'`);
+        }
+        const filePath = await attachmentPathOnDisk(file);
+        if (!filePath) {
+          throw new Error(
+            `Attachment '${file.displayName()}' has not been downloaded — call the get_attachment tool first.`
+          );
+        }
+
+        const buffer = await fs.promises.readFile(filePath);
+        audit('ok');
+        return {
+          contents: [
+            { uri: uri.href, mimeType: mimeTypeForFile(file), blob: buffer.toString('base64') },
+          ],
+        };
+      } catch (err) {
+        audit(`error: ${(err as Error).message}`.slice(0, 100));
+        throw err;
+      }
+    }
   );
 }
 
@@ -489,7 +560,7 @@ export function registerTools(server: McpServer) {
   defineTool(
     server,
     'get_attachment',
-    "View the contents of an email attachment. Find the attachment's fileId in the `files` array returned by get_message or get_thread (use search_mail's has:attachment to find mail with attachments). Returns a JSON object with the attachment's metadata and an `encoding` field describing the content: text-based attachments (text/*, JSON, XML, SVG, ICS, EML) carry their content in `data` as UTF-8 text, images (PNG/JPEG/GIF/WebP) are returned as a separate MCP image content block after the JSON so they can be viewed directly, and any other type carries `data` as base64. Attachments larger than 10MB return an error instead of content. If the attachment hasn't been downloaded from the mail server yet it is fetched first, which can take several seconds.",
+    "View the contents of an email attachment. Find the attachment's fileId in the `files` array returned by get_message or get_thread (use search_mail's has:attachment to find mail with attachments). Every result starts with a JSON metadata block (filename, contentType, size, plus the file's local `path` and its MCP `resourceUri` — this server only accepts connections from the same machine, so the path is directly readable by local tools). Text-based attachments (text/*, JSON, XML, SVG, ICS, EML) up to 10MB include their content in the JSON as UTF-8 `data`; images (PNG/JPEG/GIF/WebP) up to 10MB are additionally returned as an MCP image content block so they can be viewed directly; any other type or size returns no inline payload — instead the result ends with a resource_link content block whose URI can be fetched via resources/read, or the file can be read straight from `path`. If the attachment hasn't been downloaded from the mail server yet it is fetched first, which can take several seconds.",
     {
       messageId: z.string().describe('The ID of the message the attachment belongs to'),
       fileId: z.string().describe("The attachment's file ID (from the message's `files` array)"),
@@ -535,12 +606,6 @@ export function registerTools(server: McpServer) {
       }
 
       const { size } = await fs.promises.stat(filePath);
-      if (size > MAX_INLINE_ATTACHMENT_BYTES) {
-        return errorResult(
-          `Attachment '${file.displayName()}' is ${size} bytes, which exceeds the ${MAX_INLINE_ATTACHMENT_BYTES} byte limit for inline retrieval`
-        );
-      }
-
       const mimeType = mimeTypeForFile(file);
       const metadata = {
         id: file.id,
@@ -551,25 +616,61 @@ export function registerTools(server: McpServer) {
         messageId: message.id,
         threadId: message.threadId,
         accountId: message.accountId,
+        // The server only accepts loopback connections (see mcp-http-server),
+        // so every client runs on this machine and can use the path directly.
+        path: filePath,
+        resourceUri: attachmentResourceUri(message.id, file.id),
       };
 
-      const buffer = await fs.promises.readFile(filePath);
+      if (size <= MAX_INLINE_ATTACHMENT_BYTES) {
+        if (isTextMimeType(mimeType)) {
+          const buffer = await fs.promises.readFile(filePath);
+          return textResult({ ...metadata, data: buffer.toString('utf8') });
+        }
+        if (VIEWABLE_IMAGE_MIME_TYPES.has(mimeType)) {
+          const buffer = await fs.promises.readFile(filePath);
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: JSON.stringify(
+                  { ...metadata, note: 'The image follows this JSON as an image content block.' },
+                  null,
+                  2
+                ),
+              },
+              { type: 'image' as const, data: buffer.toString('base64'), mimeType },
+            ],
+          };
+        }
+      }
 
-      if (VIEWABLE_IMAGE_MIME_TYPES.has(mimeType)) {
-        return {
-          content: [
-            {
-              type: 'text' as const,
-              text: JSON.stringify({ ...metadata, encoding: 'image' }, null, 2),
-            },
-            { type: 'image' as const, data: buffer.toString('base64'), mimeType },
-          ],
-        };
-      }
-      if (isTextMimeType(mimeType)) {
-        return textResult({ ...metadata, encoding: 'utf8', data: buffer.toString('utf8') });
-      }
-      return textResult({ ...metadata, encoding: 'base64', data: buffer.toString('base64') });
+      // Binary and oversized attachments are deliberately never base64'd into
+      // the tool result — the payload would inflate by ~33% and reach the
+      // model as unusable text. Following the pattern other MCP servers use
+      // for binary content, return a resource_link (fetchable on demand via
+      // resources/read) alongside the local path in the metadata.
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify(
+              {
+                ...metadata,
+                note: 'Content is not returned inline for this type/size. Read the file at `path` with local tools, or fetch `resourceUri` via resources/read.',
+              },
+              null,
+              2
+            ),
+          },
+          {
+            type: 'resource_link' as const,
+            uri: metadata.resourceUri,
+            name: file.displayName(),
+            mimeType,
+          },
+        ],
+      };
     }
   );
 

--- a/app/internal_packages/mcp-server/specs/mcp-attachment-tools-spec.ts
+++ b/app/internal_packages/mcp-server/specs/mcp-attachment-tools-spec.ts
@@ -1,0 +1,454 @@
+import fs from 'fs';
+import path from 'path';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { Actions, AttachmentStore, DatabaseStore, File, Message } from 'mailspring-exports';
+import { registerTools, registerResources, getAuditLog, clearAuditLog } from '../lib/mcp-tools';
+import { serializeThreadSummary } from '../lib/mcp-serializers';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+// Smallest valid PNG (1x1 transparent pixel), so the image branch is exercised
+// with bytes a client could actually decode.
+const PNG_BYTES = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==',
+  'base64'
+);
+
+const TXT_CONTENTS = 'Hello from the attachment spec.\nSecond line.';
+const PDF_BYTES = Buffer.from('%PDF-1.4 fake pdf bytes for the resource spec');
+
+function makeFile(fields: Partial<ConstructorParameters<typeof File>[0]> = {}) {
+  return new File({
+    id: 'file-1',
+    filename: 'notes.txt',
+    contentType: 'text/plain',
+    size: 42,
+    messageId: null,
+    contentId: null,
+    ...fields,
+  });
+}
+
+function makeMessage(files: File[], fields: { body?: string | null } = {}) {
+  return new Message({
+    id: 'msg-1',
+    accountId: TEST_ACCOUNT_ID,
+    threadId: 'thread-1',
+    subject: 'Attachment fixtures',
+    body: 'body' in fields ? fields.body : '<p>Synced body</p>',
+    files,
+  } as any);
+}
+
+// get_attachment both awaits DatabaseStore.find() directly and calls
+// .include() on it before awaiting, so the stand-in for the ModelQuery is a
+// resolved promise with a pass-through `include`.
+function stubMessageQuery(message: Message | null) {
+  const query: any = Promise.resolve(message);
+  query.include = () => query;
+  return query;
+}
+
+const writtenFixtureDirs: string[] = [];
+
+// Writes contents to the exact on-disk path AttachmentStore resolves for the
+// file — the same location the sync engine writes to when it fetches a body.
+function writeAttachmentToDisk(file: File, contents: Buffer | string) {
+  const filePath = AttachmentStore.pathForFile(file);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, contents);
+  writtenFixtureDirs.push(path.dirname(filePath));
+  return filePath;
+}
+
+// ---------------------------------------------------------------------------
+// Specs
+// ---------------------------------------------------------------------------
+
+describe('MCP attachment tools', function () {
+  beforeEach(function () {
+    this.server = new McpServer({ name: 'mailspring-spec', version: '0.0.1' });
+    registerTools(this.server);
+    registerResources(this.server);
+    this.client = new Client({ name: 'mcp-attachment-spec', version: '0.0.1' });
+
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    waitsForPromise(() =>
+      Promise.all([this.server.connect(serverTransport), this.client.connect(clientTransport)])
+    );
+  });
+
+  afterEach(function () {
+    clearAuditLog();
+    while (writtenFixtureDirs.length > 0) {
+      fs.rmSync(writtenFixtureDirs.pop(), { recursive: true, force: true });
+    }
+    waitsForPromise(() => this.client.close());
+  });
+
+  const callGetAttachment = function (client: Client, message: Message, file: File) {
+    return client.callTool({
+      name: 'get_attachment',
+      arguments: { messageId: message.id, fileId: file.id },
+    });
+  };
+
+  // For specs that pump the faked clock: the SDK's own request timeout runs
+  // on that same clock, so give the request a deadline the pumping can't
+  // reach, and fold rejections into the result so nothing goes unhandled.
+  const callGetAttachmentWhilePumping = function (
+    client: Client,
+    message: Message,
+    file: File,
+    onResult: (result: any) => void
+  ) {
+    client
+      .callTool(
+        { name: 'get_attachment', arguments: { messageId: message.id, fileId: file.id } },
+        undefined,
+        { timeout: 60 * 60 * 1000 }
+      )
+      .then(onResult, (err) =>
+        onResult({
+          isError: true,
+          content: [{ type: 'text', text: JSON.stringify({ error: `client error: ${err}` }) }],
+        })
+      );
+  };
+
+  describe('get_attachment', function () {
+    it('is listed with the other tools', function () {
+      waitsForPromise(async () => {
+        const { tools } = await this.client.listTools();
+        expect(tools.map((t) => t.name)).toContain('get_attachment');
+      });
+    });
+
+    it('returns text attachments inline as UTF-8', function () {
+      const file = makeFile({ id: 'file-txt', filename: 'notes.txt', contentType: 'text/plain' });
+      const message = makeMessage([file]);
+      spyOn(DatabaseStore, 'find').andCallFake(() => stubMessageQuery(message));
+      writeAttachmentToDisk(file, TXT_CONTENTS);
+
+      waitsForPromise(async () => {
+        const result: any = await callGetAttachment(this.client, message, file);
+        expect(result.isError).toBeFalsy();
+        expect(result.content.length).toBe(1);
+
+        const payload = JSON.parse(result.content[0].text);
+        expect(payload.filename).toBe('notes.txt');
+        expect(payload.contentType).toBe('text/plain');
+        expect(payload.size).toBe(Buffer.byteLength(TXT_CONTENTS));
+        expect(payload.data).toBe(TXT_CONTENTS);
+        expect(payload.path).toBe(AttachmentStore.pathForFile(file));
+        expect(payload.resourceUri).toBe(`attachment://${message.id}/${file.id}`);
+      });
+    });
+
+    it('strips content-type parameters and falls back to the extension for octet-stream', function () {
+      const file = makeFile({
+        id: 'file-json',
+        filename: 'report.json',
+        contentType: 'application/octet-stream',
+      });
+      const message = makeMessage([file]);
+      spyOn(DatabaseStore, 'find').andCallFake(() => stubMessageQuery(message));
+      writeAttachmentToDisk(file, '{"ok": true}');
+
+      waitsForPromise(async () => {
+        const result: any = await callGetAttachment(this.client, message, file);
+        const payload = JSON.parse(result.content[0].text);
+        expect(payload.contentType).toBe('application/json');
+        expect(payload.data).toBe('{"ok": true}');
+      });
+    });
+
+    it('returns images as an MCP image content block after the metadata', function () {
+      const file = makeFile({ id: 'file-png', filename: 'pixel.png', contentType: 'image/png' });
+      const message = makeMessage([file]);
+      spyOn(DatabaseStore, 'find').andCallFake(() => stubMessageQuery(message));
+      writeAttachmentToDisk(file, PNG_BYTES);
+
+      waitsForPromise(async () => {
+        const result: any = await callGetAttachment(this.client, message, file);
+        expect(result.isError).toBeFalsy();
+        expect(result.content.length).toBe(2);
+        expect(result.content[0].type).toBe('text');
+        expect(result.content[1].type).toBe('image');
+        expect(result.content[1].mimeType).toBe('image/png');
+        expect(result.content[1].data).toBe(PNG_BYTES.toString('base64'));
+      });
+    });
+
+    it('returns binary attachments as a resource_link with no inline payload', function () {
+      const file = makeFile({
+        id: 'file-pdf',
+        filename: 'invoice.pdf',
+        contentType: 'application/pdf',
+      });
+      const message = makeMessage([file]);
+      spyOn(DatabaseStore, 'find').andCallFake(() => stubMessageQuery(message));
+      writeAttachmentToDisk(file, PDF_BYTES);
+
+      waitsForPromise(async () => {
+        const result: any = await callGetAttachment(this.client, message, file);
+        expect(result.isError).toBeFalsy();
+        expect(result.content.length).toBe(2);
+
+        const payload = JSON.parse(result.content[0].text);
+        expect(payload.data).toBeUndefined();
+        expect(payload.path).toBe(AttachmentStore.pathForFile(file));
+
+        expect(result.content[1].type).toBe('resource_link');
+        expect(result.content[1].uri).toBe(payload.resourceUri);
+        expect(result.content[1].name).toBe('invoice.pdf');
+        expect(result.content[1].mimeType).toBe('application/pdf');
+      });
+    });
+
+    it('returns a resource_link instead of inlining text larger than 200KB', function () {
+      const file = makeFile({ id: 'file-big', filename: 'big.txt', contentType: 'text/plain' });
+      const message = makeMessage([file]);
+      spyOn(DatabaseStore, 'find').andCallFake(() => stubMessageQuery(message));
+      writeAttachmentToDisk(file, 'a'.repeat(200 * 1024 + 1));
+
+      waitsForPromise(async () => {
+        const result: any = await callGetAttachment(this.client, message, file);
+        const payload = JSON.parse(result.content[0].text);
+        expect(payload.data).toBeUndefined();
+        expect(result.content[1].type).toBe('resource_link');
+      });
+    });
+
+    it('fetches the message body and waits for the attachment to appear on disk', function () {
+      const file = makeFile({ id: 'file-late', filename: 'late.txt', contentType: 'text/plain' });
+      const message = makeMessage([file], { body: null });
+      spyOn(DatabaseStore, 'find').andCallFake(() => stubMessageQuery(message));
+
+      // Simulate the sync engine: fetching the body writes the file to disk.
+      spyOn(Actions, 'fetchBodies').andCallFake(() => writeAttachmentToDisk(file, TXT_CONTENTS));
+
+      let result: any = null;
+      runs(function () {
+        callGetAttachmentWhilePumping(this.client, message, file, (r) => (result = r));
+      });
+      // The tool's poll loop sleeps on the (faked) clock — pump it until the
+      // call resolves.
+      waitsFor(
+        function () {
+          advanceClock(500);
+          return result !== null;
+        },
+        'get_attachment to resolve',
+        4000
+      );
+      runs(function () {
+        expect(Actions.fetchBodies).toHaveBeenCalledWith([message]);
+        expect(result.isError).toBeFalsy();
+        expect(JSON.parse(result.content[0].text).data).toBe(TXT_CONTENTS);
+      });
+    });
+
+    it('errors helpfully when the attachment cannot be downloaded', function () {
+      const file = makeFile({ id: 'file-gone', filename: 'gone.txt', contentType: 'text/plain' });
+      const message = makeMessage([file]);
+      spyOn(DatabaseStore, 'find').andCallFake(() => stubMessageQuery(message));
+      spyOn(Actions, 'fetchBodies');
+
+      let result: any = null;
+      runs(function () {
+        callGetAttachmentWhilePumping(this.client, message, file, (r) => (result = r));
+      });
+      // The body is already local, so the tool gives up after its short
+      // real-time recheck deadline rather than the full download timeout.
+      waitsFor(
+        function () {
+          advanceClock(500);
+          return result !== null;
+        },
+        'get_attachment to give up',
+        10000
+      );
+      runs(function () {
+        expect(result.isError).toBe(true);
+        expect(JSON.parse(result.content[0].text).error).toContain('could not be downloaded');
+      });
+    });
+
+    it('errors when the message has no attachment with the given id', function () {
+      const message = makeMessage([makeFile({ id: 'file-real' })]);
+      spyOn(DatabaseStore, 'find').andCallFake(() => stubMessageQuery(message));
+
+      waitsForPromise(async () => {
+        const result: any = await this.client.callTool({
+          name: 'get_attachment',
+          arguments: { messageId: message.id, fileId: 'file-bogus' },
+        });
+        expect(result.isError).toBe(true);
+        expect(JSON.parse(result.content[0].text).error).toBe(
+          `Message 'msg-1' has no attachment with id 'file-bogus'`
+        );
+      });
+    });
+
+    it('reports an unknown message as not found', function () {
+      spyOn(DatabaseStore, 'find').andCallFake(() => stubMessageQuery(null));
+
+      waitsForPromise(async () => {
+        const result: any = await this.client.callTool({
+          name: 'get_attachment',
+          arguments: { messageId: 'msg-1', fileId: 'file-1' },
+        });
+        expect(result.isError).toBe(true);
+        expect(JSON.parse(result.content[0].text).error).toBe(`Message 'msg-1' not found`);
+      });
+    });
+
+    it('reports an excluded account with the same message as an unknown id', function () {
+      const file = makeFile();
+      const message = makeMessage([file]);
+      spyOn(DatabaseStore, 'find').andCallFake(() => stubMessageQuery(message));
+      AppEnv.config.set('core.mcp.enabledAccounts', {
+        'some-other-account': { enabled: true },
+      });
+
+      waitsForPromise(async () => {
+        const result: any = await callGetAttachment(this.client, message, file);
+        expect(result.isError).toBe(true);
+        // Deliberately identical to the unknown-id error so callers can't
+        // probe for the existence of excluded data.
+        expect(JSON.parse(result.content[0].text).error).toBe(`Message 'msg-1' not found`);
+      });
+    });
+
+    it('records calls in the audit log', function () {
+      const file = makeFile({ id: 'file-audit', filename: 'audit.txt' });
+      const message = makeMessage([file]);
+      spyOn(DatabaseStore, 'find').andCallFake(() => stubMessageQuery(message));
+      writeAttachmentToDisk(file, TXT_CONTENTS);
+
+      waitsForPromise(async () => {
+        await callGetAttachment(this.client, message, file);
+        const entries = getAuditLog();
+        const entry = entries[entries.length - 1];
+        expect(entry.toolName).toBe('get_attachment');
+        expect(entry.resultSummary).toBe('ok');
+      });
+    });
+  });
+
+  describe('get_message attachment metadata', function () {
+    it('lists each attachment in the files array', function () {
+      const file = makeFile({ id: 'file-meta', filename: 'photo.png', contentType: 'image/png' });
+      const message = makeMessage([file]);
+      spyOn(DatabaseStore, 'find').andCallFake(() => stubMessageQuery(message));
+
+      waitsForPromise(async () => {
+        const result: any = await this.client.callTool({
+          name: 'get_message',
+          arguments: { messageId: message.id },
+        });
+        const payload = JSON.parse(result.content[0].text);
+        expect(payload.files).toEqual([
+          {
+            id: 'file-meta',
+            filename: 'photo.png',
+            contentType: 'image/png',
+            size: 42,
+            isInline: false,
+          },
+        ]);
+      });
+    });
+  });
+
+  describe('attachment resource', function () {
+    it('advertises the attachment resource template', function () {
+      waitsForPromise(async () => {
+        const { resourceTemplates } = await this.client.listResourceTemplates();
+        expect(resourceTemplates.map((t) => t.uriTemplate)).toContain(
+          'attachment://{messageId}/{fileId}'
+        );
+      });
+    });
+
+    it('serves raw attachment bytes as a blob via resources/read', function () {
+      const file = makeFile({
+        id: 'file-blob',
+        filename: 'invoice.pdf',
+        contentType: 'application/pdf',
+      });
+      const message = makeMessage([file]);
+      spyOn(DatabaseStore, 'find').andCallFake(() => stubMessageQuery(message));
+      writeAttachmentToDisk(file, PDF_BYTES);
+
+      waitsForPromise(async () => {
+        const { contents }: any = await this.client.readResource({
+          uri: `attachment://${message.id}/${file.id}`,
+        });
+        expect(contents.length).toBe(1);
+        expect(contents[0].mimeType).toBe('application/pdf');
+        expect(Buffer.from(contents[0].blob, 'base64').equals(PDF_BYTES)).toBe(true);
+
+        const entries = getAuditLog();
+        const entry = entries[entries.length - 1];
+        expect(entry.toolName).toBe('resources/read');
+        expect(entry.resultSummary).toBe('ok');
+      });
+    });
+
+    it('rejects reads for attachments that are not on disk', function () {
+      const file = makeFile({ id: 'file-nodisk', filename: 'nodisk.pdf' });
+      const message = makeMessage([file]);
+      spyOn(DatabaseStore, 'find').andCallFake(() => stubMessageQuery(message));
+
+      waitsForPromise(() =>
+        this.client.readResource({ uri: `attachment://${message.id}/${file.id}` }).then(
+          () => {
+            throw new Error('Expected readResource to reject');
+          },
+          (err) => expect(`${err}`).toContain('has not been downloaded')
+        )
+      );
+    });
+
+    it('rejects reads for excluded accounts without confirming existence', function () {
+      const file = makeFile({ id: 'file-denied' });
+      const message = makeMessage([file]);
+      spyOn(DatabaseStore, 'find').andCallFake(() => stubMessageQuery(message));
+      writeAttachmentToDisk(file, PDF_BYTES);
+      AppEnv.config.set('core.mcp.enabledAccounts', {
+        'some-other-account': { enabled: true },
+      });
+
+      waitsForPromise(() =>
+        this.client.readResource({ uri: `attachment://${message.id}/${file.id}` }).then(
+          () => {
+            throw new Error('Expected readResource to reject');
+          },
+          // Deliberately the same phrasing as an unknown message id, so
+          // callers can't probe for the existence of excluded data.
+          (err) => expect(`${err}`).toContain(`Message 'msg-1' not found`)
+        )
+      );
+    });
+  });
+
+  describe('thread summaries', function () {
+    it('include the attachment count', function () {
+      const summary = serializeThreadSummary({
+        id: 'thread-1',
+        subject: 'S',
+        accountId: TEST_ACCOUNT_ID,
+        attachmentCount: 3,
+        categories: [],
+        participants: [],
+      } as any);
+      expect(summary.attachmentCount).toBe(3);
+    });
+  });
+});

--- a/app/internal_packages/mcp-server/specs/mcp-http-server-spec.ts
+++ b/app/internal_packages/mcp-server/specs/mcp-http-server-spec.ts
@@ -1,0 +1,82 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { McpHttpServer } from '../lib/mcp-http-server';
+
+// A fixed high port — the spec process is the only thing binding it, and
+// start() needs the concrete port up front for its DNS-rebinding allowlist.
+const PORT = 21983;
+const TOKEN = 'spec-bearer-token';
+
+const initializeBody = JSON.stringify({
+  jsonrpc: '2.0',
+  id: 1,
+  method: 'initialize',
+  params: {
+    protocolVersion: '2025-06-18',
+    capabilities: {},
+    clientInfo: { name: 'mcp-http-spec', version: '0.0.1' },
+  },
+});
+
+function postInitialize(headers: Record<string, string>) {
+  return fetch(`http://127.0.0.1:${PORT}/mcp`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json, text/event-stream',
+      ...headers,
+    },
+    body: initializeBody,
+  });
+}
+
+describe('McpHttpServer', function () {
+  beforeEach(function () {
+    this.server = new McpHttpServer();
+    waitsForPromise(() => this.server.start(PORT, () => TOKEN));
+  });
+
+  afterEach(function () {
+    waitsForPromise(() => this.server.stop());
+  });
+
+  it('rejects requests without a valid bearer token', function () {
+    waitsForPromise(async () => {
+      const missing = await postInitialize({});
+      expect(missing.status).toBe(401);
+
+      const wrong = await postInitialize({ Authorization: 'Bearer not-the-token' });
+      expect(wrong.status).toBe(401);
+    });
+  });
+
+  it('rejects paths other than /mcp', function () {
+    waitsForPromise(async () => {
+      const res = await fetch(`http://127.0.0.1:${PORT}/other`, {
+        headers: { Authorization: `Bearer ${TOKEN}` },
+      });
+      expect(res.status).toBe(404);
+    });
+  });
+
+  it('serves the tools and the attachment resource to an authenticated MCP client', function () {
+    waitsForPromise(async () => {
+      const transport = new StreamableHTTPClientTransport(new URL(`http://127.0.0.1:${PORT}/mcp`), {
+        requestInit: { headers: { Authorization: `Bearer ${TOKEN}` } },
+      });
+      const client = new Client({ name: 'mcp-http-spec', version: '0.0.1' });
+      await client.connect(transport);
+      try {
+        const { tools } = await client.listTools();
+        expect(tools.map((t) => t.name)).toContain('get_attachment');
+
+        const { resourceTemplates } = await client.listResourceTemplates();
+        expect(resourceTemplates.map((t) => t.uriTemplate)).toContain(
+          'attachment://{messageId}/{fileId}'
+        );
+      } finally {
+        await client.close();
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds a `get_attachment` tool to the built-in MCP server package so connected MCP clients (local agents) can view the contents of email attachments, plus the attachment metadata needed to discover them.

### New `get_attachment` tool (read access level)

Given a `messageId` and `fileId`, resolves the attachment on disk and returns MCP-typed content matching how the wider MCP ecosystem handles media (images inline, text as text, binary as resources — never base64 stuffed into a text block):

- **Text-based types** (`text/*`, JSON, XML, SVG, ICS, EML, `+json`/`+xml`) up to 200KB — UTF-8 text in the result JSON's `data` field
- **Images** (PNG/JPEG/GIF/WebP) up to 200KB — returned as a spec `image` content block following the JSON metadata block, so clients can view them directly
- **Everything else, and anything over 200KB** — no inline payload. The result carries the metadata JSON (including the file's local `path` — the server is loopback-only, so every client runs on the same machine and can read it directly) plus a spec `resource_link` content block with an `attachment://<messageId>/<fileId>` URI
- Every result includes a JSON metadata block: `filename`, `contentType`, `size`, `isInline`, `path`, `resourceUri`
- Since providers often report `application/octet-stream` (and files attached to local drafts have no content type at all), the MIME type falls back to a by-extension lookup

If the attachment hasn't been downloaded yet, the tool asks the sync engine for the message body via `Actions.fetchBodies` — attachment files are written to disk as part of body fetch — and polls for the file to appear (30s deadline when the body was never synced, 5s recheck when it was).

### New `attachment://` MCP resource

Clients that can't touch the filesystem fetch the raw bytes on demand by dereferencing the `resource_link` via `resources/read` (registered through a `ResourceTemplate`, which also declares the `resources` capability). This keeps tool results — what reaches the model — free of binary payloads while still making the bytes reachable in-band per the MCP spec. Resource reads pass the same account/folder authorization as `get_attachment` and land in the audit log as `resources/read` entries.

### Attachment discovery

- `get_message` / `get_thread` results now include each message's `files` array (`id`, `filename`, `contentType`, `size`, `isInline`) via a new shared `serializeFile` serializer
- Thread summaries (`search_mail` / `list_threads`) now include `attachmentCount`
- Tool descriptions cross-reference `get_attachment` and `search_mail`'s existing `has:attachment` keyword

### Package conventions followed

- Registered through `defineTool`, so the access-level gate and audit logging apply automatically
- Account/folder authorization via `isMessageAllowed`, using the same "not found" phrasing as existing tools so excluded data's existence isn't confirmed
- `AttachmentStore.pathForFile`'s path-traversal guard is checked before any disk access; the altered-filename fallback mirrors `AttachmentStore._prepareAndResolveFilePath`
- The `ToolResult` type was widened to admit spec `image` and `resource_link` content blocks alongside text

## Test plan

New specs in `app/internal_packages/mcp-server/specs/` run the tools end-to-end through a real `McpServer` and MCP client:

- `mcp-attachment-tools-spec.ts` — drives `get_attachment` over an in-memory MCP transport and asserts on the wire-level content blocks: the UTF-8 text, image block, and `resource_link` branches; the 200KB inline cap; the by-extension content-type fallback; the fetch-and-wait path for attachments not yet on disk (pumping the spec clock through the tool's poll loop); the download-failure error; identical "not found" phrasing for unknown ids and excluded accounts; audit-log entries; `get_message`'s `files` array; and the `attachment://` resource (template advertisement, blob round-trip via `resources/read`, and rejections that don't leak existence)
- `mcp-http-server-spec.ts` — exercises the HTTP layer end-to-end: bearer-token auth (401 on missing/wrong token), unknown-path 404, and a full authenticated `StreamableHTTPClientTransport` session listing the tools and the attachment resource template

Verified locally: full Jasmine suite passes (1604 specs, 0 failures) under xvfb, and `npm run lint:check` and `npm run typecheck` are clean.

---
_Generated by [Claude Code](https://claude.ai/code)_