### PR TITLE
Fix month-view timed drag not preserving time + make timed drag -> all-day work

### DIFF
--- a/app/internal_packages/main-calendar/lib/core/calendar-drag-types.ts
+++ b/app/internal_packages/main-calendar/lib/core/calendar-drag-types.ts
@@ -67,6 +67,13 @@ export interface DragState {
   /** Current preview end time (updated during drag) */
   previewEnd: number;
 
+  /**
+   * Whether the current drop position would make the event all-day — true for an all-day event,
+   * or a timed event dragged onto the all-day row (which converts). Drives the preview's kind
+   * and how the drop persists.
+   */
+  previewIsAllDay: boolean;
+
   /** Time snapping interval in seconds (e.g., 900 for 15 minutes) */
   snapIntervalSeconds: number;
 

--- a/app/internal_packages/main-calendar/lib/core/calendar-drag-utils.ts
+++ b/app/internal_packages/main-calendar/lib/core/calendar-drag-utils.ts
@@ -291,7 +291,8 @@ export function updateDragState(
   // exception times and the RECURRENCE-ID, so a convert would misformat the RID and orphan the
   // exception. A recurring timed event dropped here keeps its time (moves to that day) instead.
   const previewIsAllDay =
-    state.event.isAllDay || (containerType === 'all-day-area' && !state.event.isRecurring);
+    state.event.isAllDay ||
+    (state.mode === 'move' && containerType === 'all-day-area' && !state.event.isRecurring);
 
   switch (state.mode) {
     case 'move': {

--- a/app/internal_packages/main-calendar/lib/core/calendar-drag-utils.ts
+++ b/app/internal_packages/main-calendar/lib/core/calendar-drag-utils.ts
@@ -286,14 +286,19 @@ export function updateDragState(
   const usesDaySnap = containerType !== 'day-column';
   const snapInterval = usesDaySnap ? 86400 : config.snapInterval; // 86400 = 1 day in seconds
   const minDuration = usesDaySnap ? 86400 : config.minDuration;
-  // The all-day row converts a timed event; a month cell preserves the event's kind.
-  const previewIsAllDay = state.event.isAllDay || containerType === 'all-day-area';
+  // The all-day row converts a timed event; a month cell preserves the event's kind. Recurring
+  // events are NOT converted yet: createRecurrenceException threads one isAllDay through both the
+  // exception times and the RECURRENCE-ID, so a convert would misformat the RID and orphan the
+  // exception. A recurring timed event dropped here keeps its time (moves to that day) instead.
+  const previewIsAllDay =
+    state.event.isAllDay || (containerType === 'all-day-area' && !state.event.isRecurring);
 
   switch (state.mode) {
     case 'move': {
-      if (state.event.isAllDay) {
-        // All-day: snap the start, then span the same number of whole days.
-        const numDays = Math.max(1, Math.round(eventDuration / 86400));
+      if (previewIsAllDay) {
+        // Target is all-day. An all-day event keeps its whole-day span; a converting timed
+        // event becomes a single day. Snap the start, then span that many whole days.
+        const numDays = state.event.isAllDay ? Math.max(1, Math.round(eventDuration / 86400)) : 1;
         previewStart = moment.unix(mouseTime).startOf('day').unix();
         // Via the helpers, not a raw add: where the drop day's midnight doesn't exist, add()
         // keeps the 01:00 wall clock and snapAllDayTimes then rounds it up an extra day.
@@ -303,15 +308,10 @@ export function updateDragState(
             numDays - 1
           )
         );
-      } else if (containerType === 'all-day-area') {
-        // Timed event dropped on the all-day row converts to a single all-day day.
-        previewStart = moment.unix(mouseTime).startOf('day').unix();
-        previewEnd = CalendarDateUtils.nextDayStartUnix(
-          CalendarDateUtils.calendarDateFromUnix(previewStart)
-        );
       } else if (usesDaySnap) {
-        // Timed event moved across day cells (month view): shift by whole calendar days and
-        // keep the clock time. moment add() holds 10am at 10am across a DST change.
+        // Timed event on a day-granular surface — a month cell, or a recurring event on the
+        // all-day row (not converted). Shift by whole calendar days and keep the clock time;
+        // moment add() holds 10am at 10am across a DST change.
         const daysDelta = CalendarDateUtils.calendarDaysBetween(
           CalendarDateUtils.calendarDateFromUnix(state.originalStart),
           CalendarDateUtils.calendarDateFromUnix(mouseTime)

--- a/app/internal_packages/main-calendar/lib/core/calendar-drag-utils.ts
+++ b/app/internal_packages/main-calendar/lib/core/calendar-drag-utils.ts
@@ -88,12 +88,12 @@ export function createDragPreviewEvent(dragState: DragState): EventOccurrence {
   // instants; all-day previews carry only the shifted dates.
   const shared = {
     ...event,
-    ...coveredDates(previewStart, previewEnd, event.isAllDay),
+    ...coveredDates(previewStart, previewEnd, dragState.previewIsAllDay),
     id: `${event.id}-drag-preview`,
     isDragPreview: true,
     originalEventId: event.id,
   };
-  return event.isAllDay
+  return dragState.previewIsAllDay
     ? { ...shared, isAllDay: true }
     : { ...shared, isAllDay: false, start: previewStart, end: previewEnd };
 }
@@ -236,6 +236,7 @@ export function createDragState(
     initialMouseY: mouseY,
     previewStart: start,
     previewEnd: end,
+    previewIsAllDay: event.isAllDay,
     snapIntervalSeconds: config.snapInterval,
     isDragging: false,
   };
@@ -285,17 +286,15 @@ export function updateDragState(
   const usesDaySnap = containerType !== 'day-column';
   const snapInterval = usesDaySnap ? 86400 : config.snapInterval; // 86400 = 1 day in seconds
   const minDuration = usesDaySnap ? 86400 : config.minDuration;
+  // The all-day row converts a timed event; a month cell preserves the event's kind.
+  const previewIsAllDay = state.event.isAllDay || containerType === 'all-day-area';
 
   switch (state.mode) {
     case 'move': {
-      // For move, calculate new start by subtracting the click offset from current mouse position
-      // This keeps the event at the same position relative to the mouse cursor
-      // For day-based snapping, ignore click offset since we snap to day boundaries
-      const newStart = usesDaySnap ? mouseTime : mouseTime - state.clickOffset;
-      if (usesDaySnap) {
-        // Day-based move: snap the start, then span the same number of whole days
+      if (state.event.isAllDay) {
+        // All-day: snap the start, then span the same number of whole days.
         const numDays = Math.max(1, Math.round(eventDuration / 86400));
-        previewStart = moment.unix(newStart).startOf('day').unix();
+        previewStart = moment.unix(mouseTime).startOf('day').unix();
         // Via the helpers, not a raw add: where the drop day's midnight doesn't exist, add()
         // keeps the 01:00 wall clock and snapAllDayTimes then rounds it up an extra day.
         previewEnd = CalendarDateUtils.nextDayStartUnix(
@@ -304,8 +303,23 @@ export function updateDragState(
             numDays - 1
           )
         );
+      } else if (containerType === 'all-day-area') {
+        // Timed event dropped on the all-day row converts to a single all-day day.
+        previewStart = moment.unix(mouseTime).startOf('day').unix();
+        previewEnd = CalendarDateUtils.nextDayStartUnix(
+          CalendarDateUtils.calendarDateFromUnix(previewStart)
+        );
+      } else if (usesDaySnap) {
+        // Timed event moved across day cells (month view): shift by whole calendar days and
+        // keep the clock time. moment add() holds 10am at 10am across a DST change.
+        const daysDelta = CalendarDateUtils.calendarDaysBetween(
+          CalendarDateUtils.calendarDateFromUnix(state.originalStart),
+          CalendarDateUtils.calendarDateFromUnix(mouseTime)
+        );
+        previewStart = moment.unix(state.originalStart).add(daysDelta, 'days').unix();
+        previewEnd = previewStart + eventDuration;
       } else {
-        previewStart = snapToInterval(newStart, snapInterval);
+        previewStart = snapToInterval(mouseTime - state.clickOffset, snapInterval);
         previewEnd = previewStart + eventDuration;
       }
       break;
@@ -355,7 +369,8 @@ export function updateDragState(
   if (
     isDragging === state.isDragging &&
     previewStart === state.previewStart &&
-    previewEnd === state.previewEnd
+    previewEnd === state.previewEnd &&
+    previewIsAllDay === state.previewIsAllDay
   ) {
     return state;
   }
@@ -365,6 +380,7 @@ export function updateDragState(
     isDragging,
     previewStart,
     previewEnd,
+    previewIsAllDay,
   };
 }
 

--- a/app/internal_packages/main-calendar/lib/core/mailspring-calendar.tsx
+++ b/app/internal_packages/main-calendar/lib/core/mailspring-calendar.tsx
@@ -585,10 +585,13 @@ export class MailspringCalendar extends React.Component<
       return;
     }
 
-    // Check if times actually changed
+    // Check if the times OR the kind actually changed. A timed event dropped on the all-day
+    // row can convert with identical instants (e.g. a midnight-to-midnight event), so a
+    // times-only check would silently drop the conversion.
     if (
       dragState.previewStart === dragState.originalStart &&
-      dragState.previewEnd === dragState.originalEnd
+      dragState.previewEnd === dragState.originalEnd &&
+      dragState.previewIsAllDay === dragState.event.isAllDay
     ) {
       // No change, just clear state
       this.setState({ dragState: null });

--- a/app/internal_packages/main-calendar/lib/core/mailspring-calendar.tsx
+++ b/app/internal_packages/main-calendar/lib/core/mailspring-calendar.tsx
@@ -768,7 +768,7 @@ export class MailspringCalendar extends React.Component<
       let newStart = dragState.previewStart;
       let newEnd = dragState.previewEnd;
 
-      if (dragState.event.isAllDay) {
+      if (dragState.previewIsAllDay) {
         const snapped = snapAllDayTimes(newStart, newEnd);
         newStart = snapped.start;
         newEnd = snapped.end;
@@ -784,7 +784,7 @@ export class MailspringCalendar extends React.Component<
           dragState.event.recurrenceIdStart ?? occurrenceStartUnix(dragState.event),
         newStart,
         newEnd,
-        isAllDay: dragState.event.isAllDay,
+        isAllDay: dragState.previewIsAllDay,
         isException: dragState.event.isException,
         description:
           dragState.mode === 'move' ? localized('Move event') : localized('Resize event'),

--- a/app/spec/calendar-drag-utils-spec.ts
+++ b/app/spec/calendar-drag-utils-spec.ts
@@ -228,6 +228,47 @@ describe('updateDragState move with day snapping', function () {
   // A midnight-gap block lived here, pinned with moment.tz.setDefault. The move path now
   // computes through calendar-date, which setDefault cannot reach — and the runner's pinned
   // zone transitions at 2am, so it has no missing midnight either. That case is uncovered.
+
+  // Drops a TIMED event, in the given container, and returns the preview range + target kind.
+  function dragMoveTimed(
+    start: number,
+    end: number,
+    mouseTime: number,
+    containerType: 'month-cell' | 'all-day-area'
+  ) {
+    const event = makeOccurrence({ isAllDay: false, start, end });
+    const state = createDragState(
+      event,
+      { mode: 'move', cursor: 'move' },
+      mouseTime,
+      0,
+      0,
+      MONTH_VIEW_DRAG_CONFIG
+    );
+    const dragged = updateDragState(state, mouseTime, 100, 100, containerType, MONTH_VIEW_DRAG_CONFIG);
+    return { start: dragged.previewStart, end: dragged.previewEnd, isAllDay: dragged.previewIsAllDay };
+  }
+
+  it('preserves a timed event\'s clock time when moved across month cells', function () {
+    // 10-11am on Aug 14, dropped on Aug 20 -> 10-11am on Aug 20, still timed.
+    const start = localDay(2026, 8, 14) + 10 * HOUR;
+    const end = localDay(2026, 8, 14) + 11 * HOUR;
+    expect(dragMoveTimed(start, end, localDay(2026, 8, 20), 'month-cell')).toEqual({
+      start: localDay(2026, 8, 20) + 10 * HOUR,
+      end: localDay(2026, 8, 20) + 11 * HOUR,
+      isAllDay: false,
+    });
+  });
+
+  it('converts a timed event to a single all-day day when dropped on the all-day row', function () {
+    const start = localDay(2026, 8, 14) + 10 * HOUR;
+    const end = localDay(2026, 8, 14) + 11 * HOUR;
+    expect(dragMoveTimed(start, end, localDay(2026, 8, 20), 'all-day-area')).toEqual({
+      start: localDay(2026, 8, 20),
+      end: localDay(2026, 8, 21),
+      isAllDay: true,
+    });
+  });
 });
 
 describe('createDragPreviewEvent', function () {
@@ -249,7 +290,9 @@ describe('createDragPreviewEvent', function () {
       event,
       previewStart: localDay(2026, 6, 24),
       previewEnd: localDay(2026, 6, 25),
+      previewIsAllDay: true,
     } as any);
+    expect(preview.isAllDay).toBe(true);
     expect(covered(preview)).toEqual(['2026-06-24', '2026-06-24']);
   });
 
@@ -263,7 +306,9 @@ describe('createDragPreviewEvent', function () {
       event,
       previewStart: localDay(2026, 6, 28),
       previewEnd: localDay(2026, 7, 1),
+      previewIsAllDay: true,
     } as any);
+    expect(preview.isAllDay).toBe(true);
     expect(covered(preview)).toEqual(['2026-06-28', '2026-06-30']);
   });
 
@@ -277,7 +322,25 @@ describe('createDragPreviewEvent', function () {
       event,
       previewStart: localDay(2026, 6, 25) + 10 * HOUR,
       previewEnd: localDay(2026, 6, 25) + 11 * HOUR,
+      previewIsAllDay: false,
     } as any);
+    expect(preview.isAllDay).toBe(false);
+    expect(covered(preview)).toEqual(['2026-06-25', '2026-06-25']);
+  });
+
+  it('renders a converting timed event as an all-day preview', function () {
+    const event = makeOccurrence({
+      isAllDay: false,
+      start: localDay(2026, 6, 21) + 10 * HOUR,
+      end: localDay(2026, 6, 21) + 11 * HOUR,
+    });
+    const preview = createDragPreviewEvent({
+      event,
+      previewStart: localDay(2026, 6, 25),
+      previewEnd: localDay(2026, 6, 26),
+      previewIsAllDay: true,
+    } as any);
+    expect(preview.isAllDay).toBe(true);
     expect(covered(preview)).toEqual(['2026-06-25', '2026-06-25']);
   });
 });

--- a/app/spec/calendar-drag-utils-spec.ts
+++ b/app/spec/calendar-drag-utils-spec.ts
@@ -269,6 +269,35 @@ describe('updateDragState move with day snapping', function () {
       isAllDay: true,
     });
   });
+
+  it('does not convert a RECURRING timed event on the all-day row (keeps its time for now)', function () {
+    // createRecurrenceException can't yet convert a single occurrence (the RECURRENCE-ID would
+    // misformat), so a recurring timed event dropped here keeps its clock time instead.
+    const start = localDay(2026, 8, 14) + 10 * HOUR;
+    const end = localDay(2026, 8, 14) + 11 * HOUR;
+    const event = makeOccurrence({ isAllDay: false, start, end, isRecurring: true });
+    const state = createDragState(
+      event,
+      { mode: 'move', cursor: 'move' },
+      localDay(2026, 8, 20),
+      0,
+      0,
+      MONTH_VIEW_DRAG_CONFIG
+    );
+    const dragged = updateDragState(
+      state,
+      localDay(2026, 8, 20),
+      100,
+      100,
+      'all-day-area',
+      MONTH_VIEW_DRAG_CONFIG
+    );
+    expect(dragged.previewIsAllDay).toBe(false);
+    expect({ start: dragged.previewStart, end: dragged.previewEnd }).toEqual({
+      start: localDay(2026, 8, 20) + 10 * HOUR,
+      end: localDay(2026, 8, 20) + 11 * HOUR,
+    });
+  });
 });
 
 describe('createDragPreviewEvent', function () {

--- a/app/spec/calendar-drag-utils-spec.ts
+++ b/app/spec/calendar-drag-utils-spec.ts
@@ -298,6 +298,33 @@ describe('updateDragState move with day snapping', function () {
       end: localDay(2026, 8, 20) + 11 * HOUR,
     });
   });
+
+  it('does not convert on RESIZE when the cursor drifts over the all-day row', function () {
+    // Week view shares one container for the grid and the all-day strip, so a resize cursor can
+    // stray onto 'all-day-area'. That must not flip a timed event to all-day — only move converts.
+    const event = makeOccurrence({
+      isAllDay: false,
+      start: localDay(2026, 8, 14) + 10 * HOUR,
+      end: localDay(2026, 8, 14) + 12 * HOUR,
+    });
+    const state = createDragState(
+      event,
+      { mode: 'resize-end', cursor: 'ns-resize' },
+      localDay(2026, 8, 14) + 12 * HOUR,
+      0,
+      0,
+      MONTH_VIEW_DRAG_CONFIG
+    );
+    const dragged = updateDragState(
+      state,
+      localDay(2026, 8, 15),
+      100,
+      100,
+      'all-day-area',
+      MONTH_VIEW_DRAG_CONFIG
+    );
+    expect(dragged.previewIsAllDay).toBe(false);
+  });
 });
 
 describe('createDragPreviewEvent', function () {


### PR DESCRIPTION
## What

Fixes month-view drag of a timed event turning it into a 24-hour block, and makes dragging a timed event onto the all-day row convert it to an all-day event.

## Root cause

`updateDragState` decided day-snapping from the *container* (`usesDaySnap = containerType !== 'day-column'`), so a timed event dragged in month view got its start `startOf('day')`'d to midnight and spanned to a whole day. `_persistDragChange` then keyed off the *event* (`isAllDay` still false) and stored that midnight→midnight block as a timed event.

Pre-existing, but #2805 made it visible: the old duration heuristic read the mangled event back as all-day so it hid in the all-day row; with `isAllDay` now from the ICS DATE flag, the same drag renders as a 24-hour grid block.

## Fix

The snap/persist decision now keys off the drop *target*, not the event's original kind. Added `DragState.previewIsAllDay`, read by `updateDragState`, `createDragPreviewEvent`, and `_persistDragChange`. The move case branches on it:

- **all-day event** — unchanged (midnight snap, whole-day span).
- **timed → all-day row** — converts to a single all-day day (`updateEventTimes` writes `VALUE=DATE`).
- **timed → month cell** — moves by whole calendar days *preserving the clock time* (`moment.add(days)`, DST-safe). This is the bug fix.
- **timed → timed grid** — 15-minute snap, unchanged.

## Scope

Two related cases are deliberately kept out, as follow-ups:

- **Recurring events aren't converted.** A recurring timed event dropped on the all-day row keeps its time (moves to that day) rather than converting. `createRecurrenceException` threads one `isAllDay` through both the exception's new times *and* its RECURRENCE-ID, but a convert needs those to disagree — the times go DATE while the RID must stay the original timed slot — so converting would misformat the RID and orphan the exception. That needs a real fix, not a flag.
- **The reverse direction** — dragging an all-day event *into* the timed grid — is a separate follow-up (touches all-day-event behavior, needs a default converted duration).

Both are gated/omitted rather than shipped as asymmetric or broken halves.

## Testing

Discriminating specs for each behavior: a timed event moved across month cells preserves its clock time (verified red against the old midnight-snap), a timed event dropped on the all-day row converts, a *recurring* timed event on the all-day row does **not** convert, and the converting preview renders as all-day. The persist-side conversion relies on the existing `updateEventTimes` (`VALUE=DATE` for `isAllDay: true`) and was verified against an independent client (the converted event appears correctly placed in Notion Calendar, which reads the same synced ICS). Full suite green, typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)