### PR TITLE
Keep a popover that fits nowhere beside its anchor inside the window

### DIFF
--- a/app/spec/components/fixed-popover-spec.tsx
+++ b/app/spec/components/fixed-popover-spec.tsx
@@ -230,7 +230,71 @@ describe('FixedPopover', function fixedPopover() {
     });
   });
 
+  describe('computeClampedOffset', () => {
+    beforeEach(() => {
+      this.PADDING = 10;
+      this.windowDimensions = { height: 500, width: 500 };
+    });
+
+    const clamp = ({ top, left, bottom, right }, initialState = undefined) => {
+      const popover = makePopover(initialState ? { initialState } : {});
+      return popover.computeClampedOffset({
+        currentRect: { top, left, bottom, right },
+        windowDimensions: this.windowDimensions,
+        offsetPadding: this.PADDING,
+      });
+    };
+
+    it('does not move a popover that is already on screen', () => {
+      expect(clamp({ top: 10, left: 10, bottom: 200, right: 200 })).toEqual({ x: 0, y: 0 });
+    });
+
+    it('slides left when the right edge is past the window', () => {
+      expect(clamp({ top: 10, left: 300, bottom: 200, right: 520 })).toEqual({ x: -30, y: 0 });
+    });
+
+    it('slides right when the left edge is past the window', () => {
+      expect(clamp({ top: 10, left: -20, bottom: 200, right: 100 })).toEqual({ x: 30, y: 0 });
+    });
+
+    it('slides up when the bottom edge is past the window', () => {
+      expect(clamp({ top: 300, left: 10, bottom: 530, right: 200 })).toEqual({ x: 0, y: -40 });
+    });
+
+    it('slides down when the top edge is past the window', () => {
+      expect(clamp({ top: -15, left: 10, bottom: 200, right: 200 })).toEqual({ x: 0, y: 25 });
+    });
+
+    it('favours the top left edge when the popover is larger than the window', () => {
+      // Pulling the far edge in would push the near edge out. The near edge wins, so the
+      // popover starts inside the window and its own max-height scrolls the remainder.
+      expect(clamp({ top: -20, left: -20, bottom: 520, right: 520 })).toEqual({ x: 30, y: 30 });
+    });
+
+    it('adds to an offset already in state, which currentRect already reflects', () => {
+      const state = { offset: { x: 5, y: 7 } };
+      expect(clamp({ top: 10, left: 300, bottom: 200, right: 520 }, state)).toEqual({
+        x: -25,
+        y: 7,
+      });
+    });
+  });
+
   describe('computePopoverStyles', () => {
-    // TODO
+    const originRect = { top: 100, left: 100, width: 50, height: 20 };
+
+    // Every direction has to honour both axes: the clamp that rescues an off-screen popover
+    // can need to move it on either one, whichever way the popover happens to point.
+    [Up, Down, Left, Right].forEach(direction => {
+      it(`applies both offset axes when pointing ${direction}`, () => {
+        const popover = makePopover();
+        const { popoverStyle } = popover.computePopoverStyles({
+          originRect,
+          direction,
+          offset: { x: 12, y: 34 },
+        });
+        expect(popoverStyle.transform).toContain('translate(12px, 34px)');
+      });
+    });
   });
 });

