### PR TITLE
Report mailsync startup failures instead of "an unknown error has occurred"

### DIFF
--- a/app/spec/mailsync-process-spec.ts
+++ b/app/spec/mailsync-process-spec.ts
@@ -1,0 +1,39 @@
+import { lastJSONResponse } from '../src/mailsync-process';
+
+describe('lastJSONResponse', function () {
+  it('reads a result that has no trailing newline', function () {
+    expect(lastJSONResponse('{"error":null}')).toEqual({ error: null });
+  });
+
+  it('skips the progress lines mailsync prints before the result', function () {
+    expect(lastJSONResponse('Running Setup\n{"error":null}')).toEqual({ error: null });
+  });
+
+  it('tolerates a trailing newline and blank lines', function () {
+    expect(lastJSONResponse('{"error":null}\n\n')).toEqual({ error: null });
+  });
+
+  it('returns the last result when several objects were written', function () {
+    expect(lastJSONResponse('{"error":"first"}\n{"error":"second"}\n')).toEqual({
+      error: 'second',
+    });
+  });
+
+  it('returns null when nothing on stdout is JSON', function () {
+    expect(lastJSONResponse('Error: Could not load libtidy.\nInstall libtidy.\n')).toBe(null);
+  });
+
+  it('reads a result written with Windows line endings', function () {
+    // mailsync's stdout is in text mode on Windows, so every newline arrives as CRLF and
+    // the result line carries a trailing carriage return.
+    expect(lastJSONResponse('Running Setup\r\n{"error":null}\r\n')).toEqual({ error: null });
+  });
+
+  it('returns null for empty output', function () {
+    expect(lastJSONResponse('')).toBe(null);
+  });
+
+  it('ignores a truncated object at the end of the stream', function () {
+    expect(lastJSONResponse('{"error":null}\n{"error":')).toEqual({ error: null });
+  });
+});

--- a/app/spec/mailsync-process-spec.ts
+++ b/app/spec/mailsync-process-spec.ts
@@ -37,3 +37,27 @@ describe('lastJSONResponse', function () {
     expect(lastJSONResponse('{"error":null}\n{"error":')).toEqual({ error: null });
   });
 });
+
+describe('accumulating mailsync stdout', function () {
+  // mailsync's result line carries the whole IMAP/SMTP conversation in `test` mode, so it
+  // routinely spans more than one 64KB chunk, and a server error or account name is often
+  // non-ASCII. Decoding each chunk on its own splits any multi-byte character that lands on
+  // a boundary into two replacement characters.
+  const payload = '{"error":"Café serveur"}';
+  const bytes = Buffer.from(payload, 'utf-8');
+  const splitAt = bytes.indexOf(0xc3) + 1; // between the two bytes of 'é'
+  const chunks = [bytes.subarray(0, splitAt), bytes.subarray(splitAt)];
+
+  it('mangles a character split across chunks when each chunk is decoded alone', function () {
+    const perChunk = chunks.map(c => c.toString('utf-8')).join('');
+    expect(perChunk).not.toEqual(payload);
+    expect(perChunk).toContain('�');
+    expect(lastJSONResponse(perChunk).error).not.toEqual('Café serveur');
+  });
+
+  it('preserves it when the bytes are joined before decoding', function () {
+    const joined = Buffer.concat(chunks).toString('utf-8');
+    expect(joined).toEqual(payload);
+    expect(lastJSONResponse(joined)).toEqual({ error: 'Café serveur' });
+  });
+});

