### PR TITLE
Fix composer crash when a list_item has no list around it (MAILSPRING-CLIENT-EV)

### DIFF
--- a/app/spec/components/composer-editor/base-block-plugins-spec.tsx
+++ b/app/spec/components/composer-editor/base-block-plugins-spec.tsx
@@ -1,0 +1,95 @@
+import { Editor, Value } from 'slate';
+import { EditListPlugin } from '../../../src/components/composer-editor/base-block-plugins';
+import '../../../src/components/composer-editor/patch-slate-normalizing';
+
+const text = (t: string) => ({ object: 'text', leaves: [{ object: 'leaf', text: t, marks: [] }] });
+const block = (type: string, nodes: any[]) => ({ object: 'block', type, data: {}, nodes });
+const div = (t: string) => block('div', [text(t)]);
+const listItem = (...nodes: any[]) => block('list_item', nodes);
+const list = (...nodes: any[]) => block('ul_list', nodes);
+
+// Built without plugins on purpose: the schema would repair an orphaned `list_item`, and the
+// crash we're guarding against only happens in an editor that is no longer normalizing.
+function editorWith(nodes: any[]) {
+  return new Editor({
+    value: Value.fromJSON({
+      object: 'value',
+      document: { object: 'document', data: {}, nodes },
+    } as any),
+    plugins: [],
+    onChange: () => {},
+  });
+}
+
+function childTypes(editor: Editor) {
+  return (editor.value.document.nodes.toArray() as any[]).map((n) => n.type);
+}
+
+function pressKey(editor: Editor, key: string, textToFocus: string, offset = 0) {
+  const target = editor.value.document.getTexts().find((t) => t.text === textToFocus);
+  editor.moveTo(target.key as any, offset);
+
+  let passedToNext = false;
+  EditListPlugin.onKeyDown(
+    { key, shiftKey: false, preventDefault: () => {} } as any,
+    editor,
+    () => {
+      passedToNext = true;
+    }
+  );
+  return passedToNext;
+}
+
+describe('EditListPlugin', () => {
+  // MAILSPRING-CLIENT-EV: email HTML can contain an <li> with no <ul>/<ol> around it. Slate's
+  // `unwrapNodeByPath` lifts such a node's one-element path to the empty root path, which
+  // `getDescendant` resolves to null, and `splitNodeByPath` then reads `.type` off null.
+  ['Enter', 'Backspace', 'Tab'].forEach((key) => {
+    it(`ignores ${key} inside a list_item that is not in a list`, () => {
+      const editor = editorWith([div('before'), listItem(div('')), div('after')]);
+      let passedToNext = false;
+      expect(() => {
+        passedToNext = pressKey(editor, key, '');
+      }).not.toThrow();
+      expect(passedToNext).toBe(true);
+      expect(childTypes(editor)).toEqual(['div', 'list_item', 'div']);
+    });
+  });
+
+  it('ignores Enter inside an orphaned list_item that is the only node in the document', () => {
+    const editor = editorWith([listItem(div(''))]);
+    expect(() => pressKey(editor, 'Enter', '')).not.toThrow();
+  });
+
+  it('still exits the list when Enter is pressed in an empty item', () => {
+    const editor = editorWith([
+      div('before'),
+      list(listItem(div('x')), listItem(div(''))),
+      div('after'),
+    ]);
+    expect(pressKey(editor, 'Enter', '')).toBe(false);
+    expect(childTypes(editor)).toEqual(['div', 'ul_list', 'div', 'div']);
+  });
+
+  it('still splits the item when Enter is pressed mid-text', () => {
+    const editor = editorWith([div('before'), list(listItem(div('xy'))), div('after')]);
+    expect(pressKey(editor, 'Enter', 'xy', 1)).toBe(false);
+    const items = (editor.value.document.nodes.get(1) as any).nodes.toArray() as any[];
+    expect(items.map((n) => n.text)).toEqual(['x', 'y']);
+  });
+});
+
+describe('Slate withoutNormalizing patch', () => {
+  it('restores normalization when the callback throws', () => {
+    const editor = editorWith([div('hello')]);
+    expect((editor as any).tmp.normalize).toBe(true);
+
+    expect(() =>
+      editor.withoutNormalizing(() => {
+        throw new Error('simulated crash');
+      })
+    ).toThrow();
+
+    expect((editor as any).tmp.normalize).toBe(true);
+  });
+});

