### PR TITLE
Maintain event selection + bring into view when view switching

### DIFF
--- a/app/internal_packages/main-calendar/lib/core/agenda-view.tsx
+++ b/app/internal_packages/main-calendar/lib/core/agenda-view.tsx
@@ -11,6 +11,7 @@ import {
   eventCoversDate,
   isTimed,
   occurrenceStartUnix,
+  isEventSelected,
 } from './calendar-data-source';
 import { Disposable } from 'rx-core';
 import { calcEventColors, extractMeetingDomain } from './calendar-helpers';
@@ -171,7 +172,7 @@ export class AgendaView extends React.Component<MailspringCalendarViewProps, Age
   _renderEvent(event: EventOccurrence, dayKey: string) {
     const colors = calcEventColors(event.calendarId);
     const meetingDomain = extractMeetingDomain(event.location, event.description);
-    const isSelected = this.props.selectedEvents.some((e) => e.id === event.id);
+    const isSelected = isEventSelected(this.props.selectedEvents, event);
 
     // Use a day-unique id/key so multi-day events don't produce duplicate DOM ids
     const uniqueId = `${event.id}-${dayKey}`;

--- a/app/internal_packages/main-calendar/lib/core/calendar-data-source.ts
+++ b/app/internal_packages/main-calendar/lib/core/calendar-data-source.ts
@@ -41,6 +41,18 @@ export function eventCoversDate(event: EventOccurrence, date: CalendarDate): boo
 }
 
 /**
+ * Whether an occurrence is in the selection, compared by id. Selection holds occurrences captured
+ * at click time; a data refresh gives every occurrence a fresh object identity, so an identity
+ * (`includes`) check silently drops the highlight on the next render.
+ */
+export function isEventSelected(
+  selectedEvents: EventOccurrence[],
+  event: EventOccurrence
+): boolean {
+  return selectedEvents.some((e) => e.id === event.id);
+}
+
+/**
  * Narrowing guard. The app tsconfig omits `strictNullChecks`, so `if (e.isAllDay)` does NOT
  * narrow the union — only `=== true`/`=== false` and a guard like this do. Use it to reach
  * `start`/`end`, which exist on timed occurrences only.
@@ -302,7 +314,7 @@ export function occurrencesForEvents(
 
         const masterIsRecurring = ICSEventHelpers.isRecurringEvent(master.ics);
 
-        [...expanded.events, ...expanded.occurrences].forEach((e, idx) => {
+        [...expanded.events, ...expanded.occurrences].forEach((e) => {
           const start = e.startDate.toJSDate().getTime() / 1000;
           const end = e.endDate.toJSDate().getTime() / 1000;
           // For occurrences, the actual event data is in e.item; for events, e is the event itself
@@ -311,7 +323,10 @@ export function occurrencesForEvents(
 
           occurrences.push(
             occurrenceFromICS({
-              id: `${master.id}-e${idx}`,
+              // Key on the occurrence start, not the expansion index: idx depends on the query
+              // range, so the same occurrence got a different id per view — breaking selection
+              // (and React keys) when switching views. The start is stable across ranges.
+              id: `${master.id}-e${Math.round(start)}`,
               event: master,
               item,
               startTime: e.startDate,

--- a/app/internal_packages/main-calendar/lib/core/calendar-helpers.tsx
+++ b/app/internal_packages/main-calendar/lib/core/calendar-helpers.tsx
@@ -12,6 +12,7 @@ import {
   CalendarDateUtils,
 } from 'mailspring-exports';
 import { MIN_EVENT_DURATION_SECONDS } from './calendar-constants';
+import { EventOccurrence, isTimed } from './calendar-data-source';
 
 // Cache of calendar colors synced from CalDAV servers
 const calendarColorCache: Map<string, string> = new Map();
@@ -446,4 +447,17 @@ export async function createCalendarEvent(options: CreateCalendarEventOptions): 
   } catch (error) {
     console.error('Failed to sync new event to server:', error);
   }
+}
+
+/**
+ * Scroll a day/week hour grid so a selected timed event's time is centered in the viewport;
+ * with no timed selection, fall back to the midday default.
+ */
+export function centerGridScroll(viewportEl: HTMLElement, selectedEvent?: EventOccurrence): void {
+  let dayFraction = 0.5;
+  if (selectedEvent && isTimed(selectedEvent)) {
+    const m = moment.unix(selectedEvent.start);
+    dayFraction = (m.hour() * 3600 + m.minute() * 60) / 86400;
+  }
+  viewportEl.scrollTop = viewportEl.scrollHeight * dayFraction - viewportEl.clientHeight / 2;
 }

