### PR TITLE
Fix all-day drag landing a day early near DST transitions

### DIFF
--- a/app/internal_packages/main-calendar/lib/core/calendar-drag-utils.ts
+++ b/app/internal_packages/main-calendar/lib/core/calendar-drag-utils.ts
@@ -33,6 +33,29 @@ export function snapToInterval(timestamp: number, intervalSeconds: number): numb
  * @param end End timestamp
  * @returns Snapped start and end times
  */
+/**
+ * The unix midnight of the all-day column a horizontal hit-test lands on, given the scope's
+ * bounds and the fraction across it. Date-space on purpose: the column count is derived as a
+ * day difference (so it matches the rendered columns exactly) and the result is a real calendar
+ * day's start, so neither the bucket count nor the resolved day drifts across a DST transition —
+ * unlike `ceil((end - start) / 86400)` buckets and a `start + index * 86400` offset.
+ */
+export function allDayColumnStartUnix(
+  scopeStartUnix: number,
+  scopeEndUnix: number,
+  fraction: number
+): number {
+  const startDate = CalendarDateUtils.calendarDateFromUnix(scopeStartUnix);
+  const numDays =
+    CalendarDateUtils.calendarDaysBetween(
+      startDate,
+      CalendarDateUtils.calendarDateFromUnix(scopeEndUnix)
+    ) + 1;
+  const clamped = Math.max(0, Math.min(1, fraction));
+  const dayIndex = Math.min(Math.floor(clamped * numDays), numDays - 1);
+  return CalendarDateUtils.dayStartUnix(CalendarDateUtils.addCalendarDays(startDate, dayIndex));
+}
+
 export function snapAllDayTimes(start: number, end: number): { start: number; end: number } {
   const snappedStart = moment.unix(start).startOf('day').unix();
   return { start: snappedStart, end: exclusiveDayEnd(end, snappedStart) };

--- a/app/internal_packages/main-calendar/lib/core/calendar-drag-utils.ts
+++ b/app/internal_packages/main-calendar/lib/core/calendar-drag-utils.ts
@@ -26,14 +26,6 @@ export function snapToInterval(timestamp: number, intervalSeconds: number): numb
 }
 
 /**
- * Snap all-day event times to day boundaries.
- * The end is exclusive (midnight after the last day covered), matching RFC 5545 DTEND
- * and the events the sync engine produces.
- * @param start Start timestamp
- * @param end End timestamp
- * @returns Snapped start and end times
- */
-/**
  * The unix midnight of the all-day column a horizontal hit-test lands on, given the scope's
  * bounds and the fraction across it. Date-space on purpose: the column count is derived as a
  * day difference (so it matches the rendered columns exactly) and the result is a real calendar
@@ -56,6 +48,14 @@ export function allDayColumnStartUnix(
   return CalendarDateUtils.dayStartUnix(CalendarDateUtils.addCalendarDays(startDate, dayIndex));
 }
 
+/**
+ * Snap all-day event times to day boundaries.
+ * The end is exclusive (midnight after the last day covered), matching RFC 5545 DTEND
+ * and the events the sync engine produces.
+ * @param start Start timestamp
+ * @param end End timestamp
+ * @returns Snapped start and end times
+ */
 export function snapAllDayTimes(start: number, end: number): { start: number; end: number } {
   const snappedStart = moment.unix(start).startOf('day').unix();
   return { start: snappedStart, end: exclusiveDayEnd(end, snappedStart) };

--- a/app/internal_packages/main-calendar/lib/core/calendar-event-container.tsx
+++ b/app/internal_packages/main-calendar/lib/core/calendar-event-container.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom';
 
 import { EventOccurrence } from './calendar-data-source';
 import { CalendarContainerType } from './calendar-drag-types';
+import { allDayColumnStartUnix } from './calendar-drag-utils';
 
 export interface CalendarEventArgs {
   /** The underlying DOM mouse event */
@@ -184,11 +185,11 @@ export class CalendarEventContainer extends React.Component<CalendarEventContain
         width = rect.width;
         height = rect.height;
 
-        // Calculate which day based on X position as percentage of the week
-        const percentWeek = Math.max(0, Math.min(1, (event.clientX - rect.left) / rect.width));
-        const numDays = Math.ceil((endTime - startTime) / 86400); // seconds per day
-        const dayIndex = Math.min(Math.floor(percentWeek * numDays), numDays - 1);
-        time = startTime + dayIndex * 86400;
+        // Resolve the day in date space so the column count matches what the view rendered and
+        // the result lands on a real calendar midnight — a seconds-based bucket count and offset
+        // both drift a day across a DST transition.
+        const percentWeek = (event.clientX - rect.left) / rect.width;
+        time = allDayColumnStartUnix(startTime, endTime, percentWeek);
         break;
       }
 

--- a/app/spec/calendar-drag-utils-spec.ts
+++ b/app/spec/calendar-drag-utils-spec.ts
@@ -1,4 +1,10 @@
-import { formatCalendarDate } from '../src/calendar-date';
+import {
+  formatCalendarDate,
+  parseCalendarDate,
+  dayStartUnix,
+  nextDayStartUnix,
+  addCalendarDays,
+} from '../src/calendar-date';
 // Import the functions under test directly from the source file.
 // We use a relative path because the plugin is not registered in mailspring-exports.
 import {
@@ -7,6 +13,7 @@ import {
   snapAllDayTimes,
   createDragState,
   updateDragState,
+  allDayColumnStartUnix,
 } from '../internal_packages/main-calendar/lib/core/calendar-drag-utils';
 import { MONTH_VIEW_DRAG_CONFIG } from '../internal_packages/main-calendar/lib/core/calendar-drag-types';
 import {
@@ -272,5 +279,30 @@ describe('createDragPreviewEvent', function () {
       previewEnd: localDay(2026, 6, 25) + 11 * HOUR,
     } as any);
     expect(covered(preview)).toEqual(['2026-06-25', '2026-06-25']);
+  });
+});
+
+
+describe('allDayColumnStartUnix', function () {
+  // Runner is pinned to America/Chicago (scripts/test.js), so a span across 2025-11-02 includes
+  // a 25-hour fall-back day — where a `ceil(seconds/86400)` bucket count and a `start + i*86400`
+  // offset both drift a day. Date-space resolution does not.
+  const firstDate = parseCalendarDate('2025-10-26');
+  const numDays = 21; // week view: DAYS_IN_VIEW (7) + BUFFER_DAYS (7) * 2
+  const lastDate = addCalendarDays(firstDate, numDays - 1);
+  const scopeStart = dayStartUnix(firstDate);
+  const scopeEnd = nextDayStartUnix(lastDate) - 1; // last day's final second, as the view emits
+
+  it('resolves every column to its own calendar midnight across the transition', function () {
+    for (let i = 0; i < numDays; i++) {
+      const fraction = (i + 0.5) / numDays;
+      const expected = dayStartUnix(addCalendarDays(firstDate, i));
+      expect(allDayColumnStartUnix(scopeStart, scopeEnd, fraction)).toBe(expected);
+    }
+  });
+
+  it('clamps out-of-range fractions to the first and last columns', function () {
+    expect(allDayColumnStartUnix(scopeStart, scopeEnd, -0.5)).toBe(dayStartUnix(firstDate));
+    expect(allDayColumnStartUnix(scopeStart, scopeEnd, 1.5)).toBe(dayStartUnix(lastDate));
   });
 });


