### PR TITLE
Fix the three type errors that keep CI red

### DIFF
--- a/app/internal_packages/print/lib/print-window.ts
+++ b/app/internal_packages/print/lib/print-window.ts
@@ -98,7 +98,11 @@ export default class PrintWindow {
 
       try {
         const data = await this.browserWin.webContents.printToPDF({
-          margins: { marginType: 'none' },
+          // Electron 21 replaced the old top-level `marginsType` enum with explicit
+          // per-side inches (PrintToPDFMargins). `marginType: 'none'` was neither: an
+          // unrecognised key, silently ignored, so these PDFs have been printing with the
+          // default 1cm margins rather than none.
+          margins: { top: 0, bottom: 0, left: 0, right: 0 },
           pageSize: 'Letter',
           printBackground: true,
           landscape: false,

--- a/app/src/sheet-container.tsx
+++ b/app/src/sheet-container.tsx
@@ -14,6 +14,21 @@ interface SheetContainerState {
   error?: string;
 }
 
+/*
+Marks a stacked-under subtree inert, so it takes no focus and no pointer events.
+
+Spread rather than written as `inert={...}`: `inert` is a real HTML attribute that React
+passes straight through, but it is absent from React 17's JSX types. The augmentation in
+types/react-ext.d.ts declares it and does not take effect, because two copies of
+@types/react are installed - one under app/node_modules, one at the repo root - and both
+register a global JSX namespace, so the copy that wins the JSX check is not the copy the
+`declare module 'react'` augmentation merges into. Spreading sidesteps the attribute-name
+check without asserting anything about the element.
+*/
+function inertWhenStacked(stacked: boolean): { inert?: '' } {
+  return stacked ? { inert: '' } : {};
+}
+
 export default class SheetContainer extends React.Component<
   Record<string, unknown>,
   SheetContainerState
@@ -109,7 +124,7 @@ export default class SheetContainer extends React.Component<
         style={{ order: 0, zIndex: 3 }}
         onClick={this._onToolbarDoubleClick}
       >
-        <div inert={this.state.stack.length > 1 ? '' : undefined}>{components[0]}</div>
+        <div {...inertWhenStacked(this.state.stack.length > 1)}>{components[0]}</div>
         <TransitionGroup component={null}>
           {components.slice(1).map((comp) => (
             <CSSTransition key={comp.key} classNames="opacity-125ms" timeout={125}>
@@ -158,7 +173,7 @@ export default class SheetContainer extends React.Component<
           style={{ order: 2, flex: 1, position: 'relative', zIndex: 1 }}
           aria-label={localized('Email workspace')}
         >
-          <div inert={totalSheets > 1 ? '' : undefined}>{sheetComponents[0]}</div>
+          <div {...inertWhenStacked(totalSheets > 1)}>{sheetComponents[0]}</div>
           <TransitionGroup component={null}>
             {sheetComponents.slice(1).map((comp) => (
               <CSSTransition key={comp.key} classNames="sheet-stack" timeout={125}>


### PR DESCRIPTION
`npm run typecheck` exits 2 on `master`, so the Test workflow fails on every push and every pull request — [the last several runs on master are red](https://github.com/Foundry376/Mailspring/actions/workflows/test.yaml?query=branch%3Amaster). That makes CI useless as a signal: a contributor can't tell whether their branch broke something, and neither can a reviewer.

Three errors, and one of them is a live bug.

### `printToPDF` margins (also a behaviour fix)

`app/internal_packages/print/lib/print-window.ts` passes `margins: { marginType: 'none' }`. Electron 21 replaced the old top-level `marginsType` enum with explicit per-side inches (`PrintToPDFMargins`), and `marginType` is neither — it's an unrecognised key that Electron silently ignores, so **"Save as PDF" has been printing with the default 1cm margins rather than the none that was intended.**

Changed to `{ top: 0, bottom: 0, left: 0, right: 0 }`, which fixes the output as well as the type.

### `inert` on the stacked-sheet wrappers

`inert` is a real HTML attribute that React passes straight through, but it's absent from React 17's JSX types. `app/src/types/react-ext.d.ts` already declares it — and has no effect, which took some digging:

Two copies of `@types/react` are installed, one under `app/node_modules` (17.0.93) and one at the repo root (17.0.91). Both are inside the typeRoot search path and both register a global `JSX` namespace, so the copy that wins the JSX check isn't the copy the `declare module 'react'` augmentation merges into.

The attribute is now spread from a small helper, which keeps the runtime behaviour and the intent legible without asserting anything about the element.

I tried scoping `typeRoots` to one copy first — that's worse: `@types/jasmine` lives at the repo root, so it produces 5,412 errors across the specs. Deduplicating `@types/react` properly is worth doing but belongs in its own change, not one meant to get CI reporting again.

### Result

`npm run typecheck` exits 0 with no errors. `npm run lint:check` clean, `npm test` passes (1643), prettier clean.

I have two other PRs open ([Mailspring#2827](https://github.com/Foundry376/Mailspring/pull/2827), [Mailspring-Sync#122](https://github.com/Foundry376/Mailspring-Sync/pull/122)) and a larger calendar PR coming; this one is independent of all of them, and landing it first means their CI results actually mean something.

🤖 Generated with [Claude Code](https://claude.com/claude-code)