### PR TITLE
Allow dragging past editable events

### DIFF
--- a/app/internal_packages/main-calendar/lib/core/calendar-drag-utils.ts
+++ b/app/internal_packages/main-calendar/lib/core/calendar-drag-utils.ts
@@ -346,15 +346,6 @@ export function updateDragState(
 }
 
 /**
- * Check if a timestamp is in the past
- * @param timestamp Unix timestamp to check
- * @returns True if the timestamp has passed
- */
-export function isPastDate(timestamp: number): boolean {
-  return timestamp * 1000 < Date.now();
-}
-
-/**
  * Check if an event's time can be changed by drag, resize, or keyboard
  * @param event The event occurrence
  * @param isCalendarReadOnly Whether the calendar containing this event is read-only
@@ -368,11 +359,6 @@ export function canMoveEvent(event: EventOccurrence, isCalendarReadOnly = false)
 
   // Don't allow moving cancelled events
   if (event.isCancelled) {
-    return false;
-  }
-
-  // An in-progress event can still be moved — only a past end time locks it
-  if (isPastDate(occurrenceEndUnix(event))) {
     return false;
   }
 

--- a/app/spec/calendar-drag-utils-spec.ts
+++ b/app/spec/calendar-drag-utils-spec.ts
@@ -3,7 +3,6 @@ import { formatCalendarDate } from '../src/calendar-date';
 // We use a relative path because the plugin is not registered in mailspring-exports.
 import {
   createDragPreviewEvent,
-  isPastDate,
   canMoveEvent,
   snapAllDayTimes,
   createDragState,
@@ -44,31 +43,25 @@ function makeOccurrence(overrides: OccurrenceOverrides = {}): EventOccurrence {
   return isAllDay ? { ...base, isAllDay: true } : { ...base, isAllDay: false, start, end };
 }
 
-describe('isPastDate', function () {
-  it('returns true for a timestamp in the past', function () {
-    expect(isPastDate(Date.now() / 1000 - HOUR)).toBe(true);
-  });
-
-  it('returns false for a timestamp in the future', function () {
-    expect(isPastDate(Date.now() / 1000 + HOUR)).toBe(false);
-  });
-});
-
 describe('canMoveEvent', function () {
   it('allows moving an upcoming event', function () {
     expect(canMoveEvent(makeOccurrence())).toBe(true);
   });
 
-  it('blocks moving an event that has already ended', function () {
+  it('allows moving a past event on an editable calendar', function () {
     const nowUnix = Date.now() / 1000;
     const past = makeOccurrence({ start: nowUnix - 2 * HOUR, end: nowUnix - HOUR });
-    expect(canMoveEvent(past)).toBe(false);
+    expect(canMoveEvent(past)).toBe(true);
   });
 
-  it('allows moving an in-progress event, since only the end time being past locks it', function () {
+  it('allows moving a past all-day event', function () {
     const nowUnix = Date.now() / 1000;
-    const inProgress = makeOccurrence({ start: nowUnix - HOUR, end: nowUnix + HOUR });
-    expect(canMoveEvent(inProgress)).toBe(true);
+    const pastAllDay = makeOccurrence({
+      isAllDay: true,
+      start: nowUnix - 48 * HOUR,
+      end: nowUnix - 24 * HOUR,
+    });
+    expect(canMoveEvent(pastAllDay)).toBe(true);
   });
 
   it('blocks moving an event in a read-only calendar', function () {
@@ -77,26 +70,6 @@ describe('canMoveEvent', function () {
 
   it('blocks moving a cancelled event', function () {
     expect(canMoveEvent(makeOccurrence({ isCancelled: true }))).toBe(false);
-  });
-
-  it('blocks an all-day event only once its day is over', function () {
-    const startOfToday = new Date();
-    startOfToday.setHours(0, 0, 0, 0);
-    const todayStartUnix = startOfToday.getTime() / 1000;
-
-    const today = makeOccurrence({
-      isAllDay: true,
-      start: todayStartUnix,
-      end: todayStartUnix + 24 * HOUR,
-    });
-    expect(canMoveEvent(today)).toBe(true);
-
-    const yesterday = makeOccurrence({
-      isAllDay: true,
-      start: todayStartUnix - 24 * HOUR,
-      end: todayStartUnix - 1,
-    });
-    expect(canMoveEvent(yesterday)).toBe(false);
   });
 });
 


### PR DESCRIPTION
## What

Lets you drag and resize past events on your own calendars. Previously the drag path blocked any event whose end time had passed.

## Why

The lock was drag-only and inconsistent with the rest of the app — you could already re-time a past event through the popover or delete it; you just couldn't drag it. This removes that gate (read-only calendars and cancelled events stay locked), matching the behavior in Apple Calendar and Notion Calendar.

## Testing

`canMoveEvent` specs updated to cover past timed and all-day events as movable, with read-only and cancelled still blocked. Manually verified dragging a past all-day event. Full suite green, typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)