### PR TITLE
Fix composer crash when backspacing near an unpaired UTF-16 surrogate

### DIFF
--- a/app/src/components/composer-editor/base-block-plugins.tsx
+++ b/app/src/components/composer-editor/base-block-plugins.tsx
@@ -440,9 +440,26 @@ const plugins: ComposerEditorPlugin[] = [
       ) {
         event.preventDefault();
         return;
-      } else {
-        return next();
       }
+
+      // Slate's Backspace command deletes one *character* at a time, and a character
+      // can be two UTF-16 code units wide (eg: a surrogate pair, or a stray unpaired
+      // surrogate left behind by mangled HTML). To do that, it walks backward across
+      // text nodes counting code units until it has consumed enough of them - but if
+      // the document contains fewer code units before the cursor than it needs, it
+      // walks off the start of the document and crashes trying to read `.text` of a
+      // node that doesn't exist. Guard that case by deleting only what's actually
+      // there instead of handing off to Slate's normal command.
+      if (selection.isCollapsed && selection.start && selection.start.key) {
+        const before = document.getOffset(selection.start.key) + selection.start.offset;
+        if (before > 0 && before < 2) {
+          event.preventDefault();
+          editor.deleteBackward(before);
+          return;
+        }
+      }
+
+      return next();
     },
   },
 

--- a/app/src/components/composer-editor/base-block-plugins.tsx
+++ b/app/src/components/composer-editor/base-block-plugins.tsx
@@ -26,6 +26,26 @@ function nodeIsEmpty(node: Node) {
   return false;
 }
 
+// Slate treats a UTF-16 surrogate code unit (0xd800 - 0xdfff, whether paired or a
+// stray unpaired half) as the first code unit of a 2-code-unit-wide character.
+// Mirrors slate's own TextUtils.isSurrogate.
+function isSurrogateCodeUnit(code: number) {
+  return code >= 0xd800 && code <= 0xdfff;
+}
+
+// Returns whether the single code unit immediately before `point` is a surrogate,
+// walking back into the previous text node if `point` sits at the start of its own.
+function isSurrogateCodeUnitBeforeCursor(document: any, point: any) {
+  let node = document.getDescendant(point.key);
+  let offset = point.offset;
+  while (node && offset === 0) {
+    node = document.getPreviousText(node.key);
+    offset = node ? node.text.length : 0;
+  }
+  if (!node) return false;
+  return isSurrogateCodeUnit(node.text.charCodeAt(offset - 1));
+}
+
 function isBlockTypeOrWithinType(value: Value, type: string) {
   if (!value.focusBlock) {
     return false;
@@ -443,16 +463,18 @@ const plugins: ComposerEditorPlugin[] = [
       }
 
       // Slate's Backspace command deletes one *character* at a time, and a character
-      // can be two UTF-16 code units wide (eg: a surrogate pair, or a stray unpaired
-      // surrogate left behind by mangled HTML). To do that, it walks backward across
-      // text nodes counting code units until it has consumed enough of them - but if
-      // the document contains fewer code units before the cursor than it needs, it
-      // walks off the start of the document and crashes trying to read `.text` of a
-      // node that doesn't exist. Guard that case by deleting only what's actually
-      // there instead of handing off to Slate's normal command.
+      // is two UTF-16 code units wide when the code unit immediately before the cursor
+      // is a surrogate (eg: a surrogate pair, or a stray unpaired surrogate left behind
+      // by mangled HTML). To find that character, it walks backward across text nodes
+      // counting code units until it has consumed enough of them - but if the document
+      // contains fewer code units before the cursor than it needs, it walks off the
+      // start of the document and crashes trying to read `.text` of a node that doesn't
+      // exist. Guard only that specific case (not ordinary single-code-unit backspaces,
+      // which other plugins like the list editor need to see) by deleting just the
+      // stray code unit ourselves instead of handing off to Slate's normal command.
       if (selection.isCollapsed && selection.start && selection.start.key) {
         const before = document.getOffset(selection.start.key) + selection.start.offset;
-        if (before > 0 && before < 2) {
+        if (before === 1 && isSurrogateCodeUnitBeforeCursor(document, selection.start)) {
           event.preventDefault();
           editor.deleteBackward(before);
           return;


### PR DESCRIPTION
## Summary

Fixes [MAILSPRING-CLIENT-5M](https://foundry-376-llc.sentry.io/issues/MAILSPRING-CLIENT-5M) — `Error: Cannot read properties of null (reading 'text')` in `Commands.deleteBackwardAtRange` (slate). Ongoing since May 2026, 7 users / 121 occurrences.

**What I observed in Sentry:** the culprit is `Commands$1.deleteBackwardAtRange (slate/lib/slate)`, reached from a normal Backspace keypress in the composer. The stack traces (multiple events, all `platform: darwin`) map exactly onto `slate@0.45.1` — the version this app ships (`app/package.json`).

**Root cause:** Slate's Backspace handling deletes one *character* at a time, and a character can be two UTF-16 code units wide — a surrogate pair, or a stray *unpaired* surrogate left behind by mangled/truncated HTML (e.g. an `&#55357;` entity without its matching pair, or an emoji whose two halves end up in separate DOM spans because they carry different marks, which our HTML deserializer can produce). To find that boundary, Slate's `deleteCharBackwardAtRange` walks backward across text nodes counting code units. If the document contains *fewer* code units before the cursor than it needs to consume (i.e. exactly 1 when it needs 2), the walk runs off the very start of the document and dereferences a `null` text node — throwing exactly the error seen in Sentry.

This state is stable: once a draft's first character is a lone surrogate and the cursor sits right after it, *every* subsequent Backspace throws, so the character can never be deleted and the user ends up mashing the key — which matches the event bursts in Sentry (multiple identical crashes within 1-2 seconds per user).

I verified this by reproducing the exact error message against the real `slate@0.45.1` package this app depends on, in a standalone script.

## Fix

Extend the composer's existing "backspace at top of document" guard (`app/src/components/composer-editor/base-block-plugins.tsx`) to also handle the "not enough preceding characters" case: before handing a Backspace off to Slate's command, compute how many characters actually precede the cursor in the document. If there are fewer than Slate's command would try to consume, delete exactly what's there instead, avoiding the walk-off-the-start crash entirely. Normal backspace behavior (anywhere else in a document) is untouched.

Verified against the real `slate` package that:
- The crash reproduces without the guard (same error message as Sentry).
- With the guard, a lone unpaired surrogate at the document start is deleted cleanly.
- With the guard, a split surrogate pair at the crash-triggering offset is handled without throwing.
- Normal backspace elsewhere in a document is unaffected.
- `tsc --noEmit` and `eslint` both pass clean on the changed file.

## Test plan

- [x] `npx tsc -p app/tsconfig.json --noEmit` — passes
- [x] `eslint -c .eslintrc app/src/components/composer-editor/base-block-plugins.tsx` — passes
- [x] Reproduced the exact Sentry error against real `slate@0.45.1`, then confirmed the guard prevents it (lone surrogate, split surrogate pair, and normal-backspace-unaffected cases)
- [ ] Manual verification in the running app was not performed (Electron/native deps couldn't be built in this sandbox)


---
_Generated by [Claude Code](https://claude.ai/code/session_01UusN8jix3Ye8TrU8cWVjKC)_