### PR TITLE
Fix ChangeFolderTask crash when trashing/marking spam on label-based accounts

### DIFF
--- a/app/spec/tasks/task-factory-spec.ts
+++ b/app/spec/tasks/task-factory-spec.ts
@@ -3,6 +3,7 @@ import {
   AccountStore,
   CategoryStore,
   Label,
+  Folder,
   Thread,
   ChangeFolderTask,
   ChangeLabelsTask,
@@ -12,14 +13,16 @@ describe('TaskFactory', function taskFactory() {
   beforeEach(() => {
     this.categories = {
       'ac-1': {
-        archive: new Label({ name: 'archive' } as any),
-        inbox: new Label({ name: 'inbox1' } as any),
-        trash: new Label({ name: 'trash1' } as any),
+        archive: new Folder({ name: 'archive', role: 'archive' } as any),
+        inbox: new Folder({ name: 'inbox1', role: 'inbox' } as any),
+        trash: new Folder({ name: 'trash1', role: 'trash' } as any),
+        spam: new Folder({ name: 'spam1', role: 'spam' } as any),
       },
       'ac-2': {
-        archive: new Label({ name: 'all' } as any),
-        inbox: new Label({ name: 'inbox2' } as any),
-        trash: new Label({ name: 'trash2' } as any),
+        archive: new Label({ name: 'all', role: 'all' } as any),
+        inbox: new Label({ name: 'inbox2', role: 'inbox' } as any),
+        trash: new Label({ name: 'trash2', role: 'trash' } as any),
+        spam: new Label({ name: 'spam2', role: 'spam' } as any),
       },
     };
     this.accounts = {
@@ -45,6 +48,9 @@ describe('TaskFactory', function taskFactory() {
     spyOn(CategoryStore, 'getTrashCategory').andCallFake((acc) => {
       return this.categories[acc.id].trash;
     });
+    spyOn(CategoryStore, 'getSpamCategory').andCallFake((acc) => {
+      return this.categories[acc.id].spam;
+    });
     spyOn(AccountStore, 'accountForId').andCallFake((accId) => {
       return this.accounts[accId];
     });
@@ -53,4 +59,50 @@ describe('TaskFactory', function taskFactory() {
   describe('taskForInvertingUnread', () => {});
 
   describe('taskForInvertingStarred', () => {});
+
+  describe('tasksForMovingToTrash', () => {
+    it('creates a ChangeFolderTask for accounts whose trash category is a Folder', () => {
+      const tasks = TaskFactory.tasksForMovingToTrash({
+        threads: [this.threads[0]],
+        source: 'Test',
+      });
+      expect(tasks.length).toBe(1);
+      expect(tasks[0] instanceof ChangeFolderTask).toBe(true);
+      expect((tasks[0] as any).folder).toBe(this.categories['ac-1'].trash);
+    });
+
+    it('creates a ChangeLabelsTask for accounts whose trash category is a Label', () => {
+      const tasks = TaskFactory.tasksForMovingToTrash({
+        threads: [this.threads[1]],
+        source: 'Test',
+      });
+      expect(tasks.length).toBe(1);
+      expect(tasks[0] instanceof ChangeLabelsTask).toBe(true);
+      expect((tasks[0] as any).labelsToAdd).toEqual([this.categories['ac-2'].trash]);
+      expect((tasks[0] as any).labelsToRemove).toEqual([this.categories['ac-2'].inbox]);
+    });
+  });
+
+  describe('tasksForMarkingAsSpam', () => {
+    it('creates a ChangeFolderTask for accounts whose spam category is a Folder', () => {
+      const tasks = TaskFactory.tasksForMarkingAsSpam({
+        threads: [this.threads[0]],
+        source: 'Test',
+      });
+      expect(tasks.length).toBe(1);
+      expect(tasks[0] instanceof ChangeFolderTask).toBe(true);
+      expect((tasks[0] as any).folder).toBe(this.categories['ac-1'].spam);
+    });
+
+    it('creates a ChangeLabelsTask for accounts whose spam category is a Label', () => {
+      const tasks = TaskFactory.tasksForMarkingAsSpam({
+        threads: [this.threads[1]],
+        source: 'Test',
+      });
+      expect(tasks.length).toBe(1);
+      expect(tasks[0] instanceof ChangeLabelsTask).toBe(true);
+      expect((tasks[0] as any).labelsToAdd).toEqual([this.categories['ac-2'].spam]);
+      expect((tasks[0] as any).labelsToRemove).toEqual([this.categories['ac-2'].inbox]);
+    });
+  });
 });

--- a/app/src/flux/stores/category-store.ts
+++ b/app/src/flux/stores/category-store.ts
@@ -151,15 +151,17 @@ class CategoryStore extends MailspringStore {
     return this.getCategoryByRole(accountOrId, 'inbox');
   }
 
-  // Public: Returns the Folder that should be used for
-  // "Move to Trash", or null if no trash folder exists.
+  // Public: Returns the Folder or Label that should be used for
+  // "Move to Trash", or null if no trash category exists. On Gmail-style
+  // accounts this is a Label, not a Folder.
   //
   getTrashCategory(accountOrId: Account | string | null) {
     return this.getCategoryByRole(accountOrId, 'trash');
   }
 
-  // Public: Returns the Folder that should be used for
-  // "Move to Spam", or null if no trash folder exists.
+  // Public: Returns the Folder or Label that should be used for
+  // "Move to Spam", or null if no spam category exists. On Gmail-style
+  // accounts this is a Label, not a Folder.
   //
   getSpamCategory(accountOrId: Account | string | null) {
     return this.getCategoryByRole(accountOrId, 'spam');

--- a/app/src/flux/tasks/task-factory.ts
+++ b/app/src/flux/tasks/task-factory.ts
@@ -38,9 +38,20 @@ export const TaskFactory = {
 
   tasksForMarkingAsSpam({ threads, source }: { threads: Thread[]; source: string }) {
     return this.tasksForThreadsByAccountId(threads, (accountThreads, accountId) => {
-      const folder = CategoryStore.getSpamCategory(accountId);
-      if (!folder) return null;
-      return new ChangeFolderTask({ folder, source, threads: accountThreads });
+      const spam = CategoryStore.getSpamCategory(accountId) as any;
+      if (!spam) return null;
+
+      if (spam instanceof Label) {
+        const inbox = CategoryStore.getInboxCategory(accountId);
+        return new ChangeLabelsTask({
+          labelsToAdd: [spam],
+          labelsToRemove: inbox instanceof Label ? [inbox] : [],
+          threads: accountThreads,
+          source,
+        });
+      }
+
+      return new ChangeFolderTask({ folder: spam, source, threads: accountThreads });
     });
   },
 
@@ -81,6 +92,17 @@ export const TaskFactory = {
     return this.tasksForThreadsByAccountId(threads, (accountThreads, accountId) => {
       const trash = CategoryStore.getTrashCategory(accountId) as any;
       if (!trash) return null;
+
+      if (trash instanceof Label) {
+        const inbox = CategoryStore.getInboxCategory(accountId);
+        return new ChangeLabelsTask({
+          labelsToAdd: [trash],
+          labelsToRemove: inbox instanceof Label ? [inbox] : [],
+          threads: accountThreads,
+          source,
+        });
+      }
+
       return new ChangeFolderTask({ folder: trash, threads: accountThreads, source });
     });
   },


### PR DESCRIPTION
Fixes [MAILSPRING-CLIENT-AH](https://foundry-376-llc.sentry.io/issues/MAILSPRING-CLIENT-AH) — 17 users impacted, 1084+ occurrences over the last two months, "core:delete-item" (move-to-trash) throwing and doing nothing.

## What I observed

The Sentry error is:

```
Error: ChangeFolderTask: You must provide a single folder. Got object: {"id":"...","role":"trash","path":"Trash","__cls":"Label"}
```

thrown from the `ChangeFolderTask` constructor (`change-folder-task.ts:74-78`), which asserts `this.folder instanceof Folder`. The stack trace shows it originates from the `core:delete-item` keyboard/toolbar command → `TaskFactory.tasksForMovingToTrash` → `new ChangeFolderTask({ folder: trash, ... })`, where `trash` is a `Label`, not a `Folder`.

`CategoryStore.getTrashCategory()`/`getSpamCategory()` return whatever category object the sync engine created for the `trash`/`spam` role — a `Folder` for IMAP-style accounts, but a `Label` for Gmail-style (label-based) accounts. `TaskFactory.tasksForMovingToTrash` and `tasksForMarkingAsSpam` always wrapped the result in a `ChangeFolderTask`, so any account where trash/spam is a `Label` reliably crashed on delete/spam actions.

This is exactly the same class of bug that `tasksForArchiving` and `tasksForMarkingNotSpam` already guard against — both branch on `instanceof Label` and use `ChangeLabelsTask` instead — and the same pattern used in `thread-snooze`'s `moveThreads`. `tasksForMovingToTrash`/`tasksForMarkingAsSpam` were just missing that check. `ChangeLabelsTask`'s own `description()` even already has dedicated "Trashed"/"Marked as Spam" copy for label adds, so the label-based path was clearly intended, just not wired up here.

## The fix

In `app/src/flux/tasks/task-factory.ts`, `tasksForMovingToTrash` and `tasksForMarkingAsSpam` now check whether the category is a `Label`. If so, they build a `ChangeLabelsTask` that adds the trash/spam label and removes the inbox label (mirroring `tasksForArchiving`'s inbox-removal and `thread-snooze`'s add/remove pattern), instead of constructing an invalid `ChangeFolderTask`. Non-label accounts keep using `ChangeFolderTask` as before.

Also corrected the stale doc comments on `CategoryStore.getTrashCategory`/`getSpamCategory`, which claimed to always return a `Folder`.

## Testing

- Added unit tests in `app/spec/tasks/task-factory-spec.ts` covering both the `Folder` and `Label` category cases for `tasksForMovingToTrash` and `tasksForMarkingAsSpam`.
- `npm run typecheck` and `npm run lint` pass on the changed files (pre-existing, unrelated errors from missing optional native/test dependencies in this sandbox were not introduced by this change).
- Wasn't able to run the full Electron-hosted Jasmine suite (`npm test`) in this headless sandbox — it hung with no output under Xvfb — so please double check CI runs clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_017ib2ZDXrsZqTvBmvgxBvsm)_