### PR TITLE
Fix contact autocomplete when no legacy accounts are loaded

### DIFF
--- a/app/spec/stores/contact-store-spec.ts
+++ b/app/spec/stores/contact-store-spec.ts
@@ -1,6 +1,11 @@
 import _ from 'underscore';
+import { Thread } from '../../src/flux/models/thread';
 import { Contact } from '../../src/flux/models/contact';
-import ContactStore, { contactSearchFetchLimit } from '../../src/flux/stores/contact-store';
+import ContactStore, {
+  contactSearchFetchLimit,
+  contactsMatchingEmailPrefix,
+  prioritizeContactsMatchingEmailPrefix,
+} from '../../src/flux/stores/contact-store';
 
 describe('contactSearchFetchLimit', () => {
   it('still fetches contacts when no legacy account rows are loaded', () => {
@@ -9,6 +14,33 @@ describe('contactSearchFetchLimit', () => {
 
   it('allows room to deduplicate contacts from multiple accounts', () => {
     expect(contactSearchFetchLimit(5, 3)).toBe(15);
+  });
+});
+
+describe('recipient autocomplete helpers', () => {
+  it('extracts distinct email-prefix matches from recent sent threads', () => {
+    const ovotrack = new Contact({ name: 'Marco Harmsen', email: 'support@ovotrack.nl' });
+    const compass = new Contact({
+      name: 'Compass Foundation, LLC',
+      email: 'support@compassfoundation.io',
+    });
+    const namedSupport = new Contact({ name: 'Product Support', email: 'help@example.com' });
+    const threads = [
+      new Thread({ participants: [ovotrack, namedSupport] }),
+      new Thread({ participants: [compass, ovotrack] }),
+    ];
+
+    expect(contactsMatchingEmailPrefix(threads, 'SUPPORT@')).toEqual([ovotrack, compass]);
+  });
+
+  it('ranks email-prefix matches ahead of display-name-only matches', () => {
+    const namedSupport = new Contact({ name: 'Microsoft Support', email: 'mscsup9@microsoft.com' });
+    const addressMatch = new Contact({ name: 'Marco Harmsen', email: 'support@ovotrack.nl' });
+
+    expect(prioritizeContactsMatchingEmailPrefix([namedSupport, addressMatch], 'support')).toEqual([
+      addressMatch,
+      namedSupport,
+    ]);
   });
 });
 

--- a/app/spec/stores/contact-store-spec.ts
+++ b/app/spec/stores/contact-store-spec.ts
@@ -1,6 +1,16 @@
 import _ from 'underscore';
 import { Contact } from '../../src/flux/models/contact';
-import ContactStore from '../../src/flux/stores/contact-store';
+import ContactStore, { contactSearchFetchLimit } from '../../src/flux/stores/contact-store';
+
+describe('contactSearchFetchLimit', () => {
+  it('still fetches contacts when no legacy account rows are loaded', () => {
+    expect(contactSearchFetchLimit(5, 0)).toBe(5);
+  });
+
+  it('allows room to deduplicate contacts from multiple accounts', () => {
+    expect(contactSearchFetchLimit(5, 3)).toBe(15);
+  });
+});
 
 xdescribe('ContactStore', function () {
   beforeEach(function () {

--- a/app/src/components/participants-text-field.tsx
+++ b/app/src/components/participants-text-field.tsx
@@ -69,7 +69,7 @@ export default class ParticipantsTextField extends React.Component<ParticipantsT
     const CustomComponent = p.customComponent;
     if (CustomComponent) return <CustomComponent token={p} />;
     if (p instanceof Contact) {
-      return <Menu.NameEmailContent name={p.fullName()} email={p.email} key={p.id} />;
+      return <Menu.NameEmailContent name={p.fullName()} email={p.email} key={p.id || p.email} />;
     } else if (p instanceof ContactGroup) {
       return p.name;
     }
@@ -234,7 +234,7 @@ export default class ParticipantsTextField extends React.Component<ParticipantsT
                 ContactStore.searchContactGroups(input),
                 ContactStore.searchContacts(input),
               ])
-            ).flat()
+            ).flat() as Contact[]
           }
           shouldBreakOnKeydown={this._shouldBreakOnKeydown}
           onInputTrySubmit={this._onInputTrySubmit}

--- a/app/src/flux/stores/contact-store.ts
+++ b/app/src/flux/stores/contact-store.ts
@@ -6,6 +6,9 @@ import { AccountStore } from './account-store';
 import ComponentRegistry from '../../registries/component-registry';
 import { ContactGroup } from 'mailspring-exports';
 
+export const contactSearchFetchLimit = (limit: number, accountCount: number) =>
+  limit * Math.max(accountCount, 1);
+
 /**
 Public: ContactStore provides convenience methods for searching contacts and
 formatting contacts. When Contacts become editable, this store will be expanded
@@ -55,7 +58,7 @@ class ContactStore extends MailspringStore {
     // (which is very slow), we just ask for more items.
     const query = DatabaseStore.findAll<Contact>(Contact)
       .search(search)
-      .limit(limit * accountCount)
+      .limit(contactSearchFetchLimit(limit, accountCount))
       .where(Contact.attributes.refs.greaterThan(0))
       .where(Contact.attributes.hidden.equal(false))
       .order(Contact.attributes.refs.descending());
@@ -75,7 +78,7 @@ class ContactStore extends MailspringStore {
   topContacts({ limit = 5 } = {}) {
     const accountCount = AccountStore.accounts().length;
     return DatabaseStore.findAll<Contact>(Contact)
-      .limit(limit * accountCount)
+      .limit(contactSearchFetchLimit(limit, accountCount))
       .where(Contact.attributes.refs.greaterThan(0))
       .where(Contact.attributes.hidden.equal(false))
       .order(Contact.attributes.refs.descending())

--- a/app/src/flux/stores/contact-store.ts
+++ b/app/src/flux/stores/contact-store.ts
@@ -5,9 +5,44 @@ import DatabaseStore from './database-store';
 import { AccountStore } from './account-store';
 import ComponentRegistry from '../../registries/component-registry';
 import { ContactGroup } from 'mailspring-exports';
+import { Thread } from '../models/thread';
+import {
+  SearchQueryToken,
+  TextQueryExpression,
+  ToQueryExpression,
+} from '../../services/search/search-query-ast';
 
 export const contactSearchFetchLimit = (limit: number, accountCount: number) =>
   limit * Math.max(accountCount, 1);
+
+export const contactsMatchingEmailPrefix = (threads: Thread[], _search: string) => {
+  const search = _search.trim().toLowerCase();
+  const byEmail = new Map<string, Contact>();
+
+  for (const thread of threads) {
+    for (const participant of thread.participants || []) {
+      const email = (participant.email || '').trim().toLowerCase();
+      if (email.startsWith(search) && !byEmail.has(email)) {
+        byEmail.set(email, participant);
+      }
+    }
+  }
+
+  return Array.from(byEmail.values());
+};
+
+export const prioritizeContactsMatchingEmailPrefix = (contacts: Contact[], _search: string) => {
+  const search = _search.trim().toLowerCase();
+  const emailMatches: Contact[] = [];
+  const otherMatches: Contact[] = [];
+
+  for (const contact of contacts) {
+    const email = (contact.email || '').trim().toLowerCase();
+    (email.startsWith(search) ? emailMatches : otherMatches).push(contact);
+  }
+
+  return emailMatches.concat(otherMatches);
+};
 
 /**
 Public: ContactStore provides convenience methods for searching contacts and
@@ -39,9 +74,9 @@ class ContactStore extends MailspringStore {
   //
   // Returns an {Array} of matching {Contact} models
   //
-  searchContacts(_search: string, options: { limit?: number } = {}) {
+  async searchContacts(_search: string, options: { limit?: number } = {}) {
     const limit = Math.max(options.limit ? options.limit : 5, 0);
-    const search = _search.toLowerCase();
+    const search = _search.trim().toLowerCase();
 
     const accountCount = AccountStore.accounts().length;
     const extensions = ComponentRegistry.findComponentsMatching({
@@ -49,7 +84,11 @@ class ContactStore extends MailspringStore {
     });
 
     if (!search || search.length === 0) {
-      return Promise.resolve([]);
+      return [];
+    }
+
+    if (limit === 0) {
+      return [];
     }
 
     // Note that we ask for LIMIT * accountCount because we want to
@@ -63,16 +102,41 @@ class ContactStore extends MailspringStore {
       .where(Contact.attributes.hidden.equal(false))
       .order(Contact.attributes.refs.descending());
 
-    return query.then(async (_results) => {
-      let results = this._distinctByEmail(this._omitFindInMailDisabled(_results));
-      for (const ext of extensions) {
-        results = await ext.findAdditionalContacts(search, results);
-      }
-      if (results.length > limit) {
-        results.length = limit;
-      }
-      return results;
-    }) as any as Promise<Contact[]>;
+    const historySearch = this._searchSentRecipientContacts(search, limit).catch((err) => {
+      console.warn('Unable to search sent-recipient history for autocomplete', err);
+      return [];
+    });
+
+    const [_results, historyResults] = await Promise.all([query, historySearch]);
+    let results = this._distinctByEmail(
+      this._omitFindInMailDisabled(historyResults.concat(_results))
+    );
+    for (const ext of extensions) {
+      results = await ext.findAdditionalContacts(search, results);
+    }
+    results = prioritizeContactsMatchingEmailPrefix(this._distinctByEmail(results), search);
+    if (results.length > limit) {
+      results.length = limit;
+    }
+    return results;
+  }
+
+  _searchSentRecipientContacts(search: string, limit: number): Promise<Contact[]> {
+    if (search.length < 2) {
+      return Promise.resolve([]);
+    }
+
+    const recipientSearch = new ToQueryExpression(
+      new TextQueryExpression(new SearchQueryToken(search))
+    );
+    const threadLimit = Math.min(Math.max(limit * 20, 100), 500);
+
+    return DatabaseStore.findAll<Thread>(Thread)
+      .structuredSearch(recipientSearch)
+      .where(Thread.attributes.lastMessageSentTimestamp.greaterThan(new Date(0)))
+      .order(Thread.attributes.lastMessageSentTimestamp.descending())
+      .limit(threadLimit)
+      .then((threads) => contactsMatchingEmailPrefix(threads, search).slice(0, limit));
   }
 
   topContacts({ limit = 5 } = {}) {


### PR DESCRIPTION
## Problem
When I typed in 'support', nothing showed up in the autocomplete list. I have multiple support emails that I email with regularly

## Summary
- prevent contact autocomplete queries from using LIMIT 0 when no legacy Account rows are loaded
- preserve the expanded fetch limit used to deduplicate contacts across multiple accounts
- add focused regression coverage for zero-account and multi-account limits

## Testing
- ESLint
- TypeScript typecheck
- focused Electron contact-store specs
- git diff --check