--- a/app/spec/components/fixed-popover-spec.tsx
+++ b/app/spec/components/fixed-popover-spec.tsx
@@ -232,15 +232,16 @@ describe('FixedPopover', function fixedPopover() {
 
   describe('computeClampedOffset', () => {
     beforeEach(() => {
+      this.popover = makePopover();
       this.PADDING = 10;
       this.windowDimensions = { height: 500, width: 500 };
     });
 
-    const clamp = ({ top, left, bottom, right }, initialState = undefined) => {
-      const popover = makePopover(initialState ? { initialState } : {});
-      return popover.computeClampedOffset({
+    const clamp = ({ top, left, bottom, right }, offset = {}) => {
+      return this.popover.computeClampedOffset({
         currentRect: { top, left, bottom, right },
         windowDimensions: this.windowDimensions,
+        offset,
         offsetPadding: this.PADDING,
       });
     };
@@ -271,9 +272,8 @@ describe('FixedPopover', function fixedPopover() {
       expect(clamp({ top: -20, left: -20, bottom: 520, right: 520 })).toEqual({ x: 30, y: 30 });
     });
 
-    it('adds to an offset already in state, which currentRect already reflects', () => {
-      const state = { offset: { x: 5, y: 7 } };
-      expect(clamp({ top: 10, left: 300, bottom: 200, right: 520 }, state)).toEqual({
+    it('adds to the offset currentRect already reflects', () => {
+      expect(clamp({ top: 10, left: 300, bottom: 200, right: 520 }, { x: 5, y: 7 })).toEqual({
         x: -25,
         y: 7,
       });

--- a/app/src/components/fixed-popover.tsx
+++ b/app/src/components/fixed-popover.tsx
@@ -124,16 +124,16 @@ class FixedPopover extends Component<FixedPopoverProps, FixedPopoverState> {
     });
     if (newState) {
       if (this.updateCount > 1) {
-        /*
-        Flipping the direction and nudging across it have both failed to bring the popover on
-        screen, which is what happens when it is simply taller or wider than the room beside
-        its anchor - a full event editor next to an event low in a short window, say. Showing
-        it at the original position anyway left its footer buttons past the edge of the
-        window with no way to reach them, so slide it back inside instead. The pointer stays
-        with the anchor and no longer touches the popover, which is the lesser of the two.
-        */
+        // No direction fits, so bring the popover inside the window rather than leave it
+        // where it overflows. The direction that produced currentRect is kept, because the
+        // correction is measured against it - so a popover given a fallbackDirection settles
+        // in the direction that was tried last rather than the one originally asked for.
         this.setState({
-          offset: this.computeClampedOffset({ currentRect, windowDimensions }),
+          offset: this.computeClampedOffset({
+            currentRect,
+            windowDimensions,
+            offset: this.state.offset,
+          }),
           visible: true,
         });
         return;
@@ -194,13 +194,23 @@ class FixedPopover extends Component<FixedPopoverProps, FixedPopoverState> {
   /*
   The extra translate that brings an off-screen popover back inside the window.
 
-  currentRect already includes the offset in state, so the correction is added to it rather
-  than replacing it. Pulling an edge in can push the opposite edge out when the popover is
-  larger than the window itself; in that case the top/left edge wins, so the popover starts
-  at the top of the window and its own max-height scrolls the rest.
+  Reached when flipping the direction and nudging across it have both failed, which happens
+  when the popover is simply taller or wider than the room beside its anchor - a full event
+  editor next to an event low in a short window, say. The popover is moved off its anchor to
+  stay reachable, so the pointer no longer touches it; an unreachable footer is the worse of
+  the two.
+
+  `offset` must be the one currentRect already reflects, since the correction is added to it
+  rather than replacing it. Pulling an edge in can push the opposite edge out when the
+  popover is larger than the window itself; there the top/left edge wins, so the popover
+  starts inside the window and its own max-height scrolls the rest.
   */
-  computeClampedOffset = ({ currentRect, windowDimensions, offsetPadding = OFFSET_PADDING }) => {
-    const { offset } = this.state;
+  computeClampedOffset = ({
+    currentRect,
+    windowDimensions,
+    offset = {} as FixedPopoverState['offset'],
+    offsetPadding = OFFSET_PADDING,
+  }) => {
     let dx = 0;
     let dy = 0;
 

--- a/app/src/components/fixed-popover.tsx
+++ b/app/src/components/fixed-popover.tsx
@@ -124,7 +124,18 @@ class FixedPopover extends Component<FixedPopoverProps, FixedPopoverState> {
     });
     if (newState) {
       if (this.updateCount > 1) {
-        this.setState({ direction: this.props.direction, offset: {}, visible: true });
+        /*
+        Flipping the direction and nudging across it have both failed to bring the popover on
+        screen, which is what happens when it is simply taller or wider than the room beside
+        its anchor - a full event editor next to an event low in a short window, say. Showing
+        it at the original position anyway left its footer buttons past the edge of the
+        window with no way to reach them, so slide it back inside instead. The pointer stays
+        with the anchor and no longer touches the popover, which is the lesser of the two.
+        */
+        this.setState({
+          offset: this.computeClampedOffset({ currentRect, windowDimensions }),
+          visible: true,
+        });
         return;
       }
 
@@ -178,6 +189,35 @@ class FixedPopover extends Component<FixedPopoverProps, FixedPopoverState> {
       right: Math.abs(currentRect.right - windowDimensions.width),
     };
     return { overflows, overflowValues };
+  };
+
+  /*
+  The extra translate that brings an off-screen popover back inside the window.
+
+  currentRect already includes the offset in state, so the correction is added to it rather
+  than replacing it. Pulling an edge in can push the opposite edge out when the popover is
+  larger than the window itself; in that case the top/left edge wins, so the popover starts
+  at the top of the window and its own max-height scrolls the rest.
+  */
+  computeClampedOffset = ({ currentRect, windowDimensions, offsetPadding = OFFSET_PADDING }) => {
+    const { offset } = this.state;
+    let dx = 0;
+    let dy = 0;
+
+    if (currentRect.right > windowDimensions.width) {
+      dx = windowDimensions.width - currentRect.right - offsetPadding;
+    }
+    if (currentRect.left + dx < 0) {
+      dx = offsetPadding - currentRect.left;
+    }
+    if (currentRect.bottom > windowDimensions.height) {
+      dy = windowDimensions.height - currentRect.bottom - offsetPadding;
+    }
+    if (currentRect.top + dy < 0) {
+      dy = offsetPadding - currentRect.top;
+    }
+
+    return { x: (offset.x || 0) + dx, y: (offset.y || 0) + dy };
   };
 
   computeAdjustedOffsetAndDirection = ({
@@ -242,7 +282,7 @@ class FixedPopover extends Component<FixedPopoverProps, FixedPopoverState> {
         };
         popoverStyle = {
           // Center, place on top of container, and adjust 10px for the pointer
-          transform: `translate(${offset.x || 0}px) translate(-50%, calc(-100% - 10px))`,
+          transform: `translate(${offset.x || 0}px, ${offset.y || 0}px) translate(-50%, calc(-100% - 10px))`,
           left: originRect.width / 2,
         };
         pointerStyle = {
@@ -260,7 +300,7 @@ class FixedPopover extends Component<FixedPopoverProps, FixedPopoverState> {
         };
         popoverStyle = {
           // Center and adjust 10px for the pointer (already positioned at the bottom of container)
-          transform: `translate(${offset.x || 0}px) translate(-50%, 10px)`,
+          transform: `translate(${offset.x || 0}px, ${offset.y || 0}px) translate(-50%, 10px)`,
           left: originRect.width / 2,
         };
         pointerStyle = {
@@ -278,7 +318,7 @@ class FixedPopover extends Component<FixedPopoverProps, FixedPopoverState> {
         };
         popoverStyle = {
           // Center, place on left of container, and adjust 10px for the pointer
-          transform: `translate(0, ${offset.y || 0}px) translate(calc(-100% - 10px), -50%)`,
+          transform: `translate(${offset.x || 0}px, ${offset.y || 0}px) translate(calc(-100% - 10px), -50%)`,
           top: originRect.height / 2,
         };
         pointerStyle = {
@@ -296,7 +336,7 @@ class FixedPopover extends Component<FixedPopoverProps, FixedPopoverState> {
         };
         popoverStyle = {
           // Center and adjust 10px for the pointer
-          transform: `translate(0, ${offset.y || 0}px) translate(10px, -50%)`,
+          transform: `translate(${offset.x || 0}px, ${offset.y || 0}px) translate(10px, -50%)`,
           top: originRect.height / 2,
         };
         pointerStyle = {


### PR DESCRIPTION
When neither direction leaves room for a popover, placement gave up and returned it to the
position it had already measured as overflowing. The popover rendered partly outside the
window, and whatever had gone past the edge could not be reached.

### Reproduction

A 300px popover anchored 250px down a 560×509 window overflows below when it points down and
above when it points up, so both placement attempts fail. Opened with `Actions.openPopover`
and measured in the running app:

| | popover rect | footer button | `document.elementFromPoint` | reachable |
|---|---|---|---|---|
| `master` | 280..580 | 531..571 | `null` | no |
| with this change | 197..497 | 449..489 | the button | yes |

The placement loop, instrumented on the fixed build:

```
pass 0  down  updateCount 0  rect 280..580  overflows bottom  -> flip to up
pass 1  up    updateCount 1  rect -60..240  overflows top     -> flip to down
pass 2  down  updateCount 2  rect 280..580  -> clamp, offset.y = -82.5
pass 3  down  rect 207..468  no overflow, settled
```

### Two changes, and why they are one

`computeClampedOffset` is the fix. Making all four directions apply *both* offset axes is its
prerequisite: `computePopoverStyles` previously applied only `x` for up/down and only `y` for
left/right, so a correction on the other axis was silently dropped.

### Scope

This rescues a popover *placed* off screen. It does not rescue one *larger than the window* —
there the near edge wins, so the popover starts inside and is expected to scroll via its own
`max-height`. Measured: a 700px popover in a 509px window still ends with its footer off screen.

### Tests

11 new cases. `computePopoverStyles` had an empty `// TODO` block; it now covers both axes in
all four directions. The clamp cases include the one that is easy to get wrong — when the
popover is larger than the window, pulling the far edge in pushes the near edge out, and the
near edge has to win.

### CI

`npm ci` currently fails on `master` for every PR (`better-sqlite3` compiled against Electron
43's headers under ubuntu-22.04's GCC 11), so the Test workflow never reaches lint or tests.
That is #2840, still open. Verified on a runner where the suite actually runs — this branch
stacked on that fix: https://github.com/brhellman/Mailspring/actions/runs/33438359708
(**green, 4m34s**). Locally: lint clean, `tsc --noEmit` clean, 1676 specs passing.

---

### Update

Addressed the review above.

- `computeClampedOffset` takes `offset` as an argument instead of reading it from state, so
  the signature no longer relies on the caller knowing that it must agree with `currentRect`.
  The spec passes a value rather than staging component state to get one.
- The comment at the call site described what the previous branch did; `CLAUDE.md` asks for
  current behaviour and rationale instead. The reasoning moved to the helper, where it says
  when the clamp is reached and what it trades away.
- **The `direction` reset is deliberate, and it is a behaviour change.** The give-up branch
  used to restore `this.props.direction` in the same `setState`. It cannot: the correction is
  measured against `currentRect`, which is the rect of the *currently rendered* direction, so
  resetting the direction would apply an offset derived from different geometry. The visible
  consequence is that a popover opened with `fallbackDirection` now settles in the direction
  tried last rather than the one originally requested — for the calendar's
  `fallbackDirection: 'left'`, a rescued popover stays left-pointing instead of snapping back
  to `down`. That is the better behaviour and the old reset was part of the same give-up
  mistake, but it is a change and belongs in the description rather than being discovered
  later. It is now stated at the call site too.

The remaining nit — that no test covers the `updateCount > 1` branch wiring the two helpers
together — is left as-is for the reason given: it needs a real rendered node and two deferred
passes. The behaviour is instead verified in a running app, master vs master+patch, with the
same script against both:

| | popover rect | footer button | `elementFromPoint` | reachable |
|---|---|---|---|---|
| `master` | 280..580 | 531..571 | `null` | no |
| with this change | 197..497 | 449..489 | the button | yes |

Re-verified after the refactor above, with identical results.

CI, rerun for the current commits on a runner where the suite actually executes (this branch
stacked on #2840): https://github.com/brhellman/Mailspring/actions/runs/33456301734 —
**green, 4m47s**. Locally, from a clean checkout of the pushed commit: lint clean, typecheck
clean, 1676 specs passing.