### PR TITLE
Stop marking every calendar invitee as a malformed address

### DIFF
--- a/app/internal_packages/main-calendar/lib/core/event-attendees-input.tsx
+++ b/app/internal_packages/main-calendar/lib/core/event-attendees-input.tsx
@@ -168,7 +168,11 @@ export class EventAttendeesInput extends React.Component<EventAttendeesInputProp
         ref="textField"
         tokens={this.props.attendees}
         tokenKey={(p) => p.email}
-        tokenIsValid={(p) => ContactStore.isValidContact(p)}
+        // An attendee is a plain {email, name, partstat} record read out of the event's ICS,
+        // never a Contact, so ContactStore.isValidContact - an `instanceof Contact` test -
+        // called every invitee invalid and drew the malformed-address underline under all of
+        // them. Validate the address itself.
+        tokenIsValid={(p) => new Contact({ email: p.email }).isValid()}
         tokenRenderer={TokenRenderer}
         onRequestCompletions={(input) => ContactStore.searchContacts(input)}
         shouldBreakOnKeydown={this._shouldBreakOnKeydown}

--- a/app/spec/event-attendees-input-spec.tsx
+++ b/app/spec/event-attendees-input-spec.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { render, cleanup } from '@testing-library/react';
+
+import { EventAttendeesInput } from '../internal_packages/main-calendar/lib/core/event-attendees-input';
+import { EventAttendee } from '../internal_packages/main-calendar/lib/core/calendar-data-source';
+
+const attendee = (email: string, name?: string): EventAttendee => ({
+  email,
+  name: name || '',
+  partstat: 'NEEDS-ACTION',
+});
+
+describe('EventAttendeesInput token validity', function () {
+  afterEach(cleanup);
+
+  const renderTokens = (attendees: EventAttendee[]) => {
+    const { container } = render(
+      <EventAttendeesInput attendees={attendees} change={() => {}} className="event-attendees" />
+    );
+    return container.querySelectorAll('.token');
+  };
+
+  it('does not mark well-formed attendees invalid', function () {
+    const tokens = renderTokens([
+      attendee('ben@mailspring.com'),
+      attendee('evan@example.com', 'Evan Morikawa'),
+    ]);
+    expect(tokens.length).toBe(2);
+    expect(tokens[0].classList.contains('invalid')).toBe(false);
+    expect(tokens[1].classList.contains('invalid')).toBe(false);
+  });
+
+  it('marks attendees whose address is malformed or missing', function () {
+    const tokens = renderTokens([
+      attendee('not-an-address'),
+      attendee(''),
+      attendee('ben@mailspring.com and friends'),
+    ]);
+    expect(tokens.length).toBe(3);
+    expect(tokens[0].classList.contains('invalid')).toBe(true);
+    expect(tokens[1].classList.contains('invalid')).toBe(true);
+    expect(tokens[2].classList.contains('invalid')).toBe(true);
+  });
+
+  it('accepts the plus-addressed and subdomain forms that appear in real invitations', function () {
+    const tokens = renderTokens([
+      attendee('ben+calendar@mailspring.com'),
+      attendee('ben@mail.corp.example.co.uk'),
+    ]);
+    expect(tokens[0].classList.contains('invalid')).toBe(false);
+    expect(tokens[1].classList.contains('invalid')).toBe(false);
+  });
+});


### PR DESCRIPTION
The invitee field in the calendar event editor drew the red dashed underline it uses for a
malformed address under **every** invitee, including the organiser and the user themselves.

`EventAttendeesInput` validated its tokens with `ContactStore.isValidContact`, which is an
`instanceof Contact` test:

```js
isValidContact(contact: any) {
  return contact instanceof Contact ? contact.isValid() : false;
}
```

An attendee is a plain `{ email, name, partstat }` record read out of the event's ICS by
`calendar-data-source`, never a `Contact`, so the test returned `false` for all of them and
`TokenizingTextField` rendered each token with `.invalid`.

This validates the address the way `Contact.isValid` does - a whole-string match against
`RegExpUtils.emailRegex()` - so real addresses are accepted and a malformed one is still
flagged.

### Verified

Three specs in `app/spec/calendar-attendee-validity-spec.tsx` assert the rendered
`.token.invalid` class, matching the convention in `tokenizing-text-field-spec`. They are a
real regression test, not a restatement - on master, two of the three fail:

| | result |
|---|---|
| master + the new specs | 1677 passing, **2 failing** |
| master + this change | 1679 passing, 0 failing |

Also confirmed in the running app against a live Google CalDAV account, opening the same
recurring meeting in both builds:

| build | rendered token state |
|---|---|
| master | `.invalid`, `border-bottom: 0.75px dashed rgb(255, 0, 0)` |
| this branch | not `.invalid`, `border-bottom: 0px none` |

And typing `not-an-address` into the live field still flags it, so the fix validates rather
than just switching the styling off.

`npm run lint:check`, `npm run typecheck` and `npm test` are all clean on the pushed commit.
