### PR TITLE
key-manager: use async safeStorage API

### DIFF
--- a/app/src/key-manager.ts
+++ b/app/src/key-manager.ts
@@ -95,7 +95,8 @@ class KeyManager {
       encryptedCredentials !== 'null'
     ) {
       try {
-        raw = await safeStorage.decryptString(Buffer.from(encryptedCredentials, 'utf-8'));
+        raw = (await safeStorage.decryptStringAsync(Buffer.from(encryptedCredentials, 'utf-8')))
+          .result;
       } catch (err) {
         console.error('Mailspring encountered an error reading passwords from the keychain.');
         console.error(err);
@@ -109,11 +110,11 @@ class KeyManager {
   }
 
   async _writeKeyHash(keys: KeySet) {
-    if (!safeStorage.isEncryptionAvailable()) {
+    if (!(await safeStorage.isAsyncEncryptionAvailable())) {
       const platformHint =
         process.platform === 'linux'
           ? localized(
-              ' On Linux, Mailspring requires a secret service such as GNOME Keyring or KWallet. Please ensure one is installed and running, then restart Mailspring.'
+              ' On Linux, Mailspring requires a secret service such as org.freedesktop.portal.Secret or org.freedesktop.Secret.Service. Please ensure a provider is installed and running, then restart Mailspring.'
             )
           : '';
       throw new Error(
@@ -122,7 +123,7 @@ class KeyManager {
         ) + platformHint
       );
     }
-    const enrcyptedCredentials = await safeStorage.encryptString(JSON.stringify(keys));
+    const enrcyptedCredentials = await safeStorage.encryptStringAsync(JSON.stringify(keys));
     AppEnv.config.set(configCredentialsKey, enrcyptedCredentials);
   }
 


### PR DESCRIPTION
Switch to the asynchronous `safeStorage` API available since Electron 42, as [recommended in the docs](https://www.electronjs.org/docs/latest/api/safe-storage).

Code wise this was pretty simple, as the synchronous methods were already called with an `await`, despite not returning a `Promise`.

User wise there should be no change for Windows and MacOS, as both APIs use the same backend. On Linux there might be some system setups where reauthentication of accounts is required. This is true at least for the Flatpak, where i can drop the the secrete service dbus permissions once this lands, as electron now will use the Portal, as intended for Flatpak apps. You might want to add a notice to the release notes.

Fixes #2660, #2818 closed it erroneously.

Contains #2822.