### PR DESCRIPTION
## What

Fixes all-day drag, resize, and double-click-create landing on the wrong day for a few weeks around each DST transition. Follow-on to the all-day series (#2799, #2805, #2806) — this closes the last place an all-day day was derived from seconds.

## Root cause

The drag hit-test resolved which day the cursor was over by seconds arithmetic (`calendar-event-container.tsx`, the `all-day-area` case):

```ts
const numDays = Math.ceil((endTime - startTime) / 86400);
const dayIndex = Math.min(Math.floor(percentWeek * numDays), numDays - 1);
time = startTime + dayIndex * 86400;
```

Two compounding defects across a fall-back (25-hour) day:

- **Bucket count.** The buffered week scope spans 21 days, but `ceil((end - start) / 86400)` returns 22 once the span includes the extra DST hour — so pixels map on a 22-column scale over 21 rendered columns.
- **Day offset.** `startTime + dayIndex * 86400` adds seconds, not calendar days, so every column past the transition resolves ~an hour early — i.e. the previous day.

The two partly cancel at some pixel positions, so the symptom is patchy. Concrete repro (America/New_York, range from 2025-10-26): column 8 renders Mon 11-03 but resolves Sun 11-02, and every later column is likewise a day early. Affects move, both resize edges, and create; day view has the same skew on its own scale.

## Fix

Resolve the column in date space via a pure helper, `allDayColumnStartUnix`:

```ts
const startDate = calendarDateFromUnix(scopeStartUnix);
const numDays = calendarDaysBetween(startDate, calendarDateFromUnix(scopeEndUnix)) + 1;
const dayIndex = clamp(floor(fraction * numDays), 0, numDays - 1);
return dayStartUnix(addCalendarDays(startDate, dayIndex));
```

The day count is now a `calendarDaysBetween`, so it equals the rendered column count by construction, and the result is a real calendar midnight — neither the bucketing nor the resolved day can drift across a transition. Covers week and day view (both route through `all-day-area`; the helper self-adjusts to the span).

## Scope

The downstream drag pipeline is unchanged — `updateDragState`'s all-day branch was already DST-correct after #2805. `DragState` still carries unix values for all-day, which is fine; reworking it to carry dates end-to-end is a possible later cleanup, not required here (no remaining bug behind it).

## Testing

New discriminating spec exercises every column of a 21-day span straddling the 2025-11-02 fall-back (the test runner is pinned to America/Chicago), asserting each resolves to its own calendar midnight — verified red against the old `ceil`/`* 86400` form. Full suite green, typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)