### PR TITLE
Fix Outlook read shortcuts on Windows

### DIFF
--- a/app/spec/keymap-input-integration-spec.ts
+++ b/app/spec/keymap-input-integration-spec.ts
@@ -1,0 +1,34 @@
+import path from 'path';
+
+const wait = (milliseconds: number) =>
+  new Promise<void>((resolve) => window.originalSetTimeout(resolve, milliseconds));
+
+describe('Keymap input integration', function () {
+  it('dispatches Outlook read shortcuts from physical key events', async function () {
+    const resourcePath = AppEnv.getLoadSettings().resourcePath;
+    const outlookKeymap = AppEnv.keymaps.loadKeymap(
+      path.join(resourcePath, 'keymaps', 'templates', 'Outlook.json'),
+      { replaceExistingCommands: true }
+    );
+    const receivedCommands: string[] = [];
+    const commandHandlers = AppEnv.commands.add(document.body, {
+      'core:mark-as-read': () => receivedCommands.push('core:mark-as-read'),
+      'core:mark-as-unread': () => receivedCommands.push('core:mark-as-unread'),
+    });
+
+    try {
+      await wait(250);
+      const webContents = AppEnv.getCurrentWindow().webContents;
+      webContents.sendInputEvent({ type: 'keyDown', keyCode: 'Q', modifiers: ['control'] });
+      webContents.sendInputEvent({ type: 'keyUp', keyCode: 'Q', modifiers: ['control'] });
+      webContents.sendInputEvent({ type: 'keyDown', keyCode: 'U', modifiers: ['control'] });
+      webContents.sendInputEvent({ type: 'keyUp', keyCode: 'U', modifiers: ['control'] });
+      await wait(100);
+
+      expect(receivedCommands).toEqual(['core:mark-as-read', 'core:mark-as-unread']);
+    } finally {
+      commandHandlers.dispose();
+      outlookKeymap.dispose();
+    }
+  });
+});

--- a/app/spec/keymap-manager-spec.ts
+++ b/app/spec/keymap-manager-spec.ts
@@ -1,0 +1,25 @@
+import path from 'path';
+import KeymapManager from '../src/keymap-manager';
+
+describe('KeymapManager', function () {
+  it('uses template bindings while preserving inherited commands', function () {
+    const resourcePath = AppEnv.getLoadSettings().resourcePath;
+    const manager = new KeymapManager({ configDirPath: resourcePath, resourcePath });
+    const baseKeymap = manager.loadKeymap(path.join(resourcePath, 'keymaps', 'base.json'));
+    const outlookKeymap = manager.loadKeymap(
+      path.join(resourcePath, 'keymaps', 'templates', 'Outlook.json'),
+      { replaceExistingCommands: true }
+    );
+
+    expect(manager.getBindingsForCommand('application:quit')).toEqual(['alt+f4']);
+    expect(manager.getBindingsForCommand('core:copy')).toEqual(['mod+c']);
+    expect((manager as any)._commandsCache['ctrl+q']).toEqual(['core:mark-as-read']);
+    expect((manager as any)._commandsCache['ctrl+u']).toEqual([
+      'contenteditable:underline',
+      'core:mark-as-unread',
+    ]);
+
+    outlookKeymap.dispose();
+    baseKeymap.dispose();
+  });
+});

--- a/app/spec/keymap-manager-spec.ts
+++ b/app/spec/keymap-manager-spec.ts
@@ -1,7 +1,37 @@
 import path from 'path';
