### PR TITLE
Fix scrollbars appearing in inbox-zero animation iframes

### DIFF
--- a/app/static/animations/inbox-zero/airstrip/airstrip.html
+++ b/app/static/animations/inbox-zero/airstrip/airstrip.html
@@ -7,6 +7,9 @@
 	<style>
 		html {
 			height:100%;
+			/* Hype stage is exactly 600x500, same as the iframe; non-overlay
+			   scrollbars steal layout space and trigger overflow. */
+			overflow:auto;
 		}
 		body {
 			margin:0;

--- a/app/static/animations/inbox-zero/airstrip/airstrip.html
+++ b/app/static/animations/inbox-zero/airstrip/airstrip.html
@@ -7,9 +7,7 @@
 	<style>
 		html {
 			height:100%;
-			/* Hype stage is exactly 600x500, same as the iframe; non-overlay
-			   scrollbars steal layout space and trigger overflow. */
-			overflow:auto;
+			overflow:hidden;
 		}
 		body {
 			margin:0;

--- a/app/static/animations/inbox-zero/galaxy/galaxy.html
+++ b/app/static/animations/inbox-zero/galaxy/galaxy.html
@@ -7,6 +7,7 @@
 	<style>
 		html {
 			height:100%;
+			overflow:hidden;
 		}
 		body {
 			margin:0;

--- a/app/static/animations/inbox-zero/gem/gem.html
+++ b/app/static/animations/inbox-zero/gem/gem.html
@@ -7,6 +7,7 @@
 	<style>
 		html {
 			height:100%;
+			overflow:hidden;
 		}
 		body {
 			margin:0;

--- a/app/static/animations/inbox-zero/oasis/oasis.html
+++ b/app/static/animations/inbox-zero/oasis/oasis.html
@@ -7,6 +7,7 @@
 	<style>
 		html {
 			height:100%;
+			overflow:hidden;
 		}
 		body {
 			margin:0;

--- a/app/static/animations/inbox-zero/tron/tron.html
+++ b/app/static/animations/inbox-zero/tron/tron.html
@@ -7,6 +7,7 @@
 	<style>
 		html {
 			height:100%;
+			overflow:hidden;
 		}
 		body {
 			margin:0;


### PR DESCRIPTION
The five Tumult Hype exports render a stage that is exactly 600x500, matching the iframe dimensions set in empty-list-state.less. Chromium 43 (electron 41.7.2 -> 43.4.1) renders non-overlay scrollbars that reserve layout space rather than floating above content, so the stage no longer fit its viewport: one scrollbar appeared, consumed ~15px, pushed the other axis into overflow, and the second appeared in turn.

The scrollbars belong to the iframe's own viewport, which the embedding document cannot style — overflow on an <iframe> element applies to the replaced box, not the document inside it. Set overflow:hidden on the root element of each export instead, where it propagates to the viewport and suppresses both axes.

Preferred over scrolling="no" on the iframe, which achieves the same result via the frame owner but is non-conforming and long deprecated.