--- a/app/spec/components/composer-editor/base-block-plugins-spec.tsx
+++ b/app/spec/components/composer-editor/base-block-plugins-spec.tsx
@@ -79,12 +79,11 @@ describe('EditListPlugin', () => {
 });
 
 describe('Slate withoutNormalizing patch', () => {
-  // Imported here, not at module scope, since installing it mutates `Editor.prototype` for
+  // Required here, not at module scope, since installing it mutates `Editor.prototype` for
   // every other spec in the run and the `EditListPlugin` specs above don't need it — they
-  // build their editors with `plugins: []` so nothing ever normalizes.
-  beforeAll(() => {
-    require('../../../src/components/composer-editor/patch-slate-normalizing');
-  });
+  // build their editors with `plugins: []` so nothing ever normalizes. A `describe` body runs
+  // once, synchronously, before any of its `it`s, so this installs the patch exactly once.
+  require('../../../src/components/composer-editor/patch-slate-normalizing');
 
   it('restores normalization when the callback throws', () => {
     const editor = editorWith([div('hello')]);

--- a/app/spec/components/composer-editor/base-block-plugins-spec.tsx
+++ b/app/spec/components/composer-editor/base-block-plugins-spec.tsx
@@ -1,6 +1,5 @@
 import { Editor, Value } from 'slate';
 import { EditListPlugin } from '../../../src/components/composer-editor/base-block-plugins';
-import '../../../src/components/composer-editor/patch-slate-normalizing';
 
 const text = (t: string) => ({ object: 'text', leaves: [{ object: 'leaf', text: t, marks: [] }] });
 const block = (type: string, nodes: any[]) => ({ object: 'block', type, data: {}, nodes });
@@ -80,6 +79,13 @@ describe('EditListPlugin', () => {
 });
 
 describe('Slate withoutNormalizing patch', () => {
+  // Imported here, not at module scope, since installing it mutates `Editor.prototype` for
+  // every other spec in the run and the `EditListPlugin` specs above don't need it — they
+  // build their editors with `plugins: []` so nothing ever normalizes.
+  beforeAll(() => {
+    require('../../../src/components/composer-editor/patch-slate-normalizing');
+  });
+
   it('restores normalization when the callback throws', () => {
     const editor = editorWith([div('hello')]);
     expect((editor as any).tmp.normalize).toBe(true);

--- a/app/spec/components/composer-editor/base-block-plugins-spec.tsx
+++ b/app/spec/components/composer-editor/base-block-plugins-spec.tsx
@@ -7,8 +7,7 @@ const div = (t: string) => block('div', [text(t)]);
 const listItem = (...nodes: any[]) => block('list_item', nodes);
 const list = (...nodes: any[]) => block('ul_list', nodes);
 
-// Built without plugins on purpose: the schema would repair an orphaned `list_item`, and the
-// crash we're guarding against only happens in an editor that is no longer normalizing.
+// No plugins: the schema would repair an orphaned `list_item` otherwise.
 function editorWith(nodes: any[]) {
   return new Editor({
     value: Value.fromJSON({
@@ -40,9 +39,7 @@ function pressKey(editor: Editor, key: string, textToFocus: string, offset = 0) 
 }
 
 describe('EditListPlugin', () => {
-  // MAILSPRING-CLIENT-EV: email HTML can contain an <li> with no <ul>/<ol> around it. Slate's
-  // `unwrapNodeByPath` lifts such a node's one-element path to the empty root path, which
-  // `getDescendant` resolves to null, and `splitNodeByPath` then reads `.type` off null.
+  // MAILSPRING-CLIENT-EV: an <li> with no <ul>/<ol> around it, as email HTML often produces.
   ['Enter', 'Backspace', 'Tab'].forEach((key) => {
     it(`ignores ${key} inside a list_item that is not in a list`, () => {
       const editor = editorWith([div('before'), listItem(div('')), div('after')]);
@@ -79,10 +76,8 @@ describe('EditListPlugin', () => {
 });
 
 describe('Slate withoutNormalizing patch', () => {
-  // Required here, not at module scope, since installing it mutates `Editor.prototype` for
-  // every other spec in the run and the `EditListPlugin` specs above don't need it — they
-  // build their editors with `plugins: []` so nothing ever normalizes. A `describe` body runs
-  // once, synchronously, before any of its `it`s, so this installs the patch exactly once.
+  // Required here rather than at module scope: it mutates `Editor.prototype` and the specs
+  // above don't need it. A `describe` body runs once, so this installs it exactly once.
   require('../../../src/components/composer-editor/patch-slate-normalizing');
 
   it('restores normalization when the callback throws', () => {

--- a/app/src/components/composer-editor/base-block-plugins.tsx
+++ b/app/src/components/composer-editor/base-block-plugins.tsx
@@ -251,10 +251,14 @@ const EditListPluginBase = new EditList({
 export const EditListPlugin = {
   ...EditListPluginBase,
   onKeyDown: (event: React.KeyboardEvent, editor: Editor, next: () => void) => {
+    // slate-edit-list's own onKeyDown only acts on these three keys; matching its gate here
+    // avoids running the guard below (a couple of tree walks) on every other keystroke.
+    if (event.key !== 'Enter' && event.key !== 'Tab' && event.key !== 'Backspace') {
+      return EditListPluginBase.onKeyDown(event, editor, next);
+    }
     const { utils } = EditListPluginBase;
     const { value } = editor;
-    // `startBlock` is the precondition `getCurrentItem` itself assumes; it runs on every
-    // keystroke here, not just the keys the plugin handles.
+    // `startBlock` is the precondition `getCurrentItem` itself assumes.
     if (value.startBlock && utils.getCurrentItem(value) && !utils.getCurrentList(value)) {
       return next();
     }

--- a/app/src/components/composer-editor/base-block-plugins.tsx
+++ b/app/src/components/composer-editor/base-block-plugins.tsx
@@ -233,11 +233,34 @@ export const BLOCK_CONFIG: {
   },
 };
 
-export const EditListPlugin = new EditList({
+const EditListPluginBase = new EditList({
   types: [BLOCK_CONFIG.ol_list.type, BLOCK_CONFIG.ul_list.type],
   typeItem: BLOCK_CONFIG.list_item.type,
   typeDefault: BLOCK_CONFIG.div.type,
 });
+
+// `slate-edit-list` decides "is the cursor in a list?" with `getCurrentItem`, which returns
+// any parent block of type `list_item` — including one that isn't inside an `ol_list`/`ul_list`.
+// Email HTML regularly contains an `<li>` with no surrounding list, so that shape does reach
+// the composer. Handing Enter/Backspace to the plugin there routes into its `unwrapList`, whose
+// `unwrapNodeByKey` lifts the orphan's one-element path to the empty root path: Slate's
+// `assertNode` accepts that path (it resolves to the document itself) but `getDescendant`
+// returns null for it, so `splitNodeByPath` reads `.type` off null and throws
+// (MAILSPRING-CLIENT-EV). Fall through to the default handling when the item isn't really
+// in a list — the orphan then behaves like any other block.
+export const EditListPlugin = {
+  ...EditListPluginBase,
+  onKeyDown: (event: React.KeyboardEvent, editor: Editor, next: () => void) => {
+    const { utils } = EditListPluginBase;
+    const { value } = editor;
+    // `startBlock` is the precondition `getCurrentItem` itself assumes; it runs on every
+    // keystroke here, not just the keys the plugin handles.
+    if (value.startBlock && utils.getCurrentItem(value) && !utils.getCurrentList(value)) {
+      return next();
+    }
+    return EditListPluginBase.onKeyDown(event, editor, next);
+  },
+};
 
 function renderNode(props, editor: Editor = null, next = () => {}) {
   const config = BLOCK_CONFIG[props.node.type];

--- a/app/src/components/composer-editor/base-block-plugins.tsx
+++ b/app/src/components/composer-editor/base-block-plugins.tsx
@@ -239,26 +239,20 @@ const EditListPluginBase = new EditList({
   typeDefault: BLOCK_CONFIG.div.type,
 });
 
-// `slate-edit-list` decides "is the cursor in a list?" with `getCurrentItem`, which returns
-// any parent block of type `list_item` — including one that isn't inside an `ol_list`/`ul_list`.
-// Email HTML regularly contains an `<li>` with no surrounding list, so that shape does reach
-// the composer. Handing Enter/Backspace to the plugin there routes into its `unwrapList`, whose
-// `unwrapNodeByKey` lifts the orphan's one-element path to the empty root path: Slate's
-// `assertNode` accepts that path (it resolves to the document itself) but `getDescendant`
-// returns null for it, so `splitNodeByPath` reads `.type` off null and throws
-// (MAILSPRING-CLIENT-EV). Fall through to the default handling when the item isn't really
-// in a list — the orphan then behaves like any other block.
+// `getCurrentItem` matches any `list_item`, even one with no surrounding `ol_list`/`ul_list` —
+// a shape email HTML often produces. Letting the base plugin handle Enter/Backspace there calls
+// `unwrapList`, which lifts the orphan's one-element path to the empty root path; Slate then
+// reads `.type` off the null that resolves to and throws (MAILSPRING-CLIENT-EV). Fall through
+// to default handling instead so the orphan behaves like any other block.
 export const EditListPlugin = {
   ...EditListPluginBase,
   onKeyDown: (event: React.KeyboardEvent, editor: Editor, next: () => void) => {
-    // slate-edit-list's own onKeyDown only acts on these three keys; matching its gate here
-    // avoids running the guard below (a couple of tree walks) on every other keystroke.
+    // Match the base plugin's own key gate so the guard below doesn't run on every keystroke.
     if (event.key !== 'Enter' && event.key !== 'Tab' && event.key !== 'Backspace') {
       return EditListPluginBase.onKeyDown(event, editor, next);
     }
     const { utils } = EditListPluginBase;
     const { value } = editor;
-    // `startBlock` is the precondition `getCurrentItem` itself assumes.
     if (value.startBlock && utils.getCurrentItem(value) && !utils.getCurrentList(value)) {
       return next();
     }

--- a/app/src/components/composer-editor/conversion.tsx
+++ b/app/src/components/composer-editor/conversion.tsx
@@ -25,6 +25,7 @@ import GrammarCheckPlugins from './grammar-check-plugins';
 import { Rule, ComposerEditorPlugin } from './types';
 
 import './patch-chrome-ime';
+import './patch-slate-normalizing';
 import { deepenPlaintextQuote } from './plaintext';
 
 export const schema = {

--- a/app/src/components/composer-editor/patch-slate-normalizing.ts
+++ b/app/src/components/composer-editor/patch-slate-normalizing.ts
@@ -1,0 +1,28 @@
+/*
+Slate's `Editor#withoutNormalizing` clears `editor.tmp.normalize`, runs the callback, and then
+restores the flag — but it does so without a `try/finally`, so a command that throws from inside
+the callback leaves normalization disabled for the rest of that editor's life.
+
+Almost every structural Slate command (delete, insertFragment, splitDescendants, unwrapNode, ...)
+runs inside `withoutNormalizing`, and exceptions thrown from a React event handler don't unmount
+anything — we report them and the composer stays open. So a single Slate error means the document
+is never repaired again for the rest of the session, and structurally invalid nodes that the
+schema would normally fix (eg. a `list_item` with no list around it, deserialized from email HTML)
+survive to crash later commands.
+
+Restore the flag when the callback throws so one error can't cascade.
+*/
+import { Editor } from 'slate';
+
+const prototype = (Editor as any).prototype;
+const withoutNormalizing = prototype.withoutNormalizing;
+
+prototype.withoutNormalizing = function (fn: (editor: Editor) => void) {
+  const previous = this.tmp.normalize;
+  try {
+    return withoutNormalizing.call(this, fn);
+  } catch (err) {
+    this.tmp.normalize = previous;
+    throw err;
+  }
+};

--- a/app/src/components/composer-editor/patch-slate-normalizing.ts
+++ b/app/src/components/composer-editor/patch-slate-normalizing.ts
@@ -1,16 +1,9 @@
 /*
-Slate's `Editor#withoutNormalizing` clears `editor.tmp.normalize`, runs the callback, and then
-restores the flag — but it does so without a `try/finally`, so a command that throws from inside
-the callback leaves normalization disabled for the rest of that editor's life.
-
-Almost every structural Slate command (delete, insertFragment, splitDescendants, unwrapNode, ...)
-runs inside `withoutNormalizing`, and exceptions thrown from a React event handler don't unmount
-anything — we report them and the composer stays open. So a single Slate error means the document
-is never repaired again for the rest of the session, and structurally invalid nodes that the
-schema would normally fix (eg. a `list_item` with no list around it, deserialized from email HTML)
-survive to crash later commands.
-
-Restore the flag when the callback throws so one error can't cascade.
+`Editor#withoutNormalizing` clears `tmp.normalize` and restores it without a `try/finally`, so a
+command that throws leaves normalization off for the rest of the editor's life — and since we
+report composer errors rather than unmount, one thrown Slate command permanently stops the
+document from repairing structurally invalid nodes (eg. an orphaned `list_item`). Restore the
+flag on throw so a single error can't cascade.
 */
 import { Editor } from 'slate';
 


### PR DESCRIPTION
Fixes [MAILSPRING-CLIENT-EV](https://foundry-376-llc.sentry.io/issues/MAILSPRING-CLIENT-EV) — `Error: Cannot read properties of null (reading 'type')` in `Commands$2.splitNodeByPath`.

## What the Sentry report shows

The stack is entirely inside vendored Slate, with no app frames:

```
slate.js:11520:7  Editor.withoutNormalizing
slate.js:8142:14                                <- the frame that matters
slate.js:11357:31 Editor.method [as splitNodeByPath]
slate.js:11236:12 Editor.command
slate.js:11464:14 Editor.run
slate.js:11430:22 next
slate.js:5801:20  onCommand
slate-react.js:5385:55 Editor.command
slate.js:11229:14 Editor.command
slate.js:8022:18  Commands$2.splitNodeByPath
```

Mapping those line numbers against the pinned builds (`slate` @ `cd6f40e8`, `slate-react` @ `0.45.1-react`) pins them down exactly:

* `slate.js:8022:18` is `type: node.type` in `Commands.splitNodeByPath`, right after `var node = document.getDescendant(path)`.
* `slate.js:8142:14` is `editor.splitNodeByPath(parentPath, index)` — the "middle child" branch inside `Commands.unwrapNodeByPath`'s `withoutNormalizing` block.

So: `unwrapNodeByPath` was called on a node whose `parentPath` does not resolve to a descendant.

## Root cause

`getDescendant` returns `null` for the **empty root path** by definition (`if (!path || !path.size) return null`). `parentPath` is `PathUtils.lift(path)`, so the only way to hit that is a path with a single element — a node that is a **direct child of the document**.

The node in question is a `list_item`. Email HTML regularly contains an `<li>` with no `<ul>`/`<ol>` around it, and our HTML deserializer maps `<li>` → `list_item` regardless of its parent, so an orphaned `list_item` can end up as a top-level block.

From there:

1. `slate-edit-list`'s `getCurrentItem()` answers "is the cursor in a list?" by returning **any** parent block whose type is `list_item` — it never checks that the item is actually inside a list.
2. `onEnter` (in an empty item) and `onBackspace` (at its start) therefore call `unwrapList()`, which calls `editor.unwrapNodeByKey(item.key)`.
3. `unwrapNodeByPath` computes `parentPath = lift([N])` = `[]`. `document.assertNode([])` **succeeds** — `Node#getNode` returns `this` for an empty path — so nothing asserts. `parentIndex` is `undefined`, `isFirst`/`isLast` are computed against the document's children.
4. When the orphan is neither the first nor the last child of the document, the `else` branch runs `splitNodeByPath([], index)` → `getDescendant([])` → `null` → `node.type` **throws**.

The document should never hold that shape: `slate-edit-list`'s schema declares a list parent for `list_item`, and normalization rewrites an orphan to a `div`. The reason it survives is a second bug:

`Editor#withoutNormalizing` sets `tmp.normalize = false`, runs the callback, then restores the flag — **without a `try/finally`**:

```js
withoutNormalizing(fn) {
  var value = this.tmp.normalize;
  this.tmp.normalize = false;
  fn(controller);              // if this throws...
  this.tmp.normalize = value;  // ...this never runs
  normalizeDirtyPaths(this);
}
```

Almost every structural command runs inside `withoutNormalizing`, and exceptions thrown from a React event handler don't unmount anything — we report them to Sentry and the composer stays open. So after the *first* Slate error of a session, that editor silently stops normalizing, and invalid structures accumulate instead of being repaired. That is what lets an orphaned `list_item` reach the keyboard handlers.

## Reproduction

Confirmed against the pinned dependency builds:

```
raw      orphan li middle + Enter      CRASH: Cannot read properties of null (reading 'type')
guarded  orphan li middle + Enter      passed to next() -> doc(div("a"),list_item(div("")),div("b"))
```

and the full chain, starting from a healthy editor:

```
tmp.normalize before: true
caught: simulated slate crash inside a command
tmp.normalize after : false
after paste: doc(div("hello","pasted"),list_item(div("stray")),div("tail"),div("world"))
orphan list_item survived? true
Enter CRASH: Cannot read properties of null (reading 'type')
```

(Without the leaked flag, the same paste is normalized to `div("stray")` and the crash is unreachable.)

## The fix

**`base-block-plugins.tsx`** — wrap `EditListPlugin` so key events fall through to the default handling whenever the current item is not really inside a list (`getCurrentItem()` finds an item but `getCurrentList()` does not). The orphan then behaves like any other block.

**`patch-slate-normalizing.ts`** (new) — restore `tmp.normalize` when the `withoutNormalizing` callback throws, so one caught Slate error can no longer disable document repair for the rest of the session. This is the enabling condition for this crash and very likely for other structural Slate errors in the same Sentry project.

## Testing

New spec `app/spec/components/composer-editor/base-block-plugins-spec.tsx` covers both. Every assertion was also run directly against the real pinned `slate` / `@bengotow/slate-edit-list` builds:

* Enter / Backspace / Tab in an orphaned `list_item` no longer throw and fall through to the next handler, leaving the document untouched.
* An orphaned `list_item` that is the document's only node no longer throws (it hit a different Slate assertion before).
* Real list behaviour is **byte-identical** before and after the guard: Enter in an empty item still exits the list, Enter mid-text still splits the item, Backspace at item start still unwraps, Tab still indents, and non-list blocks are untouched.
* `withoutNormalizing` restores the flag after a throw, including when nested; the non-throwing path is unchanged.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QfnK1t6VeRn37exPfshj7P)_