### PR TITLE
Add all-day → timed drag conversion

### DIFF
--- a/app/internal_packages/main-calendar/lib/core/calendar-constants.ts
+++ b/app/internal_packages/main-calendar/lib/core/calendar-constants.ts
@@ -1,6 +1,9 @@
 /** Shortest event the UI will produce, by drag, keyboard resize, or the popover's end picker. */
 export const MIN_EVENT_DURATION_SECONDS = 900;
 
+/** Default length of a new timed event, used for double-click creation and all-day→timed drags. */
+export const DEFAULT_TIMED_EVENT_DURATION_SECONDS = 3600;
+
 export enum CalendarView {
   DAY = 'Day',
   WEEK = 'Week',

--- a/app/internal_packages/main-calendar/lib/core/calendar-drag-utils.ts
+++ b/app/internal_packages/main-calendar/lib/core/calendar-drag-utils.ts
@@ -14,6 +14,7 @@ import {
 } from './calendar-data-source';
 import { CalendarDateUtils } from 'mailspring-exports';
 import { inclusiveAllDayEnd } from './calendar-helpers';
+import { DEFAULT_TIMED_EVENT_DURATION_SECONDS } from './calendar-constants';
 
 /**
  * Snap a timestamp to the nearest interval
@@ -286,13 +287,19 @@ export function updateDragState(
   const usesDaySnap = containerType !== 'day-column';
   const snapInterval = usesDaySnap ? 86400 : config.snapInterval; // 86400 = 1 day in seconds
   const minDuration = usesDaySnap ? 86400 : config.minDuration;
-  // The all-day row converts a timed event; a month cell preserves the event's kind. Recurring
-  // events are NOT converted yet: createRecurrenceException threads one isAllDay through both the
-  // exception times and the RECURRENCE-ID, so a convert would misformat the RID and orphan the
-  // exception. A recurring timed event dropped here keeps its time (moves to that day) instead.
+  // A move converts between kinds when the drop container disagrees with the event: the all-day
+  // row makes a timed event all-day, the timed grid (day-column) makes an all-day event timed. A
+  // month cell preserves the event's kind. Recurring events are NOT converted yet:
+  // createRecurrenceException threads one isAllDay through both the exception times and the
+  // RECURRENCE-ID, so a convert would misformat the RID and orphan the exception — a recurring
+  // event dropped across kinds keeps its own kind (moves to that day) instead.
+  const canConvert = state.mode === 'move' && !state.event.isRecurring;
   const previewIsAllDay =
-    state.event.isAllDay ||
-    (state.mode === 'move' && containerType === 'all-day-area' && !state.event.isRecurring);
+    containerType === 'all-day-area'
+      ? state.event.isAllDay || canConvert
+      : containerType === 'day-column'
+        ? state.event.isAllDay && !canConvert
+        : state.event.isAllDay;
 
   switch (state.mode) {
     case 'move': {
@@ -309,6 +316,12 @@ export function updateDragState(
             numDays - 1
           )
         );
+      } else if (state.event.isAllDay) {
+        // Converting an all-day event into the timed grid (reached only in day-column, the one
+        // place previewIsAllDay flips false for an all-day event). It has no clock time to keep,
+        // so drop its start at the snapped cursor time and give it the default new-event length.
+        previewStart = snapToInterval(mouseTime, snapInterval);
+        previewEnd = previewStart + DEFAULT_TIMED_EVENT_DURATION_SECONDS;
       } else if (usesDaySnap) {
         // Timed event on a day-granular surface — a month cell, or a recurring event on the
         // all-day row (not converted). Shift by whole calendar days and keep the clock time;

--- a/app/internal_packages/main-calendar/lib/core/mailspring-calendar.tsx
+++ b/app/internal_packages/main-calendar/lib/core/mailspring-calendar.tsx
@@ -34,7 +34,7 @@ import {
   occurrenceStartUnix,
   occurrenceEndUnix,
 } from './calendar-data-source';
-import { CalendarView } from './calendar-constants';
+import { CalendarView, DEFAULT_TIMED_EVENT_DURATION_SECONDS } from './calendar-constants';
 import { CalendarEmptyState } from './calendar-empty-state';
 import {
   setCalendarColors,
@@ -348,7 +348,7 @@ export class MailspringCalendar extends React.Component<
 
     const endUnix = isAllDay
       ? CalendarDateUtils.nextDayStartUnix(CalendarDateUtils.calendarDateFromUnix(startUnix))
-      : startUnix + 3600;
+      : startUnix + DEFAULT_TIMED_EVENT_DURATION_SECONDS;
 
     // Build a temporary EventOccurrence to open the popover in "new event" mode. Build the
     // right variant — an all-day new event carries dates only, like every other occurrence.

--- a/app/spec/calendar-drag-utils-spec.ts
+++ b/app/spec/calendar-drag-utils-spec.ts
@@ -11,15 +11,21 @@ import {
   createDragPreviewEvent,
   canMoveEvent,
   snapAllDayTimes,
+  snapToInterval,
   createDragState,
   updateDragState,
   allDayColumnStartUnix,
 } from '../internal_packages/main-calendar/lib/core/calendar-drag-utils';
-import { MONTH_VIEW_DRAG_CONFIG } from '../internal_packages/main-calendar/lib/core/calendar-drag-types';
+import {
+  DEFAULT_DRAG_CONFIG,
+  MONTH_VIEW_DRAG_CONFIG,
+} from '../internal_packages/main-calendar/lib/core/calendar-drag-types';
+import { DEFAULT_TIMED_EVENT_DURATION_SECONDS } from '../internal_packages/main-calendar/lib/core/calendar-constants';
 import {
   EventOccurrence,
   TimedOccurrence,
   coveredDates,
+  isTimed,
 } from '../internal_packages/main-calendar/lib/core/calendar-data-source';
 
 const HOUR = 60 * 60;
@@ -327,6 +333,70 @@ describe('updateDragState move with day snapping', function () {
   });
 });
 
+describe('updateDragState move converting all-day to timed', function () {
+  const localDay = (y: number, m: number, d: number) => new Date(y, m - 1, d).getTime() / 1000;
+
+  // Drops an all-day event into the timed grid (day-column) and returns the preview range + kind.
+  function dragAllDayToGrid(
+    start: number,
+    end: number,
+    mouseTime: number,
+    overrides: { isRecurring?: boolean } = {}
+  ) {
+    const event = makeOccurrence({ isAllDay: true, start, end, ...overrides });
+    const state = createDragState(
+      event,
+      { mode: 'move', cursor: 'move' },
+      mouseTime,
+      0,
+      0,
+      DEFAULT_DRAG_CONFIG
+    );
+    const dragged = updateDragState(state, mouseTime, 100, 100, 'day-column', DEFAULT_DRAG_CONFIG);
+    return { start: dragged.previewStart, end: dragged.previewEnd, isAllDay: dragged.previewIsAllDay };
+  }
+
+  it('converts an all-day event to a timed event at the snapped drop time', function () {
+    // A one-day event dropped at 10:05am becomes timed, starting at the snapped cursor time
+    // (not offset from midnight) and lasting the default new-event length.
+    const mouseTime = localDay(2026, 8, 20) + 10 * HOUR + 5 * 60;
+    const snappedStart = snapToInterval(mouseTime, DEFAULT_DRAG_CONFIG.snapInterval);
+    expect(dragAllDayToGrid(localDay(2026, 8, 14), localDay(2026, 8, 15), mouseTime)).toEqual({
+      start: snappedStart,
+      end: snappedStart + DEFAULT_TIMED_EVENT_DURATION_SECONDS,
+      isAllDay: false,
+    });
+  });
+
+  it('gives a multi-day all-day event the same default duration when converted', function () {
+    // The all-day span is discarded — a converted event has no clock time, so it takes the default.
+    const mouseTime = localDay(2026, 8, 20) + 14 * HOUR;
+    const snappedStart = snapToInterval(mouseTime, DEFAULT_DRAG_CONFIG.snapInterval);
+    expect(dragAllDayToGrid(localDay(2026, 8, 14), localDay(2026, 8, 17), mouseTime)).toEqual({
+      start: snappedStart,
+      end: snappedStart + DEFAULT_TIMED_EVENT_DURATION_SECONDS,
+      isAllDay: false,
+    });
+  });
+
+  it('does not convert a RECURRING all-day event in the grid (keeps it all-day for now)', function () {
+    // createRecurrenceException can't yet convert a single occurrence (the RECURRENCE-ID would
+    // misformat), so a recurring all-day event dropped here stays all-day, moved to the drop day.
+    const result = dragAllDayToGrid(
+      localDay(2026, 8, 14),
+      localDay(2026, 8, 15),
+      localDay(2026, 8, 20) + 10 * HOUR,
+      { isRecurring: true }
+    );
+    expect(result.isAllDay).toBe(true);
+    expect(result).toEqual({
+      start: localDay(2026, 8, 20),
+      end: localDay(2026, 8, 21),
+      isAllDay: true,
+    });
+  });
+});
+
 describe('createDragPreviewEvent', function () {
   const localDay = (y: number, m: number, d: number) => new Date(y, m - 1, d).getTime() / 1000;
   const covered = (occ: EventOccurrence) => [
@@ -397,6 +467,26 @@ describe('createDragPreviewEvent', function () {
       previewIsAllDay: true,
     } as any);
     expect(preview.isAllDay).toBe(true);
+    expect(covered(preview)).toEqual(['2026-06-25', '2026-06-25']);
+  });
+
+  it('renders a converting all-day event as a timed preview', function () {
+    const event = makeOccurrence({
+      isAllDay: true,
+      start: localDay(2026, 6, 21),
+      end: localDay(2026, 6, 22),
+    });
+    const preview = createDragPreviewEvent({
+      event,
+      previewStart: localDay(2026, 6, 25) + 10 * HOUR,
+      previewEnd: localDay(2026, 6, 25) + 11 * HOUR,
+      previewIsAllDay: false,
+    } as any);
+    expect(preview.isAllDay).toBe(false);
+    if (isTimed(preview)) {
+      expect(preview.start).toBe(localDay(2026, 6, 25) + 10 * HOUR);
+      expect(preview.end).toBe(localDay(2026, 6, 25) + 11 * HOUR);
+    }
     expect(covered(preview)).toEqual(['2026-06-25', '2026-06-25']);
   });
 });


### PR DESCRIPTION
Symmetric follow-up to the item-2 timed→all-day drag convert (#2812). Dragging an all-day event down into the timed grid (`day-column`) now converts it to a timed event.

## What changed

- **`calendar-drag-utils.ts`** — `previewIsAllDay` is now fully container-driven: `all-day-area` → all-day, `day-column` → timed, `month-cell` → preserve kind. The existing `move`-only and non-recurring gates are kept (folded into a `canConvert` local) so this direction mirrors the timed→all-day one. A new move-case branch places a converted all-day event at the snapped cursor time with a default 1h duration (an all-day event has no clock time to preserve).
- **`calendar-constants.ts` / `mailspring-calendar.tsx`** — extracted `DEFAULT_TIMED_EVENT_DURATION_SECONDS` (3600) and reused it for the double-click new-event default, so the create-default and convert-default are one value.
- **spec** — added discriminating specs mirroring the timed→all-day tests: all-day→timed in `day-column` yields `previewIsAllDay: false` at the snapped time + default duration, a multi-day span is discarded for the default, recurring all-day stays all-day, and `createDragPreviewEvent` renders a timed preview from an all-day source.

## Design decisions

- **Default converted duration: 1h**, matching the double-click create default.
- **Recurring all-day → timed is intentionally NOT converted.** `createRecurrenceException` picks the RECURRENCE-ID format (`formatDateOnly` vs `formatDateTimeUTC`) from a single `isAllDay` flag, so converting one occurrence of a recurring all-day series would misformat the RID and orphan the exception — the same failure the timed→all-day direction already defers. A recurring all-day event dropped in the grid keeps its kind and moves to the drop day.

## Verification

- `npm run typecheck`, `npm run lint`, `npm test` (1600 passing, 0 failing).
- Red-check: reverting the reverse-convert logic fails the two conversion specs and correctly leaves the recurring-gate and preview specs green, confirming the specs discriminate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)