--- a/app/internal_packages/main-calendar/lib/core/day-view.tsx
+++ b/app/internal_packages/main-calendar/lib/core/day-view.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { ScrollRegion, InjectedComponentSet } from 'mailspring-component-kit';
 import { HeaderControls } from './header-controls';
 import { EventOccurrence } from './calendar-data-source';
+import { centerGridScroll } from './calendar-helpers';
 import { EventGridBackground } from './event-grid-background';
 import { WeekViewEventColumn } from './week-view-event-column';
 import { WeekViewAllDayEvents } from './week-view-all-day-events';
@@ -172,8 +173,7 @@ export class DayView extends React.Component<
   };
 
   _centerScrollRegion() {
-    const wrap = this._gridScrollRegion.current.viewportEl;
-    wrap.scrollTop = wrap.scrollHeight / 2 - wrap.clientHeight / 2;
+    centerGridScroll(this._gridScrollRegion.current.viewportEl, this.props.selectedEvents?.[0]);
   }
 
   _setIntervalHeight = () => {

--- a/app/internal_packages/main-calendar/lib/core/day-view.tsx
+++ b/app/internal_packages/main-calendar/lib/core/day-view.tsx
@@ -36,6 +36,7 @@ export class DayView extends React.Component<
 
   _waitingForShift = 0;
   _mounted = false;
+  _pendingInitialCenter = false;
   _scrollbar = React.createRef<any>();
   _sub?: Disposable;
 
@@ -53,7 +54,9 @@ export class DayView extends React.Component<
 
   componentDidMount() {
     this._mounted = true;
-    this._centerScrollRegion();
+    // Center after _setIntervalHeight finalizes the grid height (below); centering now
+    // uses a too-short scrollHeight and pushes edge-of-day events off-screen.
+    this._pendingInitialCenter = true;
 
     // Shift ourselves right by BUFFER_DAYS to show the focused day (not the buffer).
     // clientWidth equals the visible viewport (1 day), so scrolling by clientWidth
@@ -183,12 +186,21 @@ export class DayView extends React.Component<
     const viewportHeight = this._gridScrollRegion.current.viewportEl.clientHeight;
     this._legendWrapEl.current.style.height = `${viewportHeight}px`;
 
-    this.setState({
-      intervalHeight: Math.max(
-        viewportHeight / (TICKS_PER_DAY * DAY_PORTION_SHOWN_VERTICALLY),
-        MIN_INTERVAL_HEIGHT
-      ),
-    });
+    this.setState(
+      {
+        intervalHeight: Math.max(
+          viewportHeight / (TICKS_PER_DAY * DAY_PORTION_SHOWN_VERTICALLY),
+          MIN_INTERVAL_HEIGHT
+        ),
+      },
+      () => {
+        // Resize also calls this; only the initial mount should reposition the scroll.
+        if (this._pendingInitialCenter) {
+          this._pendingInitialCenter = false;
+          this._centerScrollRegion();
+        }
+      }
+    );
   };
 
   _onScrollCalendarArea = (_event: React.UIEvent) => {

--- a/app/internal_packages/main-calendar/lib/core/header-controls.tsx
+++ b/app/internal_packages/main-calendar/lib/core/header-controls.tsx
@@ -62,7 +62,7 @@ export class HeaderControls extends React.Component<{
 
   render() {
     return (
-      <div className="header-controls">
+      <div className="header-controls" onClick={(e) => e.stopPropagation()}>
         <div className="center-controls">
           {this._renderPrevAction()}
           <span className="title">{this.props.title}</span>

--- a/app/internal_packages/main-calendar/lib/core/mailspring-calendar.tsx
+++ b/app/internal_packages/main-calendar/lib/core/mailspring-calendar.tsx
@@ -224,8 +224,15 @@ export class MailspringCalendar extends React.Component<
   };
 
   onChangeView = (view: CalendarView) => {
+    // If an event is selected, jump the new view to where it lives so it stays visible and
+    // selected (matching Apple Calendar) — switching to a narrow view could otherwise leave the
+    // selected event off-screen.
+    const selected = this.state.selectedEvents[0];
+    const focusedMoment = selected
+      ? moment.unix(occurrenceStartUnix(selected))
+      : this.state.focusedMoment;
     // Clear any active drag state when changing views
-    this.setState({ view, dragState: null });
+    this.setState({ view, dragState: null, focusedMoment });
     AppEnv.config.set(CALENDAR_VIEW, view);
   };
 

--- a/app/internal_packages/main-calendar/lib/core/month-view-day-cell.tsx
+++ b/app/internal_packages/main-calendar/lib/core/month-view-day-cell.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
 import { Moment } from 'moment-timezone';
 import classnames from 'classnames';
-import { EventOccurrence, FocusedEventInfo, occurrenceStartUnix } from './calendar-data-source';
+import {
+  EventOccurrence,
+  FocusedEventInfo,
+  occurrenceStartUnix,
+  isEventSelected,
+} from './calendar-data-source';
 import { MonthViewEvent } from './month-view-event';
 import { localized } from 'mailspring-exports';
 import { DragState, HitZone } from './calendar-drag-types';
@@ -38,7 +43,7 @@ export class MonthViewDayCell extends React.Component<MonthViewDayCellProps> {
   };
 
   _isEventSelected(event: EventOccurrence): boolean {
-    return this.props.selectedEvents.some((e) => e.id === event.id);
+    return isEventSelected(this.props.selectedEvents, event);
   }
 
   _sortEvents(events: EventOccurrence[]): EventOccurrence[] {

--- a/app/internal_packages/main-calendar/lib/core/week-view-all-day-events.tsx
+++ b/app/internal_packages/main-calendar/lib/core/week-view-all-day-events.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Utils } from 'mailspring-exports';
 import { CalendarEvent } from './calendar-event';
-import { EventOccurrence } from './calendar-data-source';
+import { EventOccurrence, isEventSelected } from './calendar-data-source';
 import { OverlapByEventId } from './week-view-helpers';
 import { EventRendererProps } from './mailspring-calendar';
 import { DragState, HitZone } from './calendar-drag-types';
@@ -63,7 +63,7 @@ export class WeekViewAllDayEvents extends React.Component<WeekViewAllDayEventsPr
             event={e}
             order={allDayOverlap[e.id]?.order || 1}
             key={e.id}
-            selected={selectedEvents.includes(e)}
+            selected={isEventSelected(selectedEvents, e)}
             focused={focusedEvent ? focusedEvent.id === e.id : false}
             scopeStart={this.props.start}
             scopeEnd={this.props.end}

--- a/app/internal_packages/main-calendar/lib/core/week-view-event-column.tsx
+++ b/app/internal_packages/main-calendar/lib/core/week-view-event-column.tsx
@@ -3,7 +3,7 @@ import { Moment } from 'moment';
 import classnames from 'classnames';
 import { Utils } from 'mailspring-exports';
 import { CalendarEvent } from './calendar-event';
-import { EventOccurrence, FocusedEventInfo } from './calendar-data-source';
+import { EventOccurrence, FocusedEventInfo, isEventSelected } from './calendar-data-source';
 import { overlapForEvents } from './week-view-helpers';
 import { DragState, HitZone } from './calendar-drag-types';
 
@@ -74,7 +74,7 @@ export class WeekViewEventColumn extends React.Component<WeekViewEventColumnProp
         {events.map((e) => (
           <CalendarEvent
             event={e}
-            selected={selectedEvents.includes(e)}
+            selected={isEventSelected(selectedEvents, e)}
             order={overlap[e.id]?.order || 1}
             focused={focusedEvent ? focusedEvent.id === e.id : false}
             key={e.id}

--- a/app/internal_packages/main-calendar/lib/core/week-view.tsx
+++ b/app/internal_packages/main-calendar/lib/core/week-view.tsx
@@ -36,6 +36,7 @@ export class WeekView extends React.Component<
 
   _waitingForShift = 0;
   _mounted = false;
+  _pendingInitialCenter = false;
   _scrollbar = React.createRef<any>();
   _sub?: Disposable;
 
@@ -53,7 +54,9 @@ export class WeekView extends React.Component<
 
   componentDidMount() {
     this._mounted = true;
-    this._centerScrollRegion();
+    // Center after _setIntervalHeight finalizes the grid height (below); centering now
+    // uses a too-short scrollHeight and pushes edge-of-day events off-screen.
+    this._pendingInitialCenter = true;
 
     // Shift ourselves right by a week because we preload 7 days on either side
     const wrap = this._calendarWrapEl.current;
@@ -183,12 +186,21 @@ export class WeekView extends React.Component<
     const viewportHeight = this._gridScrollRegion.current.viewportEl.clientHeight;
     this._legendWrapEl.current.style.height = `${viewportHeight}px`;
 
-    this.setState({
-      intervalHeight: Math.max(
-        viewportHeight / (TICKS_PER_DAY * DAY_PORTION_SHOWN_VERTICALLY),
-        MIN_INTERVAL_HEIGHT
-      ),
-    });
+    this.setState(
+      {
+        intervalHeight: Math.max(
+          viewportHeight / (TICKS_PER_DAY * DAY_PORTION_SHOWN_VERTICALLY),
+          MIN_INTERVAL_HEIGHT
+        ),
+      },
+      () => {
+        // Resize also calls this; only the initial mount should reposition the scroll.
+        if (this._pendingInitialCenter) {
+          this._pendingInitialCenter = false;
+          this._centerScrollRegion();
+        }
+      }
+    );
   };
 
   _onScrollCalendarArea = (_event: React.UIEvent) => {

--- a/app/internal_packages/main-calendar/lib/core/week-view.tsx
+++ b/app/internal_packages/main-calendar/lib/core/week-view.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { ScrollRegion, InjectedComponentSet } from 'mailspring-component-kit';
 import { HeaderControls } from './header-controls';
 import { EventOccurrence } from './calendar-data-source';
+import { centerGridScroll } from './calendar-helpers';
 import { EventGridBackground } from './event-grid-background';
 import { WeekViewEventColumn } from './week-view-event-column';
 import { WeekViewAllDayEvents } from './week-view-all-day-events';
@@ -172,8 +173,7 @@ export class WeekView extends React.Component<
   };
 
   _centerScrollRegion() {
-    const wrap = this._gridScrollRegion.current.viewportEl;
-    wrap.scrollTop = wrap.scrollHeight / 2 - wrap.clientHeight / 2;
+    centerGridScroll(this._gridScrollRegion.current.viewportEl, this.props.selectedEvents?.[0]);
   }
 
   _setIntervalHeight = () => {

--- a/app/spec/calendar-data-source-spec.ts
+++ b/app/spec/calendar-data-source-spec.ts
@@ -6,6 +6,8 @@ import {
   eventCoversDate,
   occurrenceStartUnix,
   occurrenceEndUnix,
+  isEventSelected,
+  EventOccurrence,
 } from '../internal_packages/main-calendar/lib/core/calendar-data-source';
 import { formatCalendarDate, parseCalendarDate } from '../src/calendar-date';
 
@@ -278,5 +280,51 @@ describe('eventCoversDate', function () {
     expect(
       ['2026-03-07', '2026-03-08', '2026-03-09'].map((iso) => eventCoversDate(occ, day(iso)))
     ).toEqual([true, true, true]);
+  });
+});
+
+
+describe('isEventSelected', function () {
+  const occ = (id: string) => ({ id } as EventOccurrence);
+
+  it('matches by id even when the object identity differs', function () {
+    // Selection is captured at click time; a data refresh gives the occurrence a fresh object,
+    // so an identity check would drop the highlight. This is the week-view bug this guards.
+    const selected = [occ('evt-1'), occ('evt-2')];
+    expect(isEventSelected(selected, occ('evt-1'))).toBe(true);
+  });
+
+  it('does not match a different id', function () {
+    expect(isEventSelected([occ('evt-1')], occ('evt-9'))).toBe(false);
+  });
+
+  it('is false for an empty selection', function () {
+    expect(isEventSelected([], occ('evt-1'))).toBe(false);
+  });
+});
+
+
+describe('occurrence id stability across query ranges', function () {
+  it('gives a recurring occurrence the same id in a wide and a narrow range', function () {
+    // idx-based ids differed per range (the Jun-20 occurrence is the 6th from Jun-15 in June but
+    // the 3rd in the Jun 18-25 week), which broke selection/React keys when switching views.
+    const event = makeEvent(
+      icsFor('DTSTART:20260615T090000Z', 'DTEND:20260615T100000Z', 'RRULE:FREQ=DAILY')
+    );
+    const wide = occurrencesForEvents([event], {
+      startUnix: new Date(2026, 5, 1).getTime() / 1000,
+      endUnix: new Date(2026, 6, 1).getTime() / 1000,
+    });
+    const narrow = occurrencesForEvents([event], {
+      startUnix: new Date(2026, 5, 18).getTime() / 1000,
+      endUnix: new Date(2026, 5, 25).getTime() / 1000,
+    });
+    const onJun20 = (occs: any[]) =>
+      occs.find((o) => formatCalendarDate(o.startDate) === '2026-06-20');
+    const w = onJun20(wide);
+    const n = onJun20(narrow);
+    expect(w).toBeDefined();
+    expect(n).toBeDefined();
+    expect(w.id).toBe(n.id);
   });
 });


### PR DESCRIPTION
## What

Selecting a calendar event and switching views now keeps it selected and brings it into view — before, the selection was lost on almost every view switch. Extends #2806/#2812-era selection handling; grew out of a narrower highlight fix.

## The layers

The visible symptom ("selection vanishes when I switch to week/day") turned out to be several stacked issues:

- **View-switch was silently deselecting.** `CalendarEventContainer` wraps `HeaderControls`, and its `_onCalendarClick` fires the background-deselect for any click inside it. `CalendarEvent` already stops propagation of its own clicks; the header's view-switch/nav buttons didn't — so clicking "Week" bubbled up and cleared the selection. Fixed by stopping propagation at the header, consistent with how events already do it.
- **Recurring occurrence ids weren't stable across views.** Ids were `${master.id}-e${expansionIndex}`, and the index depends on the query range — so the same occurrence had a different id in month vs week, breaking by-id matching (and React keys) across views. Now keyed on the occurrence start (`-e${Math.round(start)}`), stable across ranges.
- **Week/day compared selection by object reference** (`selectedEvents.includes(e)`) while month/agenda used id — so the highlight also dropped on any in-view data refresh. All four now go through one `isEventSelected` (by id).

## Behavior

With those fixed, two UX pieces make it match Apple Calendar:

- **Navigate to the selection on view switch** — `onChangeView` moves `focusedMoment` to the selected event's date, so a narrow view lands on the right day instead of leaving it off-screen.
- **Scroll the event into view** — `centerGridScroll` (shared by week/day) scrolls the hour grid toward the selected timed event's time.

## Testing

Discriminating specs for the pure logic: `isEventSelected` (matches by id across object identities) and occurrence-id stability (same recurring occurrence, wide vs narrow range → same id). The header-propagation, navigate, and scroll pieces are DOM/component behavior and were verified manually. Full suite green, typecheck and lint clean.

## Follow-up

`centerGridScroll` runs before the grid's height finalizes, so it scrolls the event into view but not perfectly centered — a small follow-up (re-run once the height settles) can true it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)