### PR TITLE
Fix crash in thread list context menu for threads with no participants

### DIFF
--- a/app/internal_packages/thread-list/lib/thread-list-context-menu.ts
+++ b/app/internal_packages/thread-list/lib/thread-list-context-menu.ts
@@ -76,6 +76,9 @@ export default class ThreadListContextMenu {
     }
     const first = this.threads[0];
     const from = first.participants.find((p) => !p.isMe()) || first.participants[0];
+    if (!from) {
+      return null;
+    }
 
     return {
       label: localized(`Search for`) + ' ' + from.email,


### PR DESCRIPTION
## Summary

Fixes [MAILSPRING-CLIENT-4E](https://foundry-376-llc.sentry.io/issues/MAILSPRING-CLIENT-4E) — "Cannot read properties of undefined (reading 'email')", 18 users impacted, 105 events over the last release cycle.

**What I observed:** The stack trace pointed at `ThreadListContextMenu.findWithFrom()` in `app/internal_packages/thread-list/lib/thread-list-context-menu.ts:81`, specifically the line `label: localized('Search for') + ' ' + from.email`. That means `from` was `undefined`.

`from` is computed as:
```ts
const from = first.participants.find((p) => !p.isMe()) || first.participants[0];
```
This only comes back `undefined` if `first.participants` is an empty array — `.find()` returns `undefined` and `participants[0]` is also `undefined`. Looking at `AttributeCollection.fromJSON` (`app/src/flux/attributes/attribute-collection.ts`), a thread's `participants` collection is always materialized as an array, but it can legitimately be empty (e.g. a draft-only thread with no sent/received messages yet, or a thread whose participants haven't synced). The sibling component `thread-list-participants.tsx` already defends against exactly this case (`thread.participants != null ? thread.participants : []`), so this is a known edge case elsewhere in the same package that `findWithFrom()` didn't account for.

**Root cause:** Right-clicking a thread with zero participants in the thread list (e.g. a thread whose only message is a still-unsent draft) throws inside the context menu builder, before the menu can even be shown.

## Fix

Add a guard so `findWithFrom()` returns `null` (omitting the "Search for <email>" menu item) when there's no participant to search for, mirroring the existing `null`-item pattern used by every other menu item builder in this file (which are already filtered out via `.filter(Boolean)` in `menuItemTemplate()`).

## Test plan

- [ ] Right-click a thread whose only message is an unsent draft (no participants) in the thread list and confirm the context menu opens without throwing, and simply omits the "Search for" item.
- [ ] Right-click a normal thread with participants and confirm the "Search for <email>" item still appears and works as before.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01RRiBUp2n7jxGDLyYQNpEBW

---
_Generated by [Claude Code](https://claude.ai/code/session_01RRiBUp2n7jxGDLyYQNpEBW)_