### PR TITLE
Build CI on ubuntu-24.04 so npm ci can compile against Electron 43

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4
@@ -22,10 +22,10 @@ jobs:
             dbus-x11 \
             libgbm1 \
             libnss3 \
-            libasound2 \
-            libatk1.0-0 \
-            libatk-bridge2.0-0 \
-            libgtk-3-0
+            libasound2t64 \
+            libatk1.0-0t64 \
+            libatk-bridge2.0-0t64 \
+            libgtk-3-0t64
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -41,6 +41,13 @@ jobs:
 
       - name: Run Typecheck
         run: npm run typecheck
+
+      # Ubuntu 23.10+ restricts unprivileged user namespaces through AppArmor, so
+      # Electron cannot use its namespace sandbox and falls back to the SUID helper,
+      # which is not setuid root inside node_modules. Re-allow the namespace sandbox
+      # rather than passing --no-sandbox, so the tests run the way the app ships.
+      - name: Allow Electron's namespace sandbox
+        run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
 
       - name: Run tests
         run: dbus-launch --exit-with-session xvfb-run -a npm test


### PR DESCRIPTION
The Test workflow has failed on **every run since `292a00ff8` ("Update electron from 41.7.2 -> 43.4.1", #2818) landed on 2026-08-23** — about 20 runs. It fails at step 5, `npm ci`, so lint, typecheck and the test suite never run at all.

That means CI has been reporting a red X that says nothing about the change under test. #2829 fixed the typecheck half of what #2818 broke; this is the build half.

### Cause

`better-sqlite3` is compiled from source against Electron's headers, and `ubuntu-22.04` ships GCC 11, which cannot parse the V8 headers Electron 43 brings in:

```
node/v8config.h:854: error: expected identifier before '__attribute__'
node/v8-primitive.h:658: error: expected primary-expression before 'public'
make: *** [better_sqlite3.target.mk:138] Error 1
gyp ERR! build error
```

`ubuntu-24.04` ships GCC 13, which parses them.

### Why the package renames are in the same commit

The runner bump alone would break the apt step. Ubuntu's 64-bit `time_t` transition renamed four of the listed libraries on noble:

| 22.04 | 24.04 |
|---|---|
| `libasound2` | `libasound2t64` |
| `libatk1.0-0` | `libatk1.0-0t64` |
| `libatk-bridge2.0-0` | `libatk-bridge2.0-0t64` |
| `libgtk-3-0` | `libgtk-3-0t64` |

`libgtk-3-0` does not exist on noble under the old name, and `libasound2` survives only as a *virtual* package provided by `liboss4-salsa-asound2` — so leaving the list untouched would quietly swap ALSA for an OSS compatibility shim. `xvfb`, `dbus-x11`, `libgbm1` and `libnss3` are unaffected.

### What this deliberately does not touch

`build-linux.yaml` stays on `ubuntu-22.04`. It produces the released binaries, and moving it to noble would raise the glibc baseline from 2.35 to 2.39 for every Linux user — that is a distribution decision, not a CI fix, and it is yours to make rather than mine.

Worth knowing that the same `npm ci` failure is waiting there: `Build for Linux` is `workflow_dispatch`-only and last ran successfully on 2026-07-22, a month before the Electron bump, so it will fail the next time it is dispatched. If you want to keep the 22.04 glibc baseline, installing `g++-12` and setting `CXX` on that runner would do it. Happy to send that as a follow-up once you say which way you want it.

### Verification

The check on this PR is the test: it runs the workflow as modified, so a green Test job here is the fix demonstrating itself.