+import mousetrap from 'mousetrap';
 import KeymapManager from '../src/keymap-manager';
 
 describe('KeymapManager', function () {
+  it('dispatches both mod and ctrl commands before propagation stops on Windows', function () {
+    if (process.platform === 'darwin') {
+      return;
+    }
+    const resourcePath = AppEnv.getLoadSettings().resourcePath;
+    const manager = new KeymapManager({ configDirPath: resourcePath, resourcePath });
+    // Isolate registrations while retaining Mailspring's real stopCallback.
+    const trap = new mousetrap(document.body);
+    spyOn(mousetrap, 'bind').andCallFake((keys, callback) => trap.bind(keys, callback));
+    spyOn(AppEnv.commands, 'dispatch');
+    const baseKeymap = manager.loadKeymap(path.join(resourcePath, 'keymaps', 'base.json'));
+    const outlookKeymap = manager.loadKeymap(
+      path.join(resourcePath, 'keymaps', 'templates', 'Outlook.json'),
+      { replaceExistingCommands: true }
+    );
+
+    try {
+      const event = new KeyboardEvent('keydown', { key: 'u', ctrlKey: true });
+      Object.defineProperty(event, 'target', { value: document.body });
+      trap.handleKey('u', ['ctrl'], event);
+      expect(AppEnv.commands.dispatch).toHaveBeenCalledWith('contenteditable:underline');
+      expect(AppEnv.commands.dispatch).toHaveBeenCalledWith('core:mark-as-unread');
+    } finally {
+      outlookKeymap.dispose();
+      baseKeymap.dispose();
+      trap.reset();
+    }
+  });
+
   it('uses template bindings while preserving inherited commands', function () {
     const resourcePath = AppEnv.getLoadSettings().resourcePath;
     const manager = new KeymapManager({ configDirPath: resourcePath, resourcePath });

--- a/app/src/keymap-manager.ts
+++ b/app/src/keymap-manager.ts
@@ -7,6 +7,13 @@ import { Emitter, Disposable } from 'event-kit';
 let suspended = false;
 const templateConfigKey = 'core.keymapTemplate';
 
+interface KeymapLoadOptions {
+  replaceExistingCommands?: boolean;
+}
+
+const normalizePlatformKeystrokes = (keystrokes: string) =>
+  keystrokes.replace(/\bmod\b/g, process.platform === 'darwin' ? 'command' : 'ctrl');
+
 /*
 By default, Mousetrap stops all hotkeys within text inputs. Override this to
 more specifically block only hotkeys that have no modifier keys (things like
@@ -72,10 +79,16 @@ class KeymapFile {
   _disposable = null;
   _path: string;
   _manager: KeymapManager;
+  _replaceExistingCommands: boolean;
 
-  constructor(manager: KeymapManager, filePath: string) {
+  constructor(
+    manager: KeymapManager,
+    filePath: string,
+    { replaceExistingCommands = false }: KeymapLoadOptions = {}
+  ) {
     this._manager = manager;
     this._path = filePath;
+    this._replaceExistingCommands = replaceExistingCommands;
   }
 
   load = () => {
@@ -116,6 +129,10 @@ class KeymapFile {
 
   bindings() {
     return this._bindings;
+  }
+
+  replacesExistingCommands() {
+    return this._replaceExistingCommands;
   }
 }
 
@@ -219,12 +236,14 @@ export default class KeymapManager {
         'templates',
         `${templateFile}.json`
       );
-      this._removeTemplate = this.loadKeymap(templateKeymapPath);
+      this._removeTemplate = this.loadKeymap(templateKeymapPath, {
+        replaceExistingCommands: true,
+      });
     }
   };
 
-  loadKeymap(filePath: string) {
-    const file = new KeymapFile(this, filePath);
+  loadKeymap(filePath: string, { replaceExistingCommands = false }: KeymapLoadOptions = {}) {
+    const file = new KeymapFile(this, filePath, { replaceExistingCommands });
     this._files.push(file);
     file.load();
 
@@ -235,13 +254,19 @@ export default class KeymapManager {
   }
 
   ensureKeystrokesRegistered(keystrokes: string) {
-    if (this._registered[keystrokes]) {
+    const platformKeystrokes = normalizePlatformKeystrokes(keystrokes);
+    if (this._registered[platformKeystrokes]) {
       return;
     }
-    this._registered[keystrokes] = true;
+    this._registered[platformKeystrokes] = true;
 
-    mousetrap.bind(keystrokes, () => {
-      for (const command of this._commandsCache[keystrokes] || []) {
+    mousetrap.bind(platformKeystrokes, () => {
+      const commands = this._commandsCache[platformKeystrokes] || [];
+      if (commands.length === 0) {
+        return;
+      }
+
+      for (const command of commands) {
         if (command.startsWith('application:')) {
           ipcRenderer.send('command', command);
         } else {
@@ -259,7 +284,13 @@ export default class KeymapManager {
       const fileBindings = file.bindings();
       for (const command of Object.keys(fileBindings)) {
         const keystrokesArray = fileBindings[command];
-        this._bindingsCache[command] = (this._bindingsCache[command] || []).concat(keystrokesArray);
+        if (file.replacesExistingCommands()) {
+          this._bindingsCache[command] = keystrokesArray.slice();
+        } else {
+          this._bindingsCache[command] = (this._bindingsCache[command] || []).concat(
+            keystrokesArray
+          );
+        }
       }
     }
     if (this.userKeymap) {
@@ -272,11 +303,12 @@ export default class KeymapManager {
     this._commandsCache = {};
     for (const command of Object.keys(this._bindingsCache)) {
       for (const keystrokes of this._bindingsCache[command]) {
-        if (!this._commandsCache[keystrokes]) {
-          this._commandsCache[keystrokes] = [];
+        const platformKeystrokes = normalizePlatformKeystrokes(keystrokes);
+        if (!this._commandsCache[platformKeystrokes]) {
+          this._commandsCache[platformKeystrokes] = [];
         }
-        if (!this._commandsCache[keystrokes].includes(command)) {
-          this._commandsCache[keystrokes].push(command);
+        if (!this._commandsCache[platformKeystrokes].includes(command)) {
+          this._commandsCache[platformKeystrokes].push(command);
         }
       }
     }

--- a/app/src/keymap-manager.ts
+++ b/app/src/keymap-manager.ts
@@ -11,6 +11,9 @@ interface KeymapLoadOptions {
   replaceExistingCommands?: boolean;
 }
 
+// Mousetrap understands mod, but keeps mod+u and ctrl+u as separate callbacks.
+// Our stopCallback skips the second after the first stops propagation, so merge
+// platform aliases before registering callbacks and collecting their commands.
 const normalizePlatformKeystrokes = (keystrokes: string) =>
   keystrokes.replace(/\bmod\b/g, process.platform === 'darwin' ? 'command' : 'ctrl');
 


### PR DESCRIPTION
Outlook maps Ctrl+Q and Ctrl+U to mark messages read and unread, but inherited bindings can consume those shortcuts on Windows. Keymap templates now replace inherited bindings for commands they define, and platform modifier aliases share one Mousetrap registration and command list.

Normalization is needed even though Mousetrap understands mod: the base keymap registers mod+u for underline and Outlook registers ctrl+u for mark unread. Mousetrap retains separate callbacks for these spellings. The first callback returns false, and Mailspring's stopCallback then skips the second because propagation has stopped. Menu accelerator formatting does not merge these renderer callbacks.

Added a focused regression test using the real Mousetrap and Mailspring stopCallback. With normalization both commands dispatch; removing normalization makes the test fail because only underline dispatches.

Validation: full TypeScript checks, focused ESLint and formatting checks, and both keymap-manager specs in an isolated Electron harness. The new regression was also run with normalization removed to confirm it fails. The existing physical-key Electron integration spec remains in the PR; it was not rerun in this review follow-up.
