### PR TITLE
Retry loading better-sqlite3 native module before failing database open

### DIFF
--- a/app/src/flux/stores/database-store.ts
+++ b/app/src/flux/stores/database-store.ts
@@ -3,13 +3,14 @@ import path from 'path';
 import createDebug from 'debug';
 import childProcess, { ChildProcess } from 'child_process';
 import { LRUCache } from 'lru-cache';
-import Sqlite3 from 'better-sqlite3';
+import type Sqlite3 from 'better-sqlite3';
 
 import { ExponentialBackoffScheduler } from '../../backoff-schedulers';
 import { Model } from '../models/model';
 import MailspringStore from '../../global/mailspring-store';
 import * as Utils from '../models/utils';
 import Query from '../models/query';
+import { localized } from '../../intl';
 
 const debug = createDebug('app:RxDB');
 const debugVerbose = createDebug('app:RxDB:all');
@@ -48,9 +49,49 @@ function handleUnrecoverableDatabaseError(
   });
 }
 
+const SQLITE_MODULE_LOAD_RETRIES = 3;
+const SQLITE_MODULE_LOAD_RETRY_DELAY = 1000;
+
+// Loading the native better-sqlite3 binary can fail transiently under
+// Windows virtual memory pressure ("The paging file is too small for this
+// operation to complete", MAILSPRING-CLIENT-9) even though the database file
+// itself is fine. Retry a few times before giving up, rather than routing
+// the failure through handleUnrecoverableDatabaseError, which would wipe and
+// resync the local database for a problem that has nothing to do with it.
+async function requireSqlite3(): Promise<typeof import('better-sqlite3')> {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return require('better-sqlite3');
+    } catch (err) {
+      if (attempt >= SQLITE_MODULE_LOAD_RETRIES) {
+        throw err;
+      }
+      await Promise.delay(SQLITE_MODULE_LOAD_RETRY_DELAY);
+    }
+  }
+}
+
+function handleUnavailableSqliteModule(err: Error) {
+  AppEnv.errorLogger.reportError(err);
+  AppEnv.showErrorDialog(
+    localized(
+      'Mailspring could not load its database engine. This usually happens when your computer is critically low on virtual memory (paging file / swap space). Please free up disk space or increase your paging file size, then restart your computer and try again.'
+    ),
+    { detail: err.toString() }
+  );
+}
+
 async function openDatabase(dbPath: string) {
+  let SqliteCtor: typeof import('better-sqlite3');
   try {
-    const db = new Sqlite3(dbPath, { readonly: true, timeout: 10000 }) as Sqlite3.Database;
+    SqliteCtor = await requireSqlite3();
+  } catch (err) {
+    handleUnavailableSqliteModule(err);
+    return null;
+  }
+
+  try {
+    const db = new SqliteCtor(dbPath, { readonly: true, timeout: 10000 }) as Sqlite3.Database;
 
     // https://www.sqlite.org/wal.html
     // WAL provides more concurrency as readers do not block writers and a writer


### PR DESCRIPTION
## Summary

Fixes [MAILSPRING-CLIENT-9](https://foundry-376-llc.sentry.io/issues/MAILSPRING-CLIENT-9): `Error: The paging file is too small for this operation to complete.` (11 users, 62 occurrences over ~4 months on Windows).

**What I observed:** the Sentry stack trace shows the error originating from `process.func [as dlopen]` deep inside `node:electron/js2c/node_init`, with no application frames above it — this is Node/Electron failing to `dlopen()` the native `better_sqlite3.node` binary. `database-store.ts` imports `better-sqlite3` as a top-level, unguarded `import Sqlite3 from 'better-sqlite3'`, so if the native module fails to load (here, because Windows reports the paging file/virtual memory is too small to satisfy the mapping), the failure is an uncaught exception with no relation to the actual database file. It's only caught by the app's generic `window.onerror` / `uncaughtException` handlers (`app-env.ts`), which just report it to Sentry — it never goes through `openDatabase()`'s existing error handling, and the app is left in a broken, unexplained state.

Windows can transiently report insufficient paging-file/commit-charge room for a native module's memory mapping when the system is under memory pressure at that exact instant (multiple Electron/mailsync processes, other apps, etc.), so simply retrying the load after a short delay is a well-known, effective mitigation — the OS often finds room a moment later.

**What I changed** in `app/src/flux/stores/database-store.ts`:
- Made the `better-sqlite3` import type-only, and lazily `require()` the module inside `openDatabase()` via a new `requireSqlite3()` helper that retries up to 3 times with a 1s delay between attempts.
- If the module still fails to load after retries, report the error to Sentry and show the user an actionable dialog explaining their system may be low on virtual memory, rather than silently leaving the app hung.
- Deliberately did **not** route this failure through the existing `handleUnrecoverableDatabaseError` (which triggers a full local database reset + resync) — that's the wrong response here, since the database file itself is fine; only the native driver failed to load.

## Test plan
- [x] Verified the lazy-require pattern (`import type` + `typeof import('better-sqlite3')`) type-checks cleanly against the project's pinned `@types/better-sqlite3@^7.6.3` in an isolated TypeScript check (couldn't run the full project's `tsc`/`eslint` in this sandbox — no `node_modules` installed).
- [ ] Exercise on Windows (or by temporarily forcing `require('better-sqlite3')` to throw) to confirm the retry/dialog path behaves as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DzBiH9WKXBG4BU6QGUxqTM

---
_Generated by [Claude Code](https://claude.ai/code/session_01DzBiH9WKXBG4BU6QGUxqTM)_