### PR TITLE
Let the day/week grid scroll to the end of the day in short windows

### DIFF
--- a/app/internal_packages/main-calendar/styles/nylas-calendar.less
+++ b/app/internal_packages/main-calendar/styles/nylas-calendar.less
@@ -334,7 +334,8 @@ body.platform-win32 {
       display: flex;
       flex-direction: row;
       position: relative;
-      height: 100%;
+      flex: 1;
+      min-height: 0;
 
       .calendar-area-wrap {
         &::-webkit-scrollbar {


### PR DESCRIPTION
`.calendar-body-wrap` used `height: 100%` inside the flex column that also
holds the banner and header controls, so it resolved to the full column
height and its bottom sat one header-height below the window. The grid's
last hour was drawn but unreachable by scrolling. Flex shrink could not
recover it because the legend's JS-set height made the row's min-content
equal to the full height.

`flex: 1; min-height: 0` sizes the row to the space the header leaves.
Verified in the running app: body-wrap bottom moved from 702 to 656 in a
656px window, in both week and day view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)