### PR TITLE
autostart: use XDG Desktop Portals when running inside of flatpak

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -68,6 +68,7 @@
         "underscore.string": "^3.3.5",
         "vcf": "^2.0.5",
         "windows-iana": "^4.2.1",
+        "xdg-portal": "^1.2.0",
         "xml2js": "^0.6.2"
       },
       "optionalDependencies": {
@@ -1036,6 +1037,21 @@
       "license": "MIT",
       "dependencies": {
         "es5-ext": "~0.10.2"
+      }
+    },
+    "node_modules/dbus-native": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/dbus-native/-/dbus-native-0.15.2.tgz",
+      "integrity": "sha512-J1IBi4LmbqrFhroN66Dj1tCCTP6TVbZgUKhWQZf3uS6t93yRWEcRRDjOZV9N6boGRhOp/BOjLliFm9vWu1QZOA==",
+      "license": "MIT",
+      "dependencies": {
+        "xml2js": "^0.6.2"
+      },
+      "bin": {
+        "dbus-native": "bin/dbus-native.js"
+      },
+      "engines": {
+        "node": ">=22.12.0"
       }
     },
     "node_modules/debug": {
@@ -5191,6 +5207,18 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/xdg-portal": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/xdg-portal/-/xdg-portal-1.2.0.tgz",
+      "integrity": "sha512-GDAtaJ/t08UyNuQddNgU9meqCpDPEI2pXGZpbPv1ZHrVbB9YAiWF8r7xk+puZkTP5tDDdqfY/Ow3msvdBAAucg==",
+      "license": "MIT",
+      "dependencies": {
+        "dbus-native": "^0.15.2"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
     },
     "node_modules/xml2js": {
       "version": "0.6.2",

--- a/app/package.json
+++ b/app/package.json
@@ -71,6 +71,7 @@
     "underscore.string": "^3.3.5",
     "vcf": "^2.0.5",
     "windows-iana": "^4.2.1",
+    "xdg-portal": "^1.2.0",
     "xml2js": "^0.6.2"
   },
   "overrides": {

--- a/app/src/system-start-service.ts
+++ b/app/src/system-start-service.ts
@@ -2,6 +2,8 @@ import path from 'path';
 import fs from 'fs';
 import pkg from './utils/package';
 import { getFirstExistingPath, XDG_CONFIG_PATHS, XDG_DATA_PATHS } from './utils/xdg-paths';
+import * as portal from 'xdg-portal';
+import { localized } from './intl';
 
 class SystemStartServiceBase {
   checkAvailability(): Promise<boolean> {
@@ -105,7 +107,7 @@ class SystemStartServiceWin32 extends SystemStartServiceBase {
   }
 }
 
-class SystemStartServiceLinux extends SystemStartServiceBase {
+class SystemStartServiceLinuxDesktopFile extends SystemStartServiceBase {
   async checkAvailability(): Promise<boolean> {
     return this._launcherPath() !== null;
   }
@@ -154,12 +156,63 @@ class SystemStartServiceLinux extends SystemStartServiceBase {
   }
 }
 
+class SystemStartServiceLinuxBackgroundPortal extends SystemStartServiceBase {
+  private async doPortalRequest(
+    options: portal.Background.RequestBackgroundOptions
+  ): Promise<void> {
+    const client = await portal.client();
+    const response = await client.desktop.Background.RequestBackground('', options);
+    client.close();
+    if (response.response !== 0 || !response.results.background)
+      throw new Error(`Portal denied setting autostart: ${JSON.stringify(response)}`);
+  }
+
+  async checkAvailability(): Promise<boolean> {
+    // We assume that this backend does only get used when the portal is available
+    return true;
+  }
+
+  async doesLaunchOnSystemStart(): Promise<boolean> {
+    // Currently no better way to check this
+    return process.argv.includes('--background');
+  }
+
+  configureToLaunchOnSystemStart() {
+    this.doPortalRequest({
+      autostart: true,
+      commandline: ['mailspring', '--background', '%U'],
+      reason: localized(
+        'Mailspring needs to run in the background to check for new mail and show notifications.'
+      ),
+    }).catch((error) => {
+      console.error('Error configuring to launch on system start:', error);
+    });
+  }
+
+  dontLaunchOnSystemStart() {
+    this.doPortalRequest({
+      autostart: false,
+    }).catch((error) => {
+      console.error('Error configuring to not launch on system start:', error);
+    });
+  }
+}
+
+function usePortal(): boolean {
+  return (
+    process.env.FLATPAK_ID !== undefined ||
+    process.env.MAILSPRING_FORCE_BACKGROUND_PORTAL === 'true'
+  );
+}
+
 /* eslint import/no-mutable-exports: 0*/
 let SystemStartService;
 if (process.platform === 'darwin') {
   SystemStartService = SystemStartServiceDarwin;
 } else if (process.platform === 'linux') {
-  SystemStartService = SystemStartServiceLinux;
+  SystemStartService = usePortal()
+    ? SystemStartServiceLinuxBackgroundPortal
+    : SystemStartServiceLinuxDesktopFile;
 } else if (process.platform === 'win32') {
   SystemStartService = SystemStartServiceWin32;
 } else {


### PR DESCRIPTION
Using the [Background Portal](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Background.html) is the modern way on Linux to configure autostart. It has the advantage to work in sandboxed environments like Flatpak, where `$XDG_CONFIG_HOME/autostart` is not accessible.

It has the shortcoming however, that there is no reliable way to tell if the app already is configured to autostart. Thats why i enable this backend only in flatpak by default right now.