### PR TITLE
Fix timed events at midnight and across DST day boundaries

### DIFF
--- a/app/internal_packages/main-calendar/lib/core/calendar-event.tsx
+++ b/app/internal_packages/main-calendar/lib/core/calendar-event.tsx
@@ -17,6 +17,11 @@ interface CalendarEventProps {
   event: EventOccurrence;
   order: number;
   selected: boolean;
+  /**
+   * The span this event is positioned within. Day columns pass one day, exclusive — its real
+   * length, not 86400. The all-day row passes the whole buffered week, and reads it only as a
+   * day count, so the two disagree by a second there without effect.
+   */
   scopeEnd: number;
   scopeStart: number;
   direction: 'horizontal' | 'vertical';

--- a/app/internal_packages/main-calendar/lib/core/day-view.tsx
+++ b/app/internal_packages/main-calendar/lib/core/day-view.tsx
@@ -17,6 +17,7 @@ import {
   overlapForEvents,
   maxConcurrentEvents,
   eventsGroupedByDay,
+  exclusiveDayEnds,
   TICKS_PER_DAY,
   tickGenerator,
 } from './week-view-helpers';
@@ -227,6 +228,7 @@ export class DayView extends React.Component<
     const days = this._daysInView();
     const events = getEventsWithDragPreview(this.state.events, this.props.dragState);
     const eventsByDay = eventsGroupedByDay(events, days);
+    const dayEnds = exclusiveDayEnds(days);
     const todayColumnIdx = days.findIndex((d) => this._isToday(d));
     const totalHeight = TICKS_PER_DAY * this.state.intervalHeight;
 
@@ -319,10 +321,10 @@ export class DayView extends React.Component<
                 style={{ width: `${this._bufferRatio() * 100}%` }}
               >
                 <div className="event-grid" style={{ height: totalHeight }}>
-                  {days.map((day) => (
+                  {days.map((day, dayIdx) => (
                     <WeekViewEventColumn
                       day={day}
-                      dayEnd={day.unix() + 24 * 60 * 60 - 1}
+                      dayEnd={dayEnds[dayIdx]}
                       key={day.valueOf()}
                       events={eventsByDay[day.unix()]}
                       focusedEvent={this.props.focusedEvent}

--- a/app/internal_packages/main-calendar/lib/core/week-view-event-column.tsx
+++ b/app/internal_packages/main-calendar/lib/core/week-view-event-column.tsx
@@ -16,6 +16,7 @@ import { DragState, HitZone } from './calendar-drag-types';
 interface WeekViewEventColumnProps {
   events: EventOccurrence[];
   day: Moment;
+  /** Exclusive — the next column's start, so a DST day is not assumed to be 86400s */
   dayEnd: number;
   focusedEvent: FocusedEventInfo | null;
   onEventClick: (e: React.MouseEvent<any>, event: EventOccurrence) => void;
@@ -61,14 +62,13 @@ export class WeekViewEventColumn extends React.Component<WeekViewEventColumnProp
     });
     const overlap = overlapForEvents(events);
     const dayStart = day.unix();
-    const dayEndUnix = dayStart + 86400; // 24 hours in seconds
 
     return (
       <div
         className={className}
         key={day.valueOf()}
         data-calendar-start={dayStart}
-        data-calendar-end={dayEndUnix}
+        data-calendar-end={dayEnd}
         data-calendar-type="day-column"
       >
         {events.map((e) => (

--- a/app/internal_packages/main-calendar/lib/core/week-view-helpers.ts
+++ b/app/internal_packages/main-calendar/lib/core/week-view-helpers.ts
@@ -1,9 +1,6 @@
 import { EventOccurrence, isTimed } from './calendar-data-source';
 import moment, { Moment } from 'moment';
-import { Utils, CalendarDateUtils } from 'mailspring-exports';
-
-// This pre-fetches from Utils to prevent constant disc access
-const overlapsBounds = Utils.overlapsBounds;
+import { CalendarDateUtils } from 'mailspring-exports';
 
 export interface OverlapByEventId {
   [id: string]: { concurrentEvents: number; order: null | number };
@@ -122,6 +119,19 @@ export function maxConcurrentEvents(eventOverlap: OverlapByEventId) {
   return max;
 }
 
+/**
+ * Each day's EXCLUSIVE end, taken from the next day's start so membership, layout and drag
+ * hit-testing cannot drift from the rendered columns. A day is not always 86400 seconds:
+ * 90000 on a fall-back day, 82800 on a spring-forward one. The last day has no successor and
+ * resolves in the host zone, which is the zone the views build `days` in today.
+ */
+export function exclusiveDayEnds(days: Moment[]): number[] {
+  const unixDays = days.map((d) => d.unix());
+  return unixDays.map((day, i) =>
+    i + 1 < unixDays.length ? unixDays[i + 1] : CalendarDateUtils.shiftedDayStartUnix(day, 1)
+  );
+}
+
 export function eventsGroupedByDay(events: EventOccurrence[], days: Moment[]) {
   const map: { allDay: EventOccurrence[]; [dayUnix: string]: EventOccurrence[] } = { allDay: [] };
 
@@ -130,17 +140,18 @@ export function eventsGroupedByDay(events: EventOccurrence[], days: Moment[]) {
     map[`${day}`] = [];
   });
 
+  const exclusiveEnds = exclusiveDayEnds(days);
+
   events.forEach((event) => {
     if (isTimed(event)) {
-      for (const day of unixDays) {
-        const bounds = {
-          start: day,
-          end: day + 24 * 60 * 60 - 1,
-        };
-        if (overlapsBounds(bounds, event)) {
+      // Half-open, matching `coveredDates`' last-covered-instant convention, so a
+      // 22:00-00:00 event covers only the day it starts on.
+      const lastInstant = Math.max(event.end - 1, event.start);
+      unixDays.forEach((day, i) => {
+        if (event.start < exclusiveEnds[i] && lastInstant >= day) {
           map[`${day}`].push(event);
         }
-      }
+      });
     } else {
       map.allDay.push(event);
     }

--- a/app/internal_packages/main-calendar/lib/core/week-view.tsx
+++ b/app/internal_packages/main-calendar/lib/core/week-view.tsx
@@ -17,6 +17,7 @@ import {
   overlapForEvents,
   maxConcurrentEvents,
   eventsGroupedByDay,
+  exclusiveDayEnds,
   TICKS_PER_DAY,
   tickGenerator,
 } from './week-view-helpers';
@@ -227,6 +228,7 @@ export class WeekView extends React.Component<
     const days = this._daysInView();
     const events = getEventsWithDragPreview(this.state.events, this.props.dragState);
     const eventsByDay = eventsGroupedByDay(events, days);
+    const dayEnds = exclusiveDayEnds(days);
     const todayColumnIdx = days.findIndex((d) => this._isToday(d));
     const totalHeight = TICKS_PER_DAY * this.state.intervalHeight;
 
@@ -320,10 +322,10 @@ export class WeekView extends React.Component<
                 style={{ width: `${this._bufferRatio() * 100}%` }}
               >
                 <div className="event-grid" style={{ height: totalHeight }}>
-                  {days.map((day) => (
+                  {days.map((day, dayIdx) => (
                     <WeekViewEventColumn
                       day={day}
-                      dayEnd={day.unix() + 24 * 60 * 60 - 1}
+                      dayEnd={dayEnds[dayIdx]}
                       key={day.valueOf()}
                       events={eventsByDay[day.unix()]}
                       focusedEvent={this.props.focusedEvent}

--- a/app/spec/calendar-event-spec.ts
+++ b/app/spec/calendar-event-spec.ts
@@ -1,39 +1,77 @@
 import { CalendarEvent } from '../internal_packages/main-calendar/lib/core/calendar-event';
-import { AllDayOccurrence } from '../internal_packages/main-calendar/lib/core/calendar-data-source';
+import {
+  AllDayOccurrence,
+  EventOccurrence,
+  TimedOccurrence,
+} from '../internal_packages/main-calendar/lib/core/calendar-data-source';
+import moment from 'moment';
 import { CalendarDateUtils } from 'mailspring-exports';
 import { parseCalendarDate } from '../src/calendar-date';
 
+// Fields _getDimensions never reads, but the occurrence type requires.
+const OCCURRENCE_META = {
+  id: 'e0',
+  accountId: 'a',
+  calendarId: 'c',
+  title: '',
+  location: '',
+  description: '',
+  isCancelled: false,
+  isPending: false,
+  isException: false,
+  isRecurring: false,
+  organizer: null,
+  attendees: [],
+};
+
 // _getDimensions reads only this.props, so we can exercise it without rendering.
-function allDayDimensions(startISO: string, endISO: string) {
-  const weekStart = parseCalendarDate('2026-06-21'); // Sun; June has no DST transition
-  const event = {
-    isAllDay: true,
-    startDate: parseCalendarDate(startISO),
-    endDate: parseCalendarDate(endISO),
-    id: 'e0',
-    accountId: 'a',
-    calendarId: 'c',
-    title: '',
-    location: '',
-    description: '',
-    isCancelled: false,
-    isPending: false,
-    isException: false,
-    isRecurring: false,
-    organizer: null,
-    attendees: [],
-  } as AllDayOccurrence;
+function dimensions(
+  event: EventOccurrence,
+  direction: 'horizontal' | 'vertical',
+  scopeStart: number,
+  scopeEnd: number
+) {
   const instance = new CalendarEvent({
     event,
     order: 1,
     concurrentEvents: 1,
     fixedSize: -1,
-    direction: 'horizontal',
-    scopeStart: CalendarDateUtils.dayStartUnix(weekStart),
-    scopeEnd: CalendarDateUtils.dayStartUnix((weekStart + 7) as any),
+    direction,
+    scopeStart,
+    scopeEnd,
   } as any);
   const d = (instance as any)._getDimensions();
   return { topPct: parseFloat(d.top), heightPct: parseFloat(d.height) };
+}
+
+function allDayDimensions(startISO: string, endISO: string) {
+  const weekStart = parseCalendarDate('2026-06-21'); // Sun; June has no DST transition
+  const event = {
+    ...OCCURRENCE_META,
+    isAllDay: true,
+    startDate: parseCalendarDate(startISO),
+    endDate: parseCalendarDate(endISO),
+  } as AllDayOccurrence;
+  return dimensions(
+    event,
+    'horizontal',
+    CalendarDateUtils.dayStartUnix(weekStart),
+    CalendarDateUtils.dayStartUnix((weekStart + 7) as any)
+  );
+}
+
+// A day column's scope: its own start, and the next day's start as the exclusive end, as
+// `exclusiveDayEnds` supplies them. Chicago runner, so 2025-11-02 is 25 hours long.
+function timedDimensions(startISO: string, endISO: string, dayISO: string, nextDayISO: string) {
+  const event = {
+    ...OCCURRENCE_META,
+    isAllDay: false,
+    start: moment(startISO).unix(),
+    end: moment(endISO).unix(),
+    startDate: parseCalendarDate(dayISO),
+    endDate: parseCalendarDate(dayISO),
+  } as TimedOccurrence;
+  return dimensions(event, 'vertical', moment(dayISO).unix(), moment(nextDayISO).unix());
 }
 
 describe('CalendarEvent all-day dimensions', function () {
@@ -50,5 +88,34 @@ describe('CalendarEvent all-day dimensions', function () {
     const { topPct, heightPct } = allDayDimensions('2026-06-19', '2026-06-22');
     expect(topPct).toBe(0);
     expect(heightPct).toBeCloseTo((2 / 7) * 100, 4);
+  });
+});
+
+describe('CalendarEvent timed dimensions across DST', function () {
+  it('keeps a late event on a 25-hour day inside its column', function () {
+    // Against a hardcoded 86399s scope a 23:30 event computes top 102%, which
+    // `.event-column { overflow: hidden }` clips away entirely.
+    const { topPct, heightPct } = timedDimensions(
+      '2025-11-02 23:30',
+      '2025-11-02 23:45',
+      '2025-11-02',
+      '2025-11-03'
+    );
+    expect(topPct).toBeCloseTo((88200 / 90000) * 100, 4);
+    expect(topPct + heightPct).toBeLessThan(100.0001);
+  });
+
+  it('sizes an event against the real length of a 23-hour day', function () {
+    // Proportional to elapsed seconds, which is NOT the wall-clock hour gridline: the
+    // legend and now-line divide the column into 24 equal hours, so on a transition day a
+    // 10:00 event draws ~37 min off its own "10 AM" line. Pre-existing and improved here
+    // (it was a full hour), not fixed — see the backlog's elapsed-vs-wall-clock item.
+    const { topPct } = timedDimensions(
+      '2026-03-08 10:00',
+      '2026-03-08 11:00',
+      '2026-03-08',
+      '2026-03-09'
+    );
+    expect(topPct).toBeCloseTo((32400 / 82800) * 100, 4);
   });
 });

--- a/app/spec/week-view-helpers-spec.ts
+++ b/app/spec/week-view-helpers-spec.ts
@@ -1,0 +1,152 @@
+// Import directly from the source file; the plugin isn't registered in mailspring-exports.
+import {
+  eventsGroupedByDay,
+  exclusiveDayEnds,
+} from '../internal_packages/main-calendar/lib/core/week-view-helpers';
+import {
+  EventOccurrence,
+  coveredDates,
+} from '../internal_packages/main-calendar/lib/core/calendar-data-source';
+import moment, { Moment } from 'moment';
+
+// Runner is pinned to America/Chicago (scripts/test.js), so 2025-11-02 is a 25-hour day and
+// 2026-03-08 a 23-hour one. Fixtures are built in that same host zone deliberately: the
+// final-column fallback resolves through plain `Date`, which moment.tz.setDefault cannot
+// reach, so a zone-pinned fixture would meet host-zone arithmetic inside the code under test.
+function at(iso: string) {
+  return moment(iso);
+}
+
+// A consecutive run of day columns, as the week and day views render them.
+function daysFrom(startISO: string, count: number) {
+  return Array.from({ length: count }, (_, i) => moment(startISO).add(i, 'days'));
+}
+
+// Mirrors makeOccurrence in calendar-drag-utils-spec: derive the dates and emit the right
+// variant, so a fixture can't encode a shape production never emits.
+function makeOccurrence(start: number, end: number, isAllDay = false): EventOccurrence {
+  const base = {
+    id: 'event-1-e0',
+    accountId: 'acct-1',
+    calendarId: 'cal-1',
+    title: 'Standup',
+    location: '',
+    description: '',
+    isCancelled: false,
+    isPending: false,
+    isException: false,
+    isRecurring: false,
+    organizer: null,
+    attendees: [],
+    ...coveredDates(start, end, isAllDay),
+  };
+  return isAllDay ? { ...base, isAllDay: true } : { ...base, isAllDay: false, start, end };
+}
+
+function timedEvent(startISO: string, endISO: string) {
+  return makeOccurrence(at(startISO).unix(), at(endISO).unix());
+}
+
+// Which of the rendered columns the event landed in, by ISO date.
+function columnsContaining(event: EventOccurrence, days: Moment[]) {
+  const map = eventsGroupedByDay([event], days);
+  return days.filter((d) => map[`${d.unix()}`].length > 0).map((d) => d.format('YYYY-MM-DD'));
+}
+
+describe('eventsGroupedByDay', function () {
+  it('places an ordinary timed event in exactly its own column', function () {
+    const days = daysFrom('2026-06-08', 7);
+    expect(columnsContaining(timedEvent('2026-06-10 10:00', '2026-06-10 11:00'), days)).toEqual([
+      '2026-06-10',
+    ]);
+  });
+
+  it('spans every column a multi-day timed event covers', function () {
+    const days = daysFrom('2026-06-08', 7);
+    expect(columnsContaining(timedEvent('2026-06-09 22:00', '2026-06-11 03:00'), days)).toEqual([
+      '2026-06-09',
+      '2026-06-10',
+      '2026-06-11',
+    ]);
+  });
+
+  it('keeps an event ending at midnight out of the following column', function () {
+    // An 11pm-midnight event covers only the day it starts on; an inclusive end renders a
+    // zero-height sliver in the next day's 12am slot.
+    const days = daysFrom('2026-06-08', 7);
+    expect(columnsContaining(timedEvent('2026-06-10 23:00', '2026-06-11 00:00'), days)).toEqual([
+      '2026-06-10',
+    ]);
+  });
+
+  it('places a late event on a 25-hour day in its own column', function () {
+    // A day end of start + 86400 falls at 23:00 on 2025-11-02 and drops anything after it
+    // from every column.
+    const days = daysFrom('2025-11-01', 4);
+    expect(columnsContaining(timedEvent('2025-11-02 23:30', '2025-11-02 23:45'), days)).toEqual([
+      '2025-11-02',
+    ]);
+  });
+
+  it('keeps an early event off the preceding 23-hour day', function () {
+    // A day end of start + 86400 reaches an hour past midnight out of 2026-03-08 into 03-09.
+    const days = daysFrom('2026-03-07', 4);
+    expect(columnsContaining(timedEvent('2026-03-09 00:30', '2026-03-09 00:45'), days)).toEqual([
+      '2026-03-09',
+    ]);
+  });
+
+  it('bounds the final column, which has no successor to take its end from', function () {
+    // The event sits on the day AFTER the last column; an unbounded fallback admits it.
+    const days = daysFrom('2026-06-08', 3);
+    expect(columnsContaining(timedEvent('2026-06-11 10:00', '2026-06-11 11:00'), days)).toEqual([]);
+    expect(columnsContaining(timedEvent('2026-06-10 10:00', '2026-06-10 11:00'), days)).toEqual([
+      '2026-06-10',
+    ]);
+  });
+
+  it('excludes an event starting exactly at the next column start', function () {
+    // Pins the strictness of `event.start < end`; with `<=` a midnight-starting event also
+    // lands in the previous column.
+    const days = daysFrom('2026-06-08', 7);
+    expect(columnsContaining(timedEvent('2026-06-11 00:00', '2026-06-11 01:00'), days)).toEqual([
+      '2026-06-11',
+    ]);
+  });
+
+  it('keeps a zero-length event on its own day', function () {
+    // Pins Math.max(end - 1, start): without it a start==end event's last instant is one
+    // second before the day it belongs to, which at midnight is the previous day.
+    const days = daysFrom('2026-06-08', 7);
+    expect(columnsContaining(timedEvent('2026-06-10 00:00', '2026-06-10 00:00'), days)).toEqual([
+      '2026-06-10',
+    ]);
+  });
+
+  it('routes all-day events to the all-day row rather than a column', function () {
+    const days = daysFrom('2026-06-08', 7);
+    const allDay = makeOccurrence(at('2026-06-10').unix(), at('2026-06-11').unix(), true);
+    const map = eventsGroupedByDay([allDay], days);
+    expect(map.allDay.length).toBe(1);
+    expect(days.every((d) => map[`${d.unix()}`].length === 0)).toBe(true);
+  });
+});
+
+describe('exclusiveDayEnds', function () {
+  it("gives each day the next day's start, so a DST day is not assumed to be 86400s", function () {
+    const days = daysFrom('2025-11-01', 4);
+    const ends = exclusiveDayEnds(days);
+    expect(ends[1] - days[1].unix()).toBe(90000);
+    expect(ends[0] - days[0].unix()).toBe(86400);
+  });
+
+  it('shortens a spring-forward day rather than assuming 86400s', function () {
+    const days = daysFrom('2026-03-07', 4);
+    expect(exclusiveDayEnds(days)[1] - days[1].unix()).toBe(82800);
+  });
+
+  it('resolves the final day, which has no successor', function () {
+    const days = daysFrom('2026-06-08', 3);
+    expect(exclusiveDayEnds(days)[2]).toBe(at('2026-06-11').unix());
+  });
+});


### PR DESCRIPTION
## The bug

`eventsGroupedByDay` decided which day column a timed event belongs to with `overlapsBounds({ start: day, end: day + 86400 - 1 }, event)` — inclusive on both ends, and assuming every day is 86400 seconds. Three bugs lived in that one line:

| Repro | Symptom |
|---|---|
| 11pm–midnight event | Also renders as a zero-height sliver in the next day's 12am slot |
| 23:30 event on a 25-hour fall-back day | Dropped from **every** column — renders nowhere |
| 00:30 event after a 23-hour spring-forward day | Also renders on the previous day, an hour past its midnight |

All three were verified against real zone arithmetic before any code changed, and the first was reproduced end to end by running an actual synced ICS (`DTSTART;TZID=America/Chicago:20260920T230000`) through `ical-expander` and the grouping predicate.

## The fix

Membership is now half-open — `event.start < end` and `max(event.end - 1, event.start) >= day` — matching `coveredDates`' last-covered-instant convention, so a 22:00–00:00 event covers only the day it starts on. That also brings the day column into agreement with `eventCoversDate`, which the month and agenda day filters already use; the two deciders had disagreed.

The day's end comes from a new `exclusiveDayEnds`, which takes each column's exclusive end from the **next column's start**, so membership and the rendered columns agree by construction on a DST day. It is the single source for the three places that previously derived a day end independently:

- grouping in `eventsGroupedByDay`
- the column's `scopeEnd`, which drives `_getDimensions`
- the `data-calendar-end` attribute the drag/click hit-test reads

Grouping alone did **not** fix the fall-back case. The column still declared its scope as 86399s, so the newly-included 23:30 event got a `top` of 102.08% and `.event-column { overflow: hidden }` clipped it away — invisible either way. Threading the real day end through is what actually fixes it.

`WeekViewEventColumn`'s `dayEnd` prop is now exclusive rather than an inclusive last second, and its local `dayEndUnix = dayStart + 86400` is deleted, so the change removes a derivation rather than adding one.

## Tests

New `app/spec/week-view-helpers-spec.ts` (12 cases) and two timed-DST geometry cases in `calendar-event-spec.ts`. **1690 passing.**

Mutation-checked rather than assumed:

- Reverting the predicate turns exactly the three bug specs red, and the others stay green.
- Hardcoding `scopeLen = 86400` in `_getDimensions` turns the two geometry cases red.

Fixtures are host-zone, relying on the runner's `TZ=America/Chicago` pin (`scripts/test.js`) for the DST-length days — the convention `calendar-drag-utils-spec.ts` states. A zone-pinned fixture is actively wrong here: `exclusiveDayEnds`' final-column fallback resolves through plain `Date`, which `moment.tz.setDefault` cannot reach, so pinned days would meet host-zone arithmetic inside the code under test.

**Known gap:** the view wiring is not unit-tested — reverting `dayEnd={dayEnds[dayIdx]}` leaves the suite green. That matches how this codebase treats component glue; it was verified by hand instead.

## Not fixed here

The grid legend and current-time indicator divide a column into 24 equal **wall-clock** hours, while layout positions by **elapsed** seconds. On a transition day an event therefore still draws ~30 minutes off its own hour line, and a double-click on the 10 AM gridline opens the popover at 9:30. That error was a full hour before this change, so this is an improvement, not a regression — but unifying the two coordinate systems is a separate change, and probably means making layout wall-clock to match the grid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)