### PR TITLE
Show meetings whose series started years ago

### DIFF
--- a/app/internal_packages/main-calendar/lib/core/calendar-data-source.ts
+++ b/app/internal_packages/main-calendar/lib/core/calendar-data-source.ts
@@ -309,7 +309,18 @@ export function occurrencesForEvents(
     // Expand the master event's ICS (handles exceptions in same ICS file)
     if (master) {
       try {
-        const icalExpander = new IcalExpander({ ics: master.ics, maxIterations: 100 });
+        // The budget is derived from the series' own frequency rather than fixed. It was
+        // 100, which is not a limit on work but on how far back a series may begin: a
+        // weekly meeting older than about two years never reached the present, so it
+        // expanded to nothing and vanished from the calendar entirely.
+        const icalExpander = new IcalExpander({
+          ics: master.ics,
+          maxIterations: ICSEventHelpers.expansionIterationBudget(
+            master.ics,
+            master.recurrenceStart,
+            endUnix
+          ),
+        });
         const expanded = icalExpander.between(new Date(startUnix * 1000), new Date(endUnix * 1000));
 
         const masterIsRecurring = ICSEventHelpers.isRecurringEvent(master.ics);

--- a/app/spec/calendar-data-source-spec.ts
+++ b/app/spec/calendar-data-source-spec.ts
@@ -328,3 +328,36 @@ describe('occurrence id stability across query ranges', function () {
     expect(w.id).toBe(n.id);
   });
 });
+
+describe('occurrencesForEvents on a long-running series', function () {
+  // ical-expander steps forward from DTSTART with no way to seek, so the iteration cap bounds
+  // how far back a series may begin rather than how much a window costs. At the fixed 100 a
+  // weekly meeting that started in 2022 ran out around early 2024 and rendered nothing at all -
+  // no error, no gap, just absent from the calendar.
+  const weeklySince2022 = () =>
+    makeEvent(
+      icsFor('DTSTART:20220308T130000Z', 'DTEND:20220308T140000Z', 'RRULE:FREQ=WEEKLY;BYDAY=TU'),
+      { recurrenceStart: Date.UTC(2022, 2, 8, 13, 0, 0) / 1000 } as any
+    );
+
+  it('still reaches a week four years after the series began', function () {
+    const occs = occurrencesForEvents([weeklySince2022()], {
+      startUnix: Date.UTC(2026, 7, 30) / 1000,
+      endUnix: Date.UTC(2026, 8, 6) / 1000,
+    });
+    expect(occs.length).toBe(1);
+    expect(new Date(occurrenceStartUnix(occs[0]) * 1000).getUTCDate()).toBe(1);
+  });
+
+  it('expands a series that began this year the same way', function () {
+    const recent = makeEvent(
+      icsFor('DTSTART:20260804T130000Z', 'DTEND:20260804T140000Z', 'RRULE:FREQ=WEEKLY;BYDAY=TU'),
+      { recurrenceStart: Date.UTC(2026, 7, 4, 13, 0, 0) / 1000 } as any
+    );
+    const occs = occurrencesForEvents([recent], {
+      startUnix: Date.UTC(2026, 7, 30) / 1000,
+      endUnix: Date.UTC(2026, 8, 6) / 1000,
+    });
+    expect(occs.length).toBe(1);
+  });
+});

--- a/app/spec/ics-event-helpers-spec.ts
+++ b/app/spec/ics-event-helpers-spec.ts
@@ -1032,3 +1032,102 @@ describe('ICSEventHelpers.updateEventTimes with all-day events', function () {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// Expansion budget. ical-expander iterates forward from DTSTART with no way to seek, so a
+// fixed cap is a limit on how far back a series may begin. At 100 a weekly meeting older
+// than about two years expanded to nothing and disappeared from the calendar.
+// ---------------------------------------------------------------------------
+
+describe('ICSEventHelpers.expansionIterationBudget', function () {
+  const series = (rrule: string, dtstart = '20220308T130000Z') =>
+    [
+      'BEGIN:VCALENDAR',
+      'VERSION:2.0',
+      'PRODID:-//Test//Test//EN',
+      // A VTIMEZONE first, with its own RRULEs - this is what a real Google calendar sends.
+      'BEGIN:VTIMEZONE',
+      'TZID:America/Indiana/Indianapolis',
+      'BEGIN:DAYLIGHT',
+      'TZOFFSETFROM:-0500',
+      'TZOFFSETTO:-0400',
+      'TZNAME:EDT',
+      'DTSTART:19700308T020000',
+      'RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU',
+      'END:DAYLIGHT',
+      'END:VTIMEZONE',
+      'BEGIN:VEVENT',
+      'UID:series@test',
+      'DTSTAMP:20220308T000000Z',
+      `DTSTART:${dtstart}`,
+      'DTEND:20220308T132000Z',
+      `RRULE:${rrule}`,
+      'SUMMARY:Standup',
+      'END:VEVENT',
+      'END:VCALENDAR',
+    ].join('\r\n');
+
+  const START = Date.UTC(2022, 2, 8, 13, 0, 0) / 1000;
+  const NOW = Date.UTC(2026, 7, 28, 0, 0, 0) / 1000;
+
+  const budgetFor = (rrule: string, start: any = START, end: any = NOW) =>
+    ICSEventHelpers.expansionIterationBudget(series(rrule), start, end);
+
+  // A weekly series over this span needs 334 steps and a yearly one 105, both of which floor
+  // to MIN - so a weekly fixture cannot tell the VEVENT's rule from the VTIMEZONE's. Daily
+  // needs more than the floor, which is what makes these assertions discriminating.
+  const DAY = 86400;
+  const WEEK = 7 * DAY;
+  const FLOOR = 1000;
+
+  it("reads the event's RRULE, not the VTIMEZONE's DST rule", function () {
+    // The DAYLIGHT block's FREQ=YEARLY comes first in the file, so a plain search for the
+    // first RRULE reads it and derives 105 - indistinguishable from any other floored
+    // result. The event's own daily rule derives well above the floor.
+    const daily = budgetFor('FREQ=DAILY');
+    expect(daily).toBe(Math.ceil((NOW - START) / DAY) + 100);
+    expect(daily).toBeGreaterThan(FLOOR);
+    // Same file shape and dates, so the difference comes only from which rule was read.
+    expect(budgetFor('FREQ=YEARLY;BYMONTH=3')).toBe(FLOOR);
+  });
+
+  it('budgets enough steps to reach the end of the window', function () {
+    // The old fixed cap of 100 is about two years of weekly steps and stopped in early 2024.
+    expect(budgetFor('FREQ=WEEKLY;BYDAY=TU')).toBeGreaterThan(Math.ceil((NOW - START) / WEEK));
+    // Daily needs 1634, more than the floor supplies, so this asserts the derivation itself.
+    const daily = budgetFor('FREQ=DAILY');
+    expect(daily).toBeGreaterThan(Math.ceil((NOW - START) / DAY));
+    expect(daily).toBeGreaterThan(budgetFor('FREQ=WEEKLY;BYDAY=TU'));
+  });
+
+  it('returns the floor when the series has no usable start', function () {
+    // recurrenceStart can be null or non-finite. A NaN budget is worse than a small one:
+    // it survives Math.max/Math.min and ical-expander reads `!this.maxIterations` as no cap,
+    // so an abusive rule iterates unbounded instead of being truncated.
+    // Passed positionally rather than through budgetFor, whose defaults would swallow
+    // undefined and quietly test a finite start instead.
+    const abusive = series('FREQ=SECONDLY');
+    [null, undefined, NaN, Infinity, -Infinity].forEach((noStart) => {
+      expect(ICSEventHelpers.expansionIterationBudget(abusive, noStart as any, NOW)).toBe(FLOOR);
+    });
+    expect(ICSEventHelpers.expansionIterationBudget(series('FREQ=DAILY'), START, NaN)).toBe(FLOOR);
+  });
+
+  it('accounts for INTERVAL, which stretches how far each step reaches', function () {
+    expect(budgetFor('FREQ=DAILY')).toBeGreaterThan(budgetFor('FREQ=DAILY;INTERVAL=3'));
+  });
+
+  it('caps a frequency fine enough to be abusive rather than spinning', function () {
+    // An invitation is untrusted input; FREQ=SECONDLY dated years back would otherwise
+    // iterate essentially forever.
+    expect(budgetFor('FREQ=SECONDLY')).toBe(50000);
+  });
+
+  it('returns the floor for an event that does not recur at all', function () {
+    // Strip the VEVENT's own rule rather than the first RRULE in the file - that one belongs
+    // to the VTIMEZONE, and removing it leaves a weekly series that floors to the same value.
+    const ics = series('FREQ=WEEKLY').replace('\r\nRRULE:FREQ=WEEKLY', '');
+    expect(/BEGIN:VEVENT[\s\S]*RRULE:/.test(ics)).toBe(false);
+    expect(ICSEventHelpers.expansionIterationBudget(ics, START, NOW)).toBe(FLOOR);
+  });
+});

--- a/app/src/ics-event-helpers.ts
+++ b/app/src/ics-event-helpers.ts
@@ -71,6 +71,80 @@ export function generateUID(): string {
 }
 
 /**
+ * How many occurrences an expander may step through before giving up on one series.
+ *
+ * ical-expander iterates forward from DTSTART with no way to seek, so a cap limits how far
+ * back a series may begin rather than how much work a window costs. Too low and a long
+ * running series silently expands to nothing: at 100, a weekly meeting that started three
+ * years ago never reaches the present and simply disappears from the calendar. Removing the
+ * cap is worse - an invitation is untrusted input, and `RRULE:FREQ=SECONDLY` dated 1970
+ * would spin forever.
+ *
+ * So the budget comes from the series itself: how many steps of its own frequency fit
+ * between where it starts and the end of the window, plus slack. Real calendars land far
+ * below the ceiling - a weekly meeting running since 2020 needs about 300 - while a
+ * frequency fine enough to be abusive exceeds it and is truncated instead of expanded.
+ *
+ * @param ics - The series' calendar object.
+ * @param seriesStartUnix - DTSTART of the series, in unix seconds.
+ * @param windowEndUnix - The end of the range being expanded, in unix seconds.
+ */
+export function expansionIterationBudget(
+  ics: string,
+  seriesStartUnix: number,
+  windowEndUnix: number
+): number {
+  // A master event can reach here with a null or non-finite recurrenceStart - the expansion
+  // fallback guards for exactly that. NaN would survive Math.max/Math.min and become the cap
+  // itself, and ical-expander's loop is `!this.maxIterations || i < this.maxIterations`
+  // (index.js:104), so a NaN cap switches the limit off rather than truncating.
+  if (!Number.isFinite(seriesStartUnix) || !Number.isFinite(windowEndUnix)) {
+    return MIN_EXPANSION_ITERATIONS;
+  }
+  const rule = firstVeventRRule(ics);
+  if (!rule) {
+    return MIN_EXPANSION_ITERATIONS; // not a series; one occurrence is all there is to reach
+  }
+  const freq = /FREQ=([A-Z]+)/i.exec(rule);
+  const interval = parseInt((/INTERVAL=(\d+)/i.exec(rule) || [])[1], 10) || 1;
+  const step =
+    (EXPANSION_STEP_SECONDS[(freq ? freq[1] : '').toUpperCase()] || EXPANSION_STEP_SECONDS.DAILY) *
+    interval;
+  const steps = Math.ceil(Math.max(0, windowEndUnix - seriesStartUnix) / step) + 100;
+  return Math.min(MAX_EXPANSION_ITERATIONS, Math.max(MIN_EXPANSION_ITERATIONS, steps));
+}
+
+/**
+ * The RRULE of the first VEVENT, ignoring any that belong to a VTIMEZONE.
+ *
+ * A VTIMEZONE's STANDARD and DAYLIGHT blocks each carry their own RRULE describing the
+ * zone's DST transitions, and they appear before the VEVENT - so a plain search for the
+ * first RRULE in the file returns `FREQ=YEARLY;BYMONTH=3;BYDAY=2SU` for a weekly meeting,
+ * and any budget derived from it is wrong by a factor of fifty.
+ */
+function firstVeventRRule(ics: string): string | null {
+  const unfolded = ics.replace(/\r\n[ \t]/g, '').replace(/\n[ \t]/g, '');
+  const vevent = unfolded.split(/^BEGIN:VEVENT$/m)[1];
+  if (!vevent) return null;
+  const match = /^RRULE:(.*)$/im.exec(vevent.split(/^END:VEVENT$/m)[0]);
+  return match ? match[1] : null;
+}
+
+const EXPANSION_STEP_SECONDS: { [freq: string]: number } = {
+  SECONDLY: 1,
+  MINUTELY: 60,
+  HOURLY: 3600,
+  DAILY: 86400,
+  WEEKLY: 604800,
+  // Deliberately the shortest month and year. Underestimating the step overestimates the
+  // budget, which errs towards expanding a legitimate series rather than truncating it.
+  MONTHLY: 28 * 86400,
+  YEARLY: 365 * 86400,
+};
+const MIN_EXPANSION_ITERATIONS = 1000;
+const MAX_EXPANSION_ITERATIONS = 50000;
+
+/**
  * Formats a Date as an ICS date-only string (YYYYMMDD)
  * Uses LOCAL date components since all-day events represent a day in the user's timezone
  */


### PR DESCRIPTION
A recurring meeting whose series started a few years ago does not appear on the calendar at
all. No error, no gap in the grid - it is simply absent, and the older the series the more
certain the disappearance.

`occurrencesForEvents` expanded every series with a fixed budget:

```js
const icalExpander = new IcalExpander({ ics: master.ics, maxIterations: 100 });
```

`ical-expander` steps forward from `DTSTART` with no way to seek, so that number is not a
limit on the work a window costs - it is a limit on **how far back a series may begin**. A
weekly meeting that started in 2022 needs about 233 steps to reach today: it runs out around
early 2024 and returns nothing.

This derives the budget from the series itself - how many steps of its own `FREQ` and
`INTERVAL` fit between `DTSTART` and the end of the window, plus slack - floored at 1000 so
short series behave exactly as they did, and capped at 50000 because an invitation is
untrusted input and `RRULE:FREQ=SECONDLY` dated 1970 would otherwise spin the renderer.

One subtlety worth flagging for review: the budget reads the RRULE of the first **VEVENT**,
not the first RRULE in the file. A `VTIMEZONE`'s `STANDARD` and `DAYLIGHT` blocks each carry
their own RRULE for the zone's DST transitions and they appear before the VEVENT, so a plain
search returns `FREQ=YEARLY;BYMONTH=3;BYDAY=2SU` for a weekly meeting and under-budgets it by
a factor of fifty. Google sends exactly that shape.

### Verified

Seven specs: five on the budget itself (including the VTIMEZONE case and the abusive-frequency
cap) and two on `occurrencesForEvents`, which are the regression test that matters.

| | result |
|---|---|
| master + the new specs | 1677 passing, **6 failing** |
| master + this change | 1683 passing, 0 failing |

The pair is deliberately discriminating: "expands a series that began this year the same way"
passes on master, while "still reaches a week four years after the series began" fails there
with `Expected 0 to be 1`. The bug is about the age of the series, not recurrence in general.

Confirmed in the running app against a live Google CalDAV account with two weekly 1:1s that
have run since March 2022, reading each rendered occurrence's start off its element id rather
than off pixels:

| build | occurrences rendered for those two series |
|---|---|
| master | none at all |
| this branch | the correct Tue and Wed occurrences, in the right week |

This is what surfaced the bug: the meetings were missing from a real calendar in daily use.

`npm run lint:check`, `npm run typecheck` and `npm test` are clean on the pushed commit.
