### PR TITLE
Capture a real stack for stackless reportError() inputs

### DIFF
--- a/app/src/error-logger.js
+++ b/app/src/error-logger.js
@@ -60,25 +60,40 @@ module.exports = ErrorLogger = (function () {
     if (this.inSpecMode) {
       return;
     }
-    // Without a message and a stack, an error logged to Sentry shows up as
-    // "Unknown error" with only the IPC handler frame, which is unactionable.
-    // Wrap such inputs in a real Error here so we capture the call site as
-    // the stack and describe the original input in the message.
+    // An error reported without a stack shows up in Sentry attributed to
+    // wherever `new Error()` happened to run to give it one — for JSON
+    // reparsed in the main process's `report-error` IPC handler (see
+    // application.ts), that's the same IPC handler frame for every caller,
+    // regardless of the error's real origin (window.onerror, uncaughtException,
+    // unhandledrejection forwarding a bare rejection reason, or an explicit
+    // reportError() call). Every stackless error, whatever its message,
+    // collapses into one unactionable Sentry issue. Wrap such inputs in a
+    // real Error *here*, in the renderer, before the IPC hop: since callers
+    // differ, this call site's stack differs too, so Sentry attributes and
+    // groups them separately going forward. Keep the original message when
+    // there is one — only the stack is synthetic.
     var hasMessage =
       error && typeof error.message === 'string' && error.message.length > 0;
     var hasStack = error && typeof error.stack === 'string' && error.stack.length > 0;
-    if (!hasMessage && !hasStack) {
-      var description;
-      try {
-        description = JSON.stringify(error);
-      } catch (e) {
-        description = Object.prototype.toString.call(error);
+    if (!hasStack) {
+      var message;
+      if (hasMessage) {
+        message = error.message;
+      } else {
+        var description;
+        try {
+          description = JSON.stringify(error);
+        } catch (e) {
+          description = Object.prototype.toString.call(error);
+        }
+        message = 'Empty error reported (' + description + ')';
       }
-      var wrapped = new Error('Empty error reported (' + description + ')');
+      var wrapped = new Error(message);
       if (error && typeof error === 'object') {
-        // Copy any other useful fields from the original, but never let an
-        // empty `message`/`stack` on the input clobber the wrap's real values
-        // — that would defeat the whole purpose of wrapping.
+        // Copy any other useful fields from the original, but never let a
+        // missing `stack` (or, when we just fell back to the description
+        // above, an empty `message`) on the input clobber the wrap's real
+        // values — that would defeat the whole purpose of wrapping.
         try {
           var keys = Object.getOwnPropertyNames(error);
           for (var i = 0; i < keys.length; i++) {


### PR DESCRIPTION
## What I observed

[MAILSPRING-CLIENT-A](https://foundry-376-llc.sentry.io/issues/MAILSPRING-CLIENT-A) — `Error: Unknown error` — is by far the highest-impact unassigned, unresolved issue in the project: **259 users, 5189 events**, ongoing since May.

Every event's stack trace is identical and useless — a single frame pointing at `application.ts`'s `report-error` IPC handler, specifically the line where it does `new Error(message || undefined)` when reconstructing an error from JSON sent over IPC from a renderer. That's the *construction* site of the wrapper, not the real origin of the error.

Tracing the renderer side: `AppEnv`'s `window.addEventListener('unhandledrejection', ...)` handler (`app-env.ts`) forwards a bare promise rejection reason straight to `errorLogger.reportError()` whenever the reason itself doesn't have a stack (`e.reason`) — this is common for certain native/DOM promise rejections whose reason carries a `message` but never captured a JS stack. `error-logger.js`'s `reportError()` already has logic to synthesize a stack for garbage input, but it only kicks in when there's **neither** a message **nor** a stack:

```js
if (!hasMessage && !hasStack) { /* wrap in a real Error to get a stack */ }
```

A rejection reason with a message ("Unknown error") but no stack skips this wrap entirely, gets JSON-stringified as-is, and only becomes a real `Error` object (with an auto-generated stack) once it reaches the IPC handler in the main process — where every caller, regardless of true origin, produces the exact same one-frame stack. That's why this single issue has absorbed 5189 events from what could be many distinct underlying problems: they're all indistinguishable once they hit Sentry.

## The fix

Broaden the existing wrap in `error-logger.js` to trigger whenever a **stack** is missing, not only when both message and stack are missing — while still preserving the original message when there is one (only the stack is synthetic). Since this runs in the renderer, before the IPC hop, and each caller (`window.onerror`, `uncaughtException`, `unhandledrejection`, or any other explicit `reportError()` call) has its own call site, Sentry will now attribute and group these separately going forward instead of bucketing every stackless error into one "Unknown error" (or whatever generic message) issue.

This doesn't change behavior for errors that already have a real stack, and doesn't touch the "drop reports with neither message nor stack" defense-in-depth check in `application.ts`'s IPC handler (still valid for callers that bypass this wrapping entirely).

Fixes MAILSPRING-CLIENT-A

## Test plan

- [x] `node --check app/src/error-logger.js` — syntax valid
- [ ] Manually trigger an `unhandledrejection` with a message-only, stack-less reason (e.g. `Promise.reject({ message: 'test', name: 'TestError' })`) in dev tools and confirm the resulting Sentry-bound error now carries a stack pointing at `app-env.ts`'s handler rather than `application.ts`'s IPC handler
- [ ] Confirm normal `Error` instances (with real stacks) are unaffected

---
_Generated by [Claude Code](https://claude.ai/code/session_01WmwYT15gaW8rVnrKk1Y6da)_