--- a/app/src/mailsync-process.ts
+++ b/app/src/mailsync-process.ts
@@ -261,21 +261,24 @@ export class MailsyncProcess extends EventEmitter {
   _spawnAndWait(mode, { onData }: { onData?: (data: any) => void } = {}) {
     return new Promise<{ response: any; buffer: Buffer }>((resolve, reject) => {
       this._spawnProcess(mode);
-      // `buffer` is both streams together and is what we show the user when something goes
-      // wrong; `out` is stdout alone, which is the only place the JSON result appears.
-      let buffer = Buffer.from([]);
-      let out = Buffer.from([]);
+      // `bothChunks` is both streams together and is what we show the user when something
+      // goes wrong; `outChunks` is stdout alone, which is the only place the JSON result
+      // appears. Chunks are concatenated as bytes and decoded once at the end: `a += b` on
+      // two Buffers coerces both through toString(), which decodes every chunk on its own
+      // and mangles any multi-byte character that straddles a chunk boundary.
+      const bothChunks: Buffer[] = [];
+      const outChunks: Buffer[] = [];
 
       if (this._proc.stdout) {
-        this._proc.stdout.on('data', (data) => {
-          buffer += data;
-          out += data;
+        this._proc.stdout.on('data', (data: Buffer) => {
+          bothChunks.push(data);
+          outChunks.push(data);
           if (onData) onData(data);
         });
       }
       if (this._proc.stderr) {
-        this._proc.stderr.on('data', (data) => {
-          buffer += data;
+        this._proc.stderr.on('data', (data: Buffer) => {
+          bothChunks.push(data);
           if (onData) onData(data);
         });
       }
@@ -285,8 +288,9 @@ export class MailsyncProcess extends EventEmitter {
       });
 
       this._proc.on('close', (code, signal) => {
+        const buffer = Buffer.concat(bothChunks);
         try {
-          const response = lastJSONResponse(out.toString('utf-8'));
+          const response = lastJSONResponse(Buffer.concat(outChunks).toString('utf-8'));
           if (!response) {
             // If the Mailsync executable itself failed to run, the logs are not JSON
             // and may contain system errors (shared library issues, etc). Include this

--- a/app/src/mailsync-process.ts
+++ b/app/src/mailsync-process.ts
@@ -89,6 +89,30 @@ export const LocalizedErrorStrings = {
 // being treated as expected, user-actionable failures.
 const AMBIGUOUS_MAILSYNC_ERRORS = new Set(['ErrorParse', 'ErrorIdentityMissingFields']);
 
+/*
+Extracts mailsync's JSON result from what it wrote to stdout.
+
+The result is one JSON object, but the end of the stream is not reliably that object. It
+arrives without a trailing newline, mailsync prints human-readable progress lines before it
+(`Running Setup`), and on Linux it can emit a diagnostic - a missing libtidy is the common
+one - at any point. Parsing the last line of stdout and stderr combined turns any of those
+into "an unknown error has occurred mailsync: 0", so scan stdout backwards for the last
+line that actually parses.
+*/
+export function lastJSONResponse(stdout: string): any | null {
+  const lines = stdout.split('\n');
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i].trim();
+    if (!line.startsWith('{')) continue;
+    try {
+      return JSON.parse(line);
+    } catch (err) {
+      // Not the result line - keep looking further back.
+    }
+  }
+  return null;
+}
+
 export class MailsyncProcess extends EventEmitter {
   _proc: ChildProcess = null;
   _win = null;
@@ -237,11 +261,15 @@ export class MailsyncProcess extends EventEmitter {
   _spawnAndWait(mode, { onData }: { onData?: (data: any) => void } = {}) {
     return new Promise<{ response: any; buffer: Buffer }>((resolve, reject) => {
       this._spawnProcess(mode);
+      // `buffer` is both streams together and is what we show the user when something goes
+      // wrong; `out` is stdout alone, which is the only place the JSON result appears.
       let buffer = Buffer.from([]);
+      let out = Buffer.from([]);
 
       if (this._proc.stdout) {
         this._proc.stdout.on('data', (data) => {
           buffer += data;
+          out += data;
           if (onData) onData(data);
         });
       }
@@ -258,12 +286,8 @@ export class MailsyncProcess extends EventEmitter {
 
       this._proc.on('close', (code, signal) => {
         try {
-          const lastLine = buffer.toString('utf-8').split('\n').pop();
-
-          let response: any;
-          try {
-            response = JSON.parse(lastLine);
-          } catch (err) {
+          const response = lastJSONResponse(out.toString('utf-8'));
+          if (!response) {
             // If the Mailsync executable itself failed to run, the logs are not JSON
             // and may contain system errors (shared library issues, etc). Include this
             // in the logs so users can fix on their own or report detailed bugs.


### PR DESCRIPTION
When mailsync can't start, the reason is currently swallowed and the user gets `an unknown error has occurred mailsync: 0` — for a problem they could usually have fixed themselves.

The result is parsed by taking the last line of stdout and stderr *combined* and running `JSON.parse` over it. The end of that stream is very often not the JSON result:

- mailsync writes the result without a trailing newline
- it prints human-readable progress lines before it (`Running Setup`)
- on Linux it can emit a diagnostic at any point — a missing libtidy being the common one

Any of those make the parse throw, and the real message is lost.

### Change

stdout is now scanned backwards for the last line that actually parses as JSON, and stdout is tracked separately from the combined buffer — the result only ever appears on stdout, while the combined buffer is what gets shown when something goes wrong. A stream with no JSON in it reports the actual output rather than a made-up error code.

`lastJSONResponse` is exported and covered by unit tests: no trailing newline, preceding progress lines, blank lines, several objects, a truncated object at the end, CRLF line endings (Windows writes stdout in text mode), and output containing no JSON at all.

### Context

Extracted from a calendar PR that follows shortly. It's independent of that work, and this failure mode costs users a diagnosis today, so it seemed worth landing on its own.

### Testing

`npm test` passes (1651). `npm run lint`, `tsc --noEmit` and prettier all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Update

Rebased onto current master, and addressed the review.

- **`out += data` on two Buffers is not concatenation.** `+` coerces both operands through
  `toString()`, so the accumulator held a string from the first chunk onward and every chunk
  was decoded on its own. A multi-byte character straddling a chunk boundary lost both halves
  to replacement characters. Chunks are collected and joined with `Buffer.concat` now, decoded
  once at the end — which also makes the promise's `buffer: Buffer` annotation true, where it
  had been resolving a string. Two specs cover it.

  Worth being precise about the impact: the damage lands inside a JSON string, so the payload
  still parses and the user gets a corrupted error message rather than a failed one. That is
  the same class of unhelpful report this change set out to remove, which is why it is worth
  fixing here, but it is not usually a `null` response.

- **Dropped the submodule bump.** It pointed at the pre-merge tip of the sync-engine hardening
  branch, which existed only on my fork, so `git submodule update` would have failed for
  anyone who checked this out. That work has since landed upstream on its own, and this change
  is client-only and needs no engine change, so the pointer goes back to what master has.

CI on a runner where the suite actually executes (this branch stacked on #2840):
https://github.com/brhellman/Mailspring/actions/runs/33457247471 — **green, 3m59s**. Locally,
from a clean checkout of the pushed commit: lint clean, typecheck clean, 1675 specs passing.