### PR TITLE
Fix ChangeLabelsTask assertion failure when removing search results

### DIFF
--- a/app/internal_packages/thread-search/lib/search-mailbox-perspective.tsx
+++ b/app/internal_packages/thread-search/lib/search-mailbox-perspective.tsx
@@ -105,6 +105,7 @@ class SearchMailboxPerspective extends MailboxPerspective {
         return new ChangeLabelsTask({
           threads: accountThreads,
           source: 'Dragged out of list',
+          labelsToAdd: [],
           labelsToRemove: [CategoryStore.getInboxCategory(accountId)],
         });
       }

--- a/app/spec/search-mailbox-perspective-spec.ts
+++ b/app/spec/search-mailbox-perspective-spec.ts
@@ -1,0 +1,33 @@
+import { AccountStore, CategoryStore, Label, Thread } from 'mailspring-exports';
+import SearchMailboxPerspective from '../internal_packages/thread-search/lib/search-mailbox-perspective';
+
+describe('SearchMailboxPerspective', function searchMailboxPerspective() {
+  beforeEach(() => {
+    this.sourcePerspective = { accountIds: ['a1'], name: 'Inbox' };
+    this.perspective = new SearchMailboxPerspective(this.sourcePerspective, 'from:ben');
+    this.thread = new Thread({ id: 't1', accountId: 'a1' });
+  });
+
+  describe('tasksForRemovingItems', () => {
+    it('builds a valid ChangeLabelsTask (with labelsToAdd) when the preferred removal destination is a Label', () => {
+      const inboxCategory = new Label({ id: 'inbox', accountId: 'a1', role: 'inbox' });
+      spyOn(AccountStore, 'accountForId').andReturn({
+        id: 'a1',
+        preferredRemovalDestination: () => new Label({ id: 'all', accountId: 'a1', role: 'all' }),
+      });
+      spyOn(CategoryStore, 'getInboxCategory').andReturn(inboxCategory);
+
+      const tasks = this.perspective.tasksForRemovingItems([this.thread], 'Dragged out of list');
+
+      expect(tasks.length).toBe(1);
+      const [task] = tasks;
+      expect(task.labelsToAdd).toEqual([]);
+      expect(task.labelsToRemove).toEqual([inboxCategory]);
+
+      // Regression test for MAILSPRING-CLIENT-AC: willBeQueued() previously threw
+      // "Assertion Failure: ChangeLabelsTask requires labelsToAdd" because labelsToAdd
+      // was never passed to the task and so was `undefined`, not `[]`.
+      expect(() => task.willBeQueued()).not.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes [MAILSPRING-CLIENT-AC](https://foundry-376-llc.sentry.io/issues/MAILSPRING-CLIENT-AC) — `Assertion Failure: ChangeLabelsTask requires labelsToAdd` (56 users impacted, 312 events since first seen).

**Root cause:** `SearchMailboxPerspective.tasksForRemovingItems()` (`app/internal_packages/thread-search/lib/search-mailbox-perspective.tsx`) constructs a `ChangeLabelsTask` for accounts whose "preferred removal destination" is a `Label` (rather than a `Folder`) — e.g. Gmail-style label-based archiving. That construction only passed `labelsToRemove`, omitting `labelsToAdd` entirely:

```ts
return new ChangeLabelsTask({
  threads: accountThreads,
  source: 'Dragged out of list',
  labelsToRemove: [CategoryStore.getInboxCategory(accountId)],
});
```

`Model`'s constructor (`app/src/flux/models/model.ts`) only assigns an attribute when the key is explicitly present in the data passed in:

```ts
for (const key of Object.keys(this.ctor.attributes)) {
  if (data[key] !== undefined) {
    this[key] = data[key];
  }
}
```

So `labelsToAdd` was left `undefined` rather than defaulting to `[]`. `ChangeLabelsTask.willBeQueued()` then throws:

```ts
if (!this.labelsToAdd) {
  throw new Error(`Assertion Failure: ChangeLabelsTask requires labelsToAdd`);
}
```

Every other `ChangeLabelsTask` call site in the codebase (thread-toolbar-buttons, mailbox-perspective, category-picker, mail-rules-processor, etc.) always passes both `labelsToAdd` and `labelsToRemove` — this was the one place that didn't. The bug fires whenever a user removes/archives an item while viewing **search results** on an account whose preferred removal destination is a label rather than a folder.

## Fix

Pass `labelsToAdd: []` alongside `labelsToRemove`, matching the equivalent branch in `CategoryMailboxPerspective.tasksForRemovingItems` (`app/src/mailbox-perspective.ts`) which already does this correctly.

## Test plan

- Added `app/spec/search-mailbox-perspective-spec.ts`, a regression test that exercises `tasksForRemovingItems()` with a Label-type removal destination and asserts `willBeQueued()` no longer throws.
- `npm run lint` passes on the changed files.
- Note: I was unable to get the full Electron/Jasmine suite (`npm test`) to complete in this sandbox (the headless Electron process hung during app initialization, unrelated to this change) — CI should validate the new spec runs cleanly.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YHEcZpx3P3TpYsXgjyqXe3)_