### PR TITLE
Fix resizing recurring events for "all events"

### DIFF
--- a/app/internal_packages/main-calendar/lib/core/calendar-event-popover.tsx
+++ b/app/internal_packages/main-calendar/lib/core/calendar-event-popover.tsx
@@ -331,8 +331,13 @@ export class CalendarEventPopover extends React.Component<
     ics = ICSEventHelpers.updateRecurrenceRule(ics, rrule);
 
     event.ics = ics;
-    event.recurrenceStart = this.state.start;
-    event.recurrenceEnd = this.state.end;
+    // Re-derive the cached columns from the written ICS, not from state: for a recurring "all
+    // events" edit the master DTSTART/DTEND are shifted+resized and differ from the edited
+    // occurrence's times (matches modifyAllOccurrences). For a non-recurring edit this equals
+    // state anyway.
+    const { event: savedIcsEvent } = CalendarUtils.parseICSString(ics);
+    event.recurrenceStart = savedIcsEvent.startDate.toJSDate().getTime() / 1000;
+    event.recurrenceEnd = savedIcsEvent.endDate.toJSDate().getTime() / 1000;
 
     Actions.queueTask(
       SyncbackEventTask.forUpdating({

--- a/app/spec/ics-event-helpers-spec.ts
+++ b/app/spec/ics-event-helpers-spec.ts
@@ -755,6 +755,37 @@ describe('ICSEventHelpers.updateRecurringEventTimes', function () {
     expect(result).toContain('20260301T040000Z');
   });
 
+  it('applies a resize to the whole series (extends the master duration)', function () {
+    // Resize the 2nd occurrence from 1h to 2h: start unchanged, end +1h. Before the fix newEnd
+    // was ignored and the master stayed 1h (07:00); now it becomes 2h (08:00).
+    const T_RESIZE_END = Date.UTC(2026, 2, 2, 8, 0, 0) / 1000; // 20260302T080000Z (2h span)
+    const result = ICSEventHelpers.updateRecurringEventTimes(
+      DAILY_STANDUP_ICS,
+      T_OCC2_START,
+      T_OCC2_START, // no move
+      T_RESIZE_END,
+      false
+    );
+    expect(result).toContain('20260301T060000Z'); // DTSTART unchanged
+    expect(result).toContain('20260301T080000Z'); // DTEND now 2h after start
+    expect(result).not.toContain('20260301T070000Z'); // old 1h end gone
+  });
+
+  it('applies a combined move and resize', function () {
+    // Move +2h AND resize to 3h: newStart 08:00, newEnd 11:00.
+    const T_MR_START = Date.UTC(2026, 2, 2, 8, 0, 0) / 1000;
+    const T_MR_END = Date.UTC(2026, 2, 2, 11, 0, 0) / 1000;
+    const result = ICSEventHelpers.updateRecurringEventTimes(
+      DAILY_STANDUP_ICS,
+      T_OCC2_START,
+      T_MR_START,
+      T_MR_END,
+      false
+    );
+    expect(result).toContain('20260301T080000Z'); // DTSTART shifted +2h
+    expect(result).toContain('20260301T110000Z'); // DTEND = new start + 3h
+  });
+
   // These pin the calendar-day SEMANTICS (whole-day moves, exclusive DTEND, month rollover)
   // but not the DST behaviour: this module does plain-Date local arithmetic, which
   // moment.tz.setDefault cannot redirect, and in CI's UTC a whole-day shift is exactly
@@ -812,6 +843,20 @@ describe('ICSEventHelpers.updateRecurringEventTimes', function () {
       );
       expect(result).toContain('DTSTART;VALUE=DATE:20260621');
       expect(result).toContain('DTEND;VALUE=DATE:20260622');
+    });
+
+    it('resizes the series to a longer span', function () {
+      // Extend the 1-day holiday to 3 days (no move). Before the fix newEnd was ignored and it
+      // stayed 1 day; now the exclusive DTEND moves out to cover three days.
+      const result = ICSEventHelpers.updateRecurringEventTimes(
+        YEARLY_ALLDAY_ICS,
+        localMidnight(2026, 6, 21),
+        localMidnight(2026, 6, 21), // no move
+        localMidnight(2026, 6, 24), // 3-day span (exclusive end)
+        true
+      );
+      expect(result).toContain('DTSTART;VALUE=DATE:20260621');
+      expect(result).toContain('DTEND;VALUE=DATE:20260624');
     });
 
     it('carries the move across a month boundary', function () {

--- a/app/src/ics-event-helpers.ts
+++ b/app/src/ics-event-helpers.ts
@@ -803,28 +803,36 @@ export function updateRecurringEventTimes(
   const { event } = parseICSString(ics);
 
   const currentStart = event.startDate.toJSDate().getTime();
-  const currentEnd = event.endDate.toJSDate().getTime();
 
   if (isAllDay) {
-    // A raw millisecond delta is wrong here: moving an occurrence across a spring-forward
-    // day yields 23h, and shifting the master by 23h leaves its date unchanged, so the
-    // series silently doesn't move. Shift the dates themselves instead.
+    // Shift the master start by the same whole days the occurrence moved, then span the new
+    // duration. Shifting by day count (not a ms delta) keeps the series on midnight across a
+    // spring-forward day, where a 23h ms shift would leave the date unchanged and the series
+    // silently wouldn't move.
     const days = calendarDaysBetween(
       calendarDateFromUnix(originalOccurrenceStart),
       calendarDateFromUnix(newStart)
     );
+    const spanDays = calendarDaysBetween(
+      calendarDateFromUnix(newStart),
+      calendarDateFromUnix(newEnd)
+    );
+    const newMasterStart = shiftedDayStartUnix(currentStart / 1000, days);
     return updateEventTimes(ics, {
-      start: shiftedDayStartUnix(currentStart / 1000, days),
-      end: shiftedDayStartUnix(currentEnd / 1000, days),
+      start: newMasterStart,
+      end: shiftedDayStartUnix(newMasterStart, spanDays),
       isAllDay,
     });
   }
 
-  // Timed events keep their wall-clock offset from the occurrence that was moved
+  // Shift the master start by the occurrence's move delta, then apply the new duration, so a
+  // resize (which changes newEnd relative to newStart) actually changes the whole series.
   const deltaMs = (newStart - originalOccurrenceStart) * 1000;
+  const durationMs = (newEnd - newStart) * 1000;
+  const newMasterStart = currentStart + deltaMs;
   return updateEventTimes(ics, {
-    start: (currentStart + deltaMs) / 1000,
-    end: (currentEnd + deltaMs) / 1000,
+    start: newMasterStart / 1000,
+    end: (newMasterStart + durationMs) / 1000,
     isAllDay,
   });
 }


### PR DESCRIPTION
## What

Resizing a recurring event and choosing "All events" now actually changes the series' duration. It was a silent no-op before — the resize appeared to take, then snapped back or reverted after sync.

## Root cause

`updateRecurringEventTimes` shifted the master's DTSTART **and** DTEND by the same start-delta, so `newEnd` was a dead parameter and the duration never changed:

```ts
// timed branch — both shift by the start delta, so duration is preserved
const deltaMs = (newStart - originalOccurrenceStart) * 1000;
return updateEventTimes(ics, {
  start: (currentStart + deltaMs) / 1000,
  end: (currentEnd + deltaMs) / 1000,   // newEnd never read
  isAllDay,
});
```

The two callers then diverged on the cached `recurrenceStart/End` columns, giving two symptoms: `modifyAllOccurrences` re-parses the ICS (so the resize **snapped back** on the next render), while the popover set `recurrenceEnd = state.end` directly (so it **stuck, then reverted after sync**).

## Fix

- **`updateRecurringEventTimes`** now sets the master end to `master's new start + (newEnd − newStart)` — the new duration — in both the timed and all-day branches. A move is unchanged (its `newEnd − newStart` equals the original duration); a resize now propagates to the series. The now-dead `currentEnd` read is removed.
- **The popover "all events" path** re-derives the cached `recurrenceStart/End` from the written ICS (matching `modifyAllOccurrences`) instead of caching the *occurrence's* `state.start/end`. This removes the caller divergence.
- **Undo revives for free** — the resize now changes the ICS, so the pre-change `undoData` differs from the new state (it was previously identical, hence a no-op).

## Scope

The this-occurrence exception save-path caches occurrence times as master columns in the same way — a related bug on a different code path (exception embed, not resize/all-events), left as a tracked follow-up.

## Testing

The coverage gap was the whole reason this hid: every existing fixture passed `newEnd === newStart + master duration`, so the resize path was never exercised. Added three discriminating tests — a timed resize, a combined move+resize, and an all-day resize — each asserting a duration the old code couldn't produce. Manually verified an "All events" resize sticks (drag and popover), including undo. Full suite green, typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)