### PR TITLE
Position timed events by wall clock so they sit on their gridlines on DST days

### DIFF
--- a/app/internal_packages/main-calendar/lib/core/calendar-drag-types.ts
+++ b/app/internal_packages/main-calendar/lib/core/calendar-drag-types.ts
@@ -49,9 +49,6 @@ export interface DragState {
   /** Original end time (unix timestamp) - for calculating deltas and cancellation */
   originalEnd: number;
 
-  /** Unix timestamp at the initial mouse position when drag started */
-  initialMouseTime: number;
-
   /** Offset between click position and event start (for 'move' mode) - preserves grab point */
   clickOffset: number;
 

--- a/app/internal_packages/main-calendar/lib/core/calendar-drag-utils.ts
+++ b/app/internal_packages/main-calendar/lib/core/calendar-drag-utils.ts
@@ -214,9 +214,8 @@ export function createDragState(
   const start = occurrenceStartUnix(event);
   const end = occurrenceEndUnix(event);
 
-  // The grab offset keeps the event from jumping when the drag starts. It is measured against
-  // the instant the grid maps the event's clock reading to (`mouseTime` comes from the grid),
-  // which inside a fall-back repeated hour is the first occurrence, not the event's own.
+  // The grab offset keeps the event from jumping when the drag starts. `mouseTime` comes from
+  // the grid, so it is measured against the grid's reading of the edge, not the edge itself.
   let clickOffset = 0;
   if (hitZone.mode === 'move') {
     clickOffset = mouseTime - CalendarDateUtils.firstOccurrenceUnix(start);
@@ -229,7 +228,6 @@ export function createDragState(
     event,
     originalStart: start,
     originalEnd: end,
-    initialMouseTime: mouseTime,
     clickOffset,
     initialMouseX: mouseX,
     initialMouseY: mouseY,
@@ -331,8 +329,8 @@ export function updateDragState(
         previewStart = moment.unix(state.originalStart).add(daysDelta, 'days').unix();
         previewEnd = previewStart + eventDuration;
       } else {
-        // A grid reading inside a repeated hour names two instants; keep the event's own.
-        previewStart = CalendarDateUtils.nearestOccurrenceUnix(
+        // A grid reading inside a repeated hour names two instants; stay on the event's side.
+        previewStart = CalendarDateUtils.sameOffsetOccurrenceUnix(
           snapToInterval(mouseTime - state.clickOffset, snapInterval),
           state.originalStart
         );
@@ -348,7 +346,7 @@ export function updateDragState(
         previewStart = moment.unix(Math.min(mouseTime, lastDay)).startOf('day').unix();
         previewEnd = exclusiveDayEnd(state.originalEnd, previewStart);
       } else {
-        previewStart = CalendarDateUtils.nearestOccurrenceUnix(
+        previewStart = CalendarDateUtils.sameOffsetOccurrenceUnix(
           snapToInterval(mouseTime, snapInterval),
           state.originalStart
         );
@@ -372,7 +370,7 @@ export function updateDragState(
         );
       } else {
         previewStart = state.originalStart;
-        previewEnd = CalendarDateUtils.nearestOccurrenceUnix(
+        previewEnd = CalendarDateUtils.sameOffsetOccurrenceUnix(
           snapToInterval(mouseTime - state.clickOffset, snapInterval),
           state.originalEnd
         );

--- a/app/internal_packages/main-calendar/lib/core/calendar-drag-utils.ts
+++ b/app/internal_packages/main-calendar/lib/core/calendar-drag-utils.ts
@@ -214,17 +214,15 @@ export function createDragState(
   const start = occurrenceStartUnix(event);
   const end = occurrenceEndUnix(event);
 
-  // Calculate click offset for 'move' mode - this is the time difference between
-  // where the user clicked and the event's start time. We'll preserve this offset
-  // so the event doesn't jump when dragging starts.
+  // The grab offset keeps the event from jumping when the drag starts. It is measured against
+  // the instant the grid maps the event's clock reading to (`mouseTime` comes from the grid),
+  // which inside a fall-back repeated hour is the first occurrence, not the event's own.
   let clickOffset = 0;
   if (hitZone.mode === 'move') {
-    clickOffset = mouseTime - start;
+    clickOffset = mouseTime - CalendarDateUtils.firstOccurrenceUnix(start);
   } else if (hitZone.mode === 'resize-end') {
-    // For resize-end, offset is from the end of the event
-    clickOffset = mouseTime - end;
+    clickOffset = mouseTime - CalendarDateUtils.firstOccurrenceUnix(end);
   }
-  // For resize-start, no offset needed (we resize from start time)
 
   return {
     mode: hitZone.mode,
@@ -333,7 +331,11 @@ export function updateDragState(
         previewStart = moment.unix(state.originalStart).add(daysDelta, 'days').unix();
         previewEnd = previewStart + eventDuration;
       } else {
-        previewStart = snapToInterval(mouseTime - state.clickOffset, snapInterval);
+        // A grid reading inside a repeated hour names two instants; keep the event's own.
+        previewStart = CalendarDateUtils.nearestOccurrenceUnix(
+          snapToInterval(mouseTime - state.clickOffset, snapInterval),
+          state.originalStart
+        );
         previewEnd = previewStart + eventDuration;
       }
       break;
@@ -346,8 +348,10 @@ export function updateDragState(
         previewStart = moment.unix(Math.min(mouseTime, lastDay)).startOf('day').unix();
         previewEnd = exclusiveDayEnd(state.originalEnd, previewStart);
       } else {
-        const newStart = Math.min(mouseTime, state.originalEnd - minDuration);
-        previewStart = snapToInterval(newStart, snapInterval);
+        previewStart = CalendarDateUtils.nearestOccurrenceUnix(
+          snapToInterval(mouseTime, snapInterval),
+          state.originalStart
+        );
         previewEnd = state.originalEnd;
         // Ensure minimum duration after snapping
         if (previewEnd - previewStart < minDuration) {
@@ -367,9 +371,11 @@ export function updateDragState(
           CalendarDateUtils.calendarDateFromUnix(lastDay)
         );
       } else {
-        const newEnd = Math.max(mouseTime - state.clickOffset, state.originalStart + minDuration);
         previewStart = state.originalStart;
-        previewEnd = snapToInterval(newEnd, snapInterval);
+        previewEnd = CalendarDateUtils.nearestOccurrenceUnix(
+          snapToInterval(mouseTime - state.clickOffset, snapInterval),
+          state.originalEnd
+        );
         // Ensure minimum duration after snapping
         if (previewEnd - previewStart < minDuration) {
           previewEnd = previewStart + minDuration;

--- a/app/internal_packages/main-calendar/lib/core/calendar-event-container.tsx
+++ b/app/internal_packages/main-calendar/lib/core/calendar-event-container.tsx
@@ -173,7 +173,7 @@ export class CalendarEventContainer extends React.Component<CalendarEventContain
         // The grid is 24 wall-clock hours, so a fraction of it is a time of day — not a share of
         // the day's elapsed seconds, which lands up to an hour off the gridline on a DST day.
         const percentDay = Math.max(0, Math.min(1, y / height));
-        time = CalendarDateUtils.unixAtSecondsIntoDay(
+        time = CalendarDateUtils.secondsIntoDayUnix(
           CalendarDateUtils.calendarDateFromUnix(startTime),
           Math.round(percentDay * DAY_DUR)
         );

--- a/app/internal_packages/main-calendar/lib/core/calendar-event-container.tsx
+++ b/app/internal_packages/main-calendar/lib/core/calendar-event-container.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { CalendarDateUtils } from 'mailspring-exports';
 
 import { EventOccurrence } from './calendar-data-source';
 import { CalendarContainerType } from './calendar-drag-types';
 import { allDayColumnStartUnix } from './calendar-drag-utils';
+import { DAY_DUR } from './week-view-helpers';
 
 export interface CalendarEventArgs {
   /** The underlying DOM mouse event */
@@ -168,10 +170,13 @@ export class CalendarEventContainer extends React.Component<CalendarEventContain
             : event.clientX - rect.left;
         width = rect.width;
 
-        // Calculate time as percentage through the day
+        // The grid is 24 wall-clock hours, so a fraction of it is a time of day — not a share of
+        // the day's elapsed seconds, which lands up to an hour off the gridline on a DST day.
         const percentDay = Math.max(0, Math.min(1, y / height));
-        const timeOffset = (endTime - startTime) * percentDay;
-        time = startTime + timeOffset;
+        time = CalendarDateUtils.unixAtSecondsIntoDay(
+          CalendarDateUtils.calendarDateFromUnix(startTime),
+          Math.round(percentDay * DAY_DUR)
+        );
         break;
       }
 

--- a/app/internal_packages/main-calendar/lib/core/calendar-event.tsx
+++ b/app/internal_packages/main-calendar/lib/core/calendar-event.tsx
@@ -44,12 +44,7 @@ interface CalendarEventProps {
   onFocused: (event: EventOccurrence) => void;
 
   /** Called when a drag operation starts on this event */
-  onDragStart?: (
-    event: EventOccurrence,
-    mouseEvent: React.MouseEvent,
-    hitZone: HitZone,
-    mouseTime: number
-  ) => void;
+  onDragStart?: (event: EventOccurrence, mouseEvent: React.MouseEvent, hitZone: HitZone) => void;
 }
 
 interface CalendarEventState {
@@ -220,31 +215,6 @@ export class CalendarEvent extends React.Component<CalendarEventProps, CalendarE
   };
 
   /**
-   * Calculate the time at the mouse position within this event's scope
-   */
-  _getMouseTime(e: React.MouseEvent<HTMLDivElement>): number {
-    const bounds = e.currentTarget.getBoundingClientRect();
-    const { scopeStart, scopeEnd, direction } = this.props;
-    const scopeLen = scopeEnd - scopeStart;
-
-    let percent: number;
-    if (direction === 'vertical') {
-      // Vertical layout: Y position determines time
-      percent = (e.clientY - bounds.top) / bounds.height;
-    } else {
-      // Horizontal layout: X position determines time
-      percent = (e.clientX - bounds.left) / bounds.width;
-    }
-
-    // Clamp to [0, 1] and calculate time
-    percent = Math.max(0, Math.min(1, percent));
-    // Drag works in unix throughout, so hand it an instant even for all-day events.
-    const start = occurrenceStartUnix(this.props.event);
-    const eventDuration = occurrenceEndUnix(this.props.event) - start;
-    return start + percent * eventDuration;
-  }
-
-  /**
    * Initiate drag on mouse down
    */
   _onMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
@@ -260,12 +230,10 @@ export class CalendarEvent extends React.Component<CalendarEventProps, CalendarE
     // Prevent text selection during drag
     e.preventDefault();
 
-    // Calculate the time at the click position within this event
-    const mouseTime = this._getMouseTime(e);
-
-    // Notify parent of drag start
+    // The grab time comes from the grid, not this box: the container maps the same mousedown
+    // as it bubbles, so the anchor and every later drag target share one coordinate system.
     if (this.props.onDragStart) {
-      this.props.onDragStart(this.props.event, e, this.state.hitZone, mouseTime);
+      this.props.onDragStart(this.props.event, e, this.state.hitZone);
     }
   };
 

--- a/app/internal_packages/main-calendar/lib/core/calendar-event.tsx
+++ b/app/internal_packages/main-calendar/lib/core/calendar-event.tsx
@@ -12,6 +12,7 @@ import { calcEventColors, extractMeetingDomain, formatEventTimeRange } from './c
 import { RecurringIcon } from './calendar-icons';
 import { HitZone, ViewDirection } from './calendar-drag-types';
 import { detectHitZone, canMoveEvent, formatDragPreviewTime } from './calendar-drag-utils';
+import { DAY_DUR } from './week-view-helpers';
 
 interface CalendarEventProps {
   event: EventOccurrence;
@@ -100,16 +101,20 @@ export class CalendarEvent extends React.Component<CalendarEventProps, CalendarE
   _getDimensions() {
     const event = this.props.event;
 
-    // top/height are fractions of the scope. Timed events fill a day vertically by instant;
-    // all-day events fill the week horizontally (remapped in _getStyles) by whole days, so their
-    // fraction is computed in date space — DST-immune, unlike a seconds-based fraction would be.
+    // top/height are fractions of the scope, in the grid's own coordinates rather than elapsed
+    // seconds, so neither drifts on a DST day: timed events fill a day vertically by wall clock
+    // (the gridlines are 24 uniform hours), all-day events fill the week horizontally (remapped
+    // in _getStyles) by whole days.
     let top: number | string;
     let height: number | string;
     if (isTimed(event)) {
-      const scopeLen = this.props.scopeEnd - this.props.scopeStart;
-      const duration = event.end - event.start;
-      top = Math.max((event.start - this.props.scopeStart) / scopeLen, 0);
-      height = Math.min((duration - this._overflowBefore()) / scopeLen, 1);
+      // Instants outside the column clamp to its edges; `scopeEnd` is the next day's start, so an
+      // end exactly there reaches the bottom rather than reading as 00:00.
+      const { scopeStart, scopeEnd } = this.props;
+      top = event.start <= scopeStart ? 0 : CalendarDateUtils.secondsIntoDay(event.start) / DAY_DUR;
+      const bottom =
+        event.end >= scopeEnd ? 1 : CalendarDateUtils.secondsIntoDay(event.end) / DAY_DUR;
+      height = Math.max(bottom - top, 0);
     } else {
       const scopeStartDate = CalendarDateUtils.calendarDateFromUnix(this.props.scopeStart);
       const scopeDays = Math.round((this.props.scopeEnd - this.props.scopeStart) / 86400);
@@ -173,11 +178,6 @@ export class CalendarEvent extends React.Component<CalendarEventProps, CalendarE
       styles.backgroundColor = colors.background;
     }
     return styles;
-  }
-
-  _overflowBefore() {
-    const event = this.props.event;
-    return isTimed(event) ? Math.max(this.props.scopeStart - event.start, 0) : 0;
   }
 
   /**

--- a/app/internal_packages/main-calendar/lib/core/calendar-event.tsx
+++ b/app/internal_packages/main-calendar/lib/core/calendar-event.tsx
@@ -12,7 +12,7 @@ import { calcEventColors, extractMeetingDomain, formatEventTimeRange } from './c
 import { RecurringIcon } from './calendar-icons';
 import { HitZone, ViewDirection } from './calendar-drag-types';
 import { detectHitZone, canMoveEvent, formatDragPreviewTime } from './calendar-drag-utils';
-import { dayFraction } from './week-view-helpers';
+import { DAY_DUR, columnSpan } from './week-view-helpers';
 
 interface CalendarEventProps {
   event: EventOccurrence;
@@ -106,10 +106,9 @@ export class CalendarEvent extends React.Component<CalendarEventProps, CalendarE
     let top: number | string;
     let height: number | string;
     if (isTimed(event)) {
-      const { scopeStart, scopeEnd } = this.props;
-      top = event.start < scopeStart ? 0 : dayFraction(event.start);
-      const bottom = event.end >= scopeEnd ? 1 : dayFraction(event.end);
-      height = Math.max(bottom - top, 0);
+      const span = columnSpan(event, this.props.scopeStart, this.props.scopeEnd);
+      top = span.top / DAY_DUR;
+      height = (span.bottom - span.top) / DAY_DUR;
     } else {
       const scopeStartDate = CalendarDateUtils.calendarDateFromUnix(this.props.scopeStart);
       const scopeDays = Math.round((this.props.scopeEnd - this.props.scopeStart) / 86400);

--- a/app/internal_packages/main-calendar/lib/core/calendar-event.tsx
+++ b/app/internal_packages/main-calendar/lib/core/calendar-event.tsx
@@ -12,7 +12,7 @@ import { calcEventColors, extractMeetingDomain, formatEventTimeRange } from './c
 import { RecurringIcon } from './calendar-icons';
 import { HitZone, ViewDirection } from './calendar-drag-types';
 import { detectHitZone, canMoveEvent, formatDragPreviewTime } from './calendar-drag-utils';
-import { DAY_DUR } from './week-view-helpers';
+import { dayFraction } from './week-view-helpers';
 
 interface CalendarEventProps {
   event: EventOccurrence;
@@ -101,19 +101,14 @@ export class CalendarEvent extends React.Component<CalendarEventProps, CalendarE
   _getDimensions() {
     const event = this.props.event;
 
-    // top/height are fractions of the scope, in the grid's own coordinates rather than elapsed
-    // seconds, so neither drifts on a DST day: timed events fill a day vertically by wall clock
-    // (the gridlines are 24 uniform hours), all-day events fill the week horizontally (remapped
-    // in _getStyles) by whole days.
+    // Fractions of the scope: timed events by wall clock down a day column, all-day events by
+    // whole days across the week (remapped in _getStyles).
     let top: number | string;
     let height: number | string;
     if (isTimed(event)) {
-      // Instants outside the column clamp to its edges; `scopeEnd` is the next day's start, so an
-      // end exactly there reaches the bottom rather than reading as 00:00.
       const { scopeStart, scopeEnd } = this.props;
-      top = event.start <= scopeStart ? 0 : CalendarDateUtils.secondsIntoDay(event.start) / DAY_DUR;
-      const bottom =
-        event.end >= scopeEnd ? 1 : CalendarDateUtils.secondsIntoDay(event.end) / DAY_DUR;
+      top = event.start < scopeStart ? 0 : dayFraction(event.start);
+      const bottom = event.end >= scopeEnd ? 1 : dayFraction(event.end);
       height = Math.max(bottom - top, 0);
     } else {
       const scopeStartDate = CalendarDateUtils.calendarDateFromUnix(this.props.scopeStart);

--- a/app/internal_packages/main-calendar/lib/core/calendar-event.tsx
+++ b/app/internal_packages/main-calendar/lib/core/calendar-event.tsx
@@ -101,7 +101,7 @@ export class CalendarEvent extends React.Component<CalendarEventProps, CalendarE
     let top: number | string;
     let height: number | string;
     if (isTimed(event)) {
-      const span = columnSpan(event, this.props.scopeStart, this.props.scopeEnd);
+      const span = columnSpan(event, { start: this.props.scopeStart, end: this.props.scopeEnd });
       top = span.top / DAY_DUR;
       height = (span.bottom - span.top) / DAY_DUR;
     } else {
@@ -230,8 +230,7 @@ export class CalendarEvent extends React.Component<CalendarEventProps, CalendarE
     // Prevent text selection during drag
     e.preventDefault();
 
-    // The grab time comes from the grid, not this box: the container maps the same mousedown
-    // as it bubbles, so the anchor and every later drag target share one coordinate system.
+    // No time is passed: the container's hit-test supplies it as this mousedown bubbles.
     if (this.props.onDragStart) {
       this.props.onDragStart(this.props.event, e, this.state.hitZone);
     }

--- a/app/internal_packages/main-calendar/lib/core/calendar-helpers.tsx
+++ b/app/internal_packages/main-calendar/lib/core/calendar-helpers.tsx
@@ -13,6 +13,7 @@ import {
 } from 'mailspring-exports';
 import { MIN_EVENT_DURATION_SECONDS } from './calendar-constants';
 import { EventOccurrence, isTimed } from './calendar-data-source';
+import { dayFraction } from './week-view-helpers';
 
 // Cache of calendar colors synced from CalDAV servers
 const calendarColorCache: Map<string, string> = new Map();
@@ -454,9 +455,6 @@ export async function createCalendarEvent(options: CreateCalendarEventOptions): 
  * with no timed selection, fall back to the midday default.
  */
 export function centerGridScroll(viewportEl: HTMLElement, selectedEvent?: EventOccurrence): void {
-  let dayFraction = 0.5;
-  if (selectedEvent && isTimed(selectedEvent)) {
-    dayFraction = CalendarDateUtils.secondsIntoDay(selectedEvent.start) / 86400;
-  }
-  viewportEl.scrollTop = viewportEl.scrollHeight * dayFraction - viewportEl.clientHeight / 2;
+  const fraction = selectedEvent && isTimed(selectedEvent) ? dayFraction(selectedEvent.start) : 0.5;
+  viewportEl.scrollTop = viewportEl.scrollHeight * fraction - viewportEl.clientHeight / 2;
 }

--- a/app/internal_packages/main-calendar/lib/core/calendar-helpers.tsx
+++ b/app/internal_packages/main-calendar/lib/core/calendar-helpers.tsx
@@ -456,8 +456,7 @@ export async function createCalendarEvent(options: CreateCalendarEventOptions): 
 export function centerGridScroll(viewportEl: HTMLElement, selectedEvent?: EventOccurrence): void {
   let dayFraction = 0.5;
   if (selectedEvent && isTimed(selectedEvent)) {
-    const m = moment.unix(selectedEvent.start);
-    dayFraction = (m.hour() * 3600 + m.minute() * 60) / 86400;
+    dayFraction = CalendarDateUtils.secondsIntoDay(selectedEvent.start) / 86400;
   }
   viewportEl.scrollTop = viewportEl.scrollHeight * dayFraction - viewportEl.clientHeight / 2;
 }

--- a/app/internal_packages/main-calendar/lib/core/current-time-indicator.tsx
+++ b/app/internal_packages/main-calendar/lib/core/current-time-indicator.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import Moment from 'moment';
 import classNames from 'classnames';
+import { CalendarDateUtils } from 'mailspring-exports';
+import { DAY_DUR } from './week-view-helpers';
 
 interface CurrentTimeIndicatorProps {
   gridHeight: number;
@@ -12,7 +13,7 @@ interface CurrentTimeIndicatorProps {
 
 export class CurrentTimeIndicator extends React.Component<
   CurrentTimeIndicatorProps,
-  { msecIntoDay: number }
+  { dayFraction: number }
 > {
   _movementTimer = null;
 
@@ -35,17 +36,12 @@ export class CurrentTimeIndicator extends React.Component<
   }
 
   getStateFromTime() {
-    const now = Moment();
-    return {
-      msecIntoDay:
-        now.millisecond() + (now.second() + (now.minute() + now.hour() * 60) * 60) * 1000,
-    };
+    return { dayFraction: CalendarDateUtils.secondsIntoDay(Date.now() / 1000) / DAY_DUR };
   }
 
   render() {
     const { gridHeight, numColumns, todayColumnIdx, visible } = this.props;
-    const msecsPerDay = 24 * 60 * 60 * 1000;
-    const { msecIntoDay } = this.state;
+    const { dayFraction } = this.state;
 
     const todayMarker =
       todayColumnIdx !== -1 ? (
@@ -55,7 +51,7 @@ export class CurrentTimeIndicator extends React.Component<
     return (
       <div
         className={classNames({ 'current-time-indicator': true, visible: visible })}
-        style={{ top: gridHeight * (msecIntoDay / msecsPerDay) }}
+        style={{ top: gridHeight * dayFraction }}
       >
         {todayMarker}
       </div>

--- a/app/internal_packages/main-calendar/lib/core/current-time-indicator.tsx
+++ b/app/internal_packages/main-calendar/lib/core/current-time-indicator.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import classNames from 'classnames';
-import { CalendarDateUtils } from 'mailspring-exports';
-import { DAY_DUR } from './week-view-helpers';
+import { dayFraction } from './week-view-helpers';
 
 interface CurrentTimeIndicatorProps {
   gridHeight: number;
@@ -36,7 +35,7 @@ export class CurrentTimeIndicator extends React.Component<
   }
 
   getStateFromTime() {
-    return { dayFraction: CalendarDateUtils.secondsIntoDay(Date.now() / 1000) / DAY_DUR };
+    return { dayFraction: dayFraction(Date.now() / 1000) };
   }
 
   render() {

--- a/app/internal_packages/main-calendar/lib/core/mailspring-calendar.tsx
+++ b/app/internal_packages/main-calendar/lib/core/mailspring-calendar.tsx
@@ -522,18 +522,14 @@ export class MailspringCalendar extends React.Component<
   }
 
   /**
-   * Handle drag start from an event
+   * A grab waiting for its position: the event's mousedown lands here first, then bubbles to
+   * the CalendarEventContainer, whose hit-test hands _onCalendarMouseDown the grid time and
+   * container coordinates under the cursor — the same frame every later drag target uses.
    */
-  /**
-   * A grab waiting for its time: the event's mousedown lands here first, then bubbles to the
-   * CalendarEventContainer, whose hit-test hands _onCalendarMouseDown the grid time under the
-   * cursor. Anchoring on the grid rather than the event's box keeps the grab offset in the same
-   * coordinates as every later drag target.
-   */
-  _pendingDrag: { event: EventOccurrence; hitZone: HitZone; x: number; y: number } | null = null;
+  _pendingDrag: { event: EventOccurrence; hitZone: HitZone } | null = null;
 
-  _onEventDragStart = (event: EventOccurrence, mouseEvent: React.MouseEvent, hitZone: HitZone) => {
-    this._pendingDrag = { event, hitZone, x: mouseEvent.clientX, y: mouseEvent.clientY };
+  _onEventDragStart = (event: EventOccurrence, _mouseEvent: React.MouseEvent, hitZone: HitZone) => {
+    this._pendingDrag = { event, hitZone };
   };
 
   /**
@@ -610,8 +606,8 @@ export class MailspringCalendar extends React.Component<
       pending.event,
       pending.hitZone,
       args.time,
-      pending.x,
-      pending.y,
+      args.x,
+      args.y,
       this._getDragConfig()
     );
     this.setState({ dragState });

--- a/app/internal_packages/main-calendar/lib/core/mailspring-calendar.tsx
+++ b/app/internal_packages/main-calendar/lib/core/mailspring-calendar.tsx
@@ -101,8 +101,7 @@ export interface MailspringCalendarViewProps extends EventRendererProps {
   onEventDragStart: (
     event: EventOccurrence,
     mouseEvent: React.MouseEvent,
-    hitZone: HitZone,
-    mouseTime: number
+    hitZone: HitZone
   ) => void;
 
   /** Set of calendar IDs that are read-only (events in these calendars cannot be dragged) */
@@ -525,24 +524,16 @@ export class MailspringCalendar extends React.Component<
   /**
    * Handle drag start from an event
    */
-  _onEventDragStart = (
-    event: EventOccurrence,
-    mouseEvent: React.MouseEvent,
-    hitZone: HitZone,
-    mouseTime: number
-  ) => {
-    const config = this._getDragConfig();
+  /**
+   * A grab waiting for its time: the event's mousedown lands here first, then bubbles to the
+   * CalendarEventContainer, whose hit-test hands _onCalendarMouseDown the grid time under the
+   * cursor. Anchoring on the grid rather than the event's box keeps the grab offset in the same
+   * coordinates as every later drag target.
+   */
+  _pendingDrag: { event: EventOccurrence; hitZone: HitZone; x: number; y: number } | null = null;
 
-    const dragState = createDragState(
-      event,
-      hitZone,
-      mouseTime,
-      mouseEvent.clientX,
-      mouseEvent.clientY,
-      config
-    );
-
-    this.setState({ dragState });
+  _onEventDragStart = (event: EventOccurrence, mouseEvent: React.MouseEvent, hitZone: HitZone) => {
+    this._pendingDrag = { event, hitZone, x: mouseEvent.clientX, y: mouseEvent.clientY };
   };
 
   /**
@@ -609,11 +600,21 @@ export class MailspringCalendar extends React.Component<
     this._persistDragChange(dragState);
   };
 
-  /**
-   * Handle mouse down on calendar
-   */
-  _onCalendarMouseDown = (_args: CalendarEventArgs) => {
-    // No-op: mouseUp handles drag completion, mouseMove handles drag updates
+  _onCalendarMouseDown = (args: CalendarEventArgs) => {
+    const pending = this._pendingDrag;
+    this._pendingDrag = null;
+    if (!pending || args.time === null) {
+      return;
+    }
+    const dragState = createDragState(
+      pending.event,
+      pending.hitZone,
+      args.time,
+      pending.x,
+      pending.y,
+      this._getDragConfig()
+    );
+    this.setState({ dragState });
   };
 
   /**

--- a/app/internal_packages/main-calendar/lib/core/month-view-day-cell.tsx
+++ b/app/internal_packages/main-calendar/lib/core/month-view-day-cell.tsx
@@ -27,8 +27,7 @@ interface MonthViewDayCellProps {
   onEventDragStart: (
     event: EventOccurrence,
     mouseEvent: React.MouseEvent,
-    hitZone: HitZone,
-    mouseTime: number
+    hitZone: HitZone
   ) => void;
   /** Set of calendar IDs that are read-only */
   readOnlyCalendarIds: Set<string>;

--- a/app/internal_packages/main-calendar/lib/core/month-view-event.tsx
+++ b/app/internal_packages/main-calendar/lib/core/month-view-event.tsx
@@ -18,12 +18,7 @@ interface MonthViewEventProps {
   onClick: (e: React.MouseEvent<any>, event: EventOccurrence) => void;
   onDoubleClick: (event: EventOccurrence) => void;
   onFocused: (event: EventOccurrence) => void;
-  onDragStart?: (
-    event: EventOccurrence,
-    mouseEvent: React.MouseEvent,
-    hitZone: HitZone,
-    mouseTime: number
-  ) => void;
+  onDragStart?: (event: EventOccurrence, mouseEvent: React.MouseEvent, hitZone: HitZone) => void;
 }
 
 interface MonthViewEventState {
@@ -137,13 +132,9 @@ export class MonthViewEvent extends React.Component<MonthViewEventProps, MonthVi
     // Note: Don't call stopPropagation() - the event needs to bubble to
     // CalendarEventContainer so it can track _mouseIsDown state
 
-    // For month view events, use the event's start time as the mouse time
-    // since day-level snapping doesn't require precise time positioning
-    const mouseTime = occurrenceStartUnix(this.props.event);
-
     // Notify parent of drag start
     if (this.props.onDragStart) {
-      this.props.onDragStart(this.props.event, e, this.state.hitZone, mouseTime);
+      this.props.onDragStart(this.props.event, e, this.state.hitZone);
     }
   };
 

--- a/app/internal_packages/main-calendar/lib/core/week-view-all-day-events.tsx
+++ b/app/internal_packages/main-calendar/lib/core/week-view-all-day-events.tsx
@@ -24,8 +24,7 @@ interface WeekViewAllDayEventsProps extends EventRendererProps {
   onEventDragStart: (
     event: EventOccurrence,
     mouseEvent: React.MouseEvent,
-    hitZone: HitZone,
-    mouseTime: number
+    hitZone: HitZone
   ) => void;
   /** Set of calendar IDs that are read-only */
   readOnlyCalendarIds: Set<string>;

--- a/app/internal_packages/main-calendar/lib/core/week-view-event-column.tsx
+++ b/app/internal_packages/main-calendar/lib/core/week-view-event-column.tsx
@@ -27,8 +27,7 @@ interface WeekViewEventColumnProps {
   onEventDragStart: (
     event: EventOccurrence,
     mouseEvent: React.MouseEvent,
-    hitZone: HitZone,
-    mouseTime: number
+    hitZone: HitZone
   ) => void;
   /** Set of calendar IDs that are read-only */
   readOnlyCalendarIds: Set<string>;

--- a/app/internal_packages/main-calendar/lib/core/week-view-event-column.tsx
+++ b/app/internal_packages/main-calendar/lib/core/week-view-event-column.tsx
@@ -60,8 +60,8 @@ export class WeekViewEventColumn extends React.Component<WeekViewEventColumnProp
       'event-column': true,
       weekend: day.day() === 0 || day.day() === 6,
     });
-    const overlap = overlapForEvents(events);
     const dayStart = day.unix();
+    const overlap = overlapForEvents(events, { start: dayStart, end: dayEnd });
 
     return (
       <div

--- a/app/internal_packages/main-calendar/lib/core/week-view-helpers.ts
+++ b/app/internal_packages/main-calendar/lib/core/week-view-helpers.ts
@@ -1,4 +1,4 @@
-import { EventOccurrence, isTimed } from './calendar-data-source';
+import { EventOccurrence, TimedOccurrence, isTimed } from './calendar-data-source';
 import moment, { Moment } from 'moment';
 import { CalendarDateUtils } from 'mailspring-exports';
 
@@ -13,22 +13,39 @@ export interface OverlapByEventId {
  *   - concurrentEvents: number of concurrent events
  *   - order: the order in that series of concurrent events
  */
+/** A day column's bounds: its start and the next column's start, as `exclusiveDayEnds` gives them. */
+export interface ColumnBounds {
+  start: number;
+  end: number;
+}
+
 /**
  * Sweep-line bounds for an occurrence, as a half-open `[lo, hi)`. Each call is homogeneous —
  * the all-day bar passes only all-day events, day columns only timed — so all-day stacks in
- * date space (`addCalendarDays(endDate, 1)` exclusive) and timed in instants, and the two never mix in one call.
+ * date space (`addCalendarDays(endDate, 1)` exclusive) and timed in the column's grid
+ * coordinates, and the two never mix in one call.
  */
-function sweepBounds(e: EventOccurrence): { lo: number; hi: number } {
-  return isTimed(e)
-    ? { lo: e.start, hi: e.end }
-    : { lo: e.startDate, hi: CalendarDateUtils.addCalendarDays(e.endDate, 1) };
+function sweepBounds(e: EventOccurrence, column?: ColumnBounds): { lo: number; hi: number } {
+  if (!isTimed(e)) {
+    return { lo: e.startDate, hi: CalendarDateUtils.addCalendarDays(e.endDate, 1) };
+  }
+  if (!column) {
+    return { lo: e.start, hi: e.end };
+  }
+  const { top, bottom } = columnSpan(e, column.start, column.end);
+  return { lo: top, hi: bottom };
 }
 
-export function overlapForEvents(events: EventOccurrence[]) {
+/**
+ * `column` puts timed events in the grid's wall-clock coordinates, the same ones they are
+ * drawn in, so two events in a fall-back day's repeated hour stack side by side instead of
+ * one hiding the other — by instant they are sequential, on screen they share a slot.
+ */
+export function overlapForEvents(events: EventOccurrence[], column?: ColumnBounds) {
   const eventsByTime: { [unix: number]: EventOccurrence[] } = {};
 
   for (const event of events) {
-    const b = sweepBounds(event);
+    const b = sweepBounds(event, column);
     if (!eventsByTime[b.lo]) {
       eventsByTime[b.lo] = [];
     }
@@ -50,7 +67,7 @@ export function overlapForEvents(events: EventOccurrence[]) {
     // Process all event start/ends during this time to keep our
     // "ongoingEvents" set correct.
     for (const e of eventsByTime[t]) {
-      const b = sweepBounds(e);
+      const b = sweepBounds(e, column);
       if (b.lo === t) {
         overlapById[e.id] = { concurrentEvents: 1, order: null };
         ongoingEvents.push(e);
@@ -167,6 +184,26 @@ export const TICKS_PER_DAY = DAY_DUR / TICK_STEP;
 /** Where an instant sits down the grid, 0..1: the grid is 24 wall-clock hours on every day. */
 export function dayFraction(unixSeconds: number): number {
   return CalendarDateUtils.secondsIntoDay(unixSeconds) / DAY_DUR;
+}
+
+/**
+ * The grid rows a timed event occupies in one day column, in grid seconds (0..DAY_DUR; integers,
+ * so they are safe as sweep keys). Instants outside the column clamp to its edges; `scopeEnd`
+ * is the next column's start, so an end exactly there is the bottom rather than a 00:00
+ * reading. Across a fall-back transition an end can read no later than its start; such an
+ * event is drawn at its real duration instead.
+ */
+export function columnSpan(
+  event: TimedOccurrence,
+  scopeStart: number,
+  scopeEnd: number
+): { top: number; bottom: number } {
+  const top = event.start < scopeStart ? 0 : CalendarDateUtils.secondsIntoDay(event.start);
+  if (event.end >= scopeEnd) {
+    return { top, bottom: DAY_DUR };
+  }
+  const wallClockEnd = CalendarDateUtils.secondsIntoDay(event.end);
+  return { top, bottom: wallClockEnd > top ? wallClockEnd : top + (event.end - event.start) };
 }
 
 export function* tickGenerator(type: 'major' | 'minor', tickHeight: number) {

--- a/app/internal_packages/main-calendar/lib/core/week-view-helpers.ts
+++ b/app/internal_packages/main-calendar/lib/core/week-view-helpers.ts
@@ -21,25 +21,21 @@ export interface ColumnBounds {
 
 /**
  * Sweep-line bounds for an occurrence, as a half-open `[lo, hi)`. Each call is homogeneous —
- * the all-day bar passes only all-day events, day columns only timed — so all-day stacks in
- * date space (`addCalendarDays(endDate, 1)` exclusive) and timed in the column's grid
- * coordinates, and the two never mix in one call.
+ * the all-day bar passes only all-day events, day columns only timed with their bounds — so
+ * all-day stacks in date space (`addCalendarDays(endDate, 1)` exclusive) and timed in the
+ * column's grid coordinates, and the two never mix in one call.
  */
 function sweepBounds(e: EventOccurrence, column?: ColumnBounds): { lo: number; hi: number } {
   if (!isTimed(e)) {
     return { lo: e.startDate, hi: CalendarDateUtils.addCalendarDays(e.endDate, 1) };
   }
-  if (!column) {
-    return { lo: e.start, hi: e.end };
-  }
-  const { top, bottom } = columnSpan(e, column.start, column.end);
+  const { top, bottom } = columnSpan(e, column);
   return { lo: top, hi: bottom };
 }
 
 /**
- * `column` puts timed events in the grid's wall-clock coordinates, the same ones they are
- * drawn in, so two events in a fall-back day's repeated hour stack side by side instead of
- * one hiding the other — by instant they are sequential, on screen they share a slot.
+ * Timed events sweep in the grid's wall-clock coordinates, the ones they are drawn in, so what
+ * overlaps on screen overlaps here — including the two occurrences of a repeated hour.
  */
 export function overlapForEvents(events: EventOccurrence[], column?: ColumnBounds) {
   const eventsByTime: { [unix: number]: EventOccurrence[] } = {};
@@ -187,23 +183,22 @@ export function dayFraction(unixSeconds: number): number {
 }
 
 /**
- * The grid rows a timed event occupies in one day column, in grid seconds (0..DAY_DUR; integers,
- * so they are safe as sweep keys). Instants outside the column clamp to its edges; `scopeEnd`
- * is the next column's start, so an end exactly there is the bottom rather than a 00:00
- * reading. Across a fall-back transition an end can read no later than its start; such an
- * event is drawn at its real duration instead.
+ * The grid rows a timed event occupies in one day column, in whole grid seconds (0..DAY_DUR),
+ * so they double as sweep keys. Instants outside the column clamp to its edges. Across a
+ * fall-back transition an end can read no later than its start; such an event is drawn at
+ * its real duration instead.
  */
 export function columnSpan(
   event: TimedOccurrence,
-  scopeStart: number,
-  scopeEnd: number
+  column: ColumnBounds
 ): { top: number; bottom: number } {
-  const top = event.start < scopeStart ? 0 : CalendarDateUtils.secondsIntoDay(event.start);
-  if (event.end >= scopeEnd) {
+  const top = event.start < column.start ? 0 : CalendarDateUtils.secondsIntoDay(event.start);
+  if (event.end >= column.end) {
     return { top, bottom: DAY_DUR };
   }
   const wallClockEnd = CalendarDateUtils.secondsIntoDay(event.end);
-  return { top, bottom: wallClockEnd > top ? wallClockEnd : top + (event.end - event.start) };
+  const bottom = wallClockEnd > top ? wallClockEnd : top + (event.end - event.start);
+  return { top, bottom: Math.min(Math.max(bottom, top), DAY_DUR) };
 }
 
 export function* tickGenerator(type: 'major' | 'minor', tickHeight: number) {

--- a/app/internal_packages/main-calendar/lib/core/week-view-helpers.ts
+++ b/app/internal_packages/main-calendar/lib/core/week-view-helpers.ts
@@ -20,17 +20,17 @@ export interface ColumnBounds {
 }
 
 /**
- * Sweep-line bounds for an occurrence, as a half-open `[lo, hi)`. Each call is homogeneous —
- * the all-day bar passes only all-day events, day columns only timed with their bounds — so
- * all-day stacks in date space (`addCalendarDays(endDate, 1)` exclusive) and timed in the
- * column's grid coordinates, and the two never mix in one call.
+ * Sweep-line bounds for an occurrence, as a half-open `[lo, hi)`. Inside a day column a timed
+ * event sweeps by its grid rows; everywhere else — the all-day bar, or any call without a
+ * column — by the dates it covers (`addCalendarDays(endDate, 1)` exclusive), which every
+ * occurrence carries. Each call is homogeneous, so the two coordinate systems never mix.
  */
 function sweepBounds(e: EventOccurrence, column?: ColumnBounds): { lo: number; hi: number } {
-  if (!isTimed(e)) {
-    return { lo: e.startDate, hi: CalendarDateUtils.addCalendarDays(e.endDate, 1) };
+  if (column && isTimed(e)) {
+    const { top, bottom } = columnSpan(e, column);
+    return { lo: top, hi: bottom };
   }
-  const { top, bottom } = columnSpan(e, column);
-  return { lo: top, hi: bottom };
+  return { lo: e.startDate, hi: CalendarDateUtils.addCalendarDays(e.endDate, 1) };
 }
 
 /**

--- a/app/internal_packages/main-calendar/lib/core/week-view-helpers.ts
+++ b/app/internal_packages/main-calendar/lib/core/week-view-helpers.ts
@@ -164,6 +164,11 @@ export const DAY_DUR = 24 * 60 * 60;
 export const TICK_STEP = 30 * 60;
 export const TICKS_PER_DAY = DAY_DUR / TICK_STEP;
 
+/** Where an instant sits down the grid, 0..1: the grid is 24 wall-clock hours on every day. */
+export function dayFraction(unixSeconds: number): number {
+  return CalendarDateUtils.secondsIntoDay(unixSeconds) / DAY_DUR;
+}
+
 export function* tickGenerator(type: 'major' | 'minor', tickHeight: number) {
   const step = TICK_STEP * 2;
   const skip = TICK_STEP * 2;

--- a/app/spec/calendar-date-spec.ts
+++ b/app/spec/calendar-date-spec.ts
@@ -9,6 +9,8 @@ import {
   parseCalendarDate,
   secondsIntoDay,
   secondsIntoDayUnix,
+  firstOccurrenceUnix,
+  nearestOccurrenceUnix,
 } from '../src/calendar-date';
 
 /** Fixtures read as dates, not epoch-day integers — a failure says 2026-06-21, not 20627 */
@@ -197,6 +199,47 @@ describe('secondsIntoDayUnix', function () {
     SAMPLE_DAYS.forEach((iso) => {
       expect(secondsIntoDayUnix(d(iso), 86400)).toBe(nextDayStartUnix(d(iso)));
     });
+  });
+});
+
+describe('firstOccurrenceUnix', function () {
+  const cdt130 = Date.UTC(2025, 10, 2, 6, 30) / 1000;
+  const cst130 = Date.UTC(2025, 10, 2, 7, 30) / 1000;
+
+  it('is the instant itself outside a repeated hour', function () {
+    [
+      at(ORDINARY_DAY, 10, 30),
+      at(FALL_BACK_DAY, 10, 30),
+      at(SPRING_FORWARD_DAY, 3, 30),
+      cdt130,
+    ].forEach((unix) => expect(firstOccurrenceUnix(unix)).toBe(unix));
+  });
+
+  it('is an hour earlier inside the second occurrence of a repeated hour', function () {
+    expect(firstOccurrenceUnix(cst130)).toBe(cdt130);
+  });
+});
+
+describe('nearestOccurrenceUnix', function () {
+  const cdt130 = Date.UTC(2025, 10, 2, 6, 30) / 1000;
+  const cst130 = Date.UTC(2025, 10, 2, 7, 30) / 1000;
+  const cst330 = Date.UTC(2025, 10, 2, 9, 30) / 1000;
+
+  it('resolves a repeated reading toward the reference', function () {
+    expect(nearestOccurrenceUnix(cdt130, cst130)).toBe(cst130);
+    expect(nearestOccurrenceUnix(cst130, cdt130)).toBe(cdt130);
+    expect(nearestOccurrenceUnix(cdt130, cst330)).toBe(cst130); // 3:30 CST is nearer the CST 1:30
+  });
+
+  it('keeps an instant whose reading happens once', function () {
+    const ten = at(FALL_BACK_DAY, 10, 30);
+    expect(nearestOccurrenceUnix(ten, ten - 5 * 3600)).toBe(ten);
+    const gapEdge = at(SPRING_FORWARD_DAY, 3, 30); // 2:30 does not exist; 3:30 happens once
+    expect(nearestOccurrenceUnix(gapEdge, gapEdge - 3600)).toBe(gapEdge);
+  });
+
+  it('keeps the instant when it is already the nearer occurrence', function () {
+    expect(nearestOccurrenceUnix(cdt130, cdt130 - 600)).toBe(cdt130);
   });
 });
 

--- a/app/spec/calendar-date-spec.ts
+++ b/app/spec/calendar-date-spec.ts
@@ -7,6 +7,8 @@ import {
   calendarDaysBetween,
   formatCalendarDate,
   parseCalendarDate,
+  secondsIntoDay,
+  unixAtSecondsIntoDay,
 } from '../src/calendar-date';
 
 /** Fixtures read as dates, not epoch-day integers — a failure says 2026-06-21, not 20627 */
@@ -146,6 +148,47 @@ describe('nextDayStartUnix', function () {
       const next = addCalendarDays(d(iso), 1);
       expect(nextDayStartUnix(d(iso))).toBe(dayStartUnix(next));
       expect(nextDayStartUnix(d(iso)) > dayStartUnix(d(iso))).toBe(true);
+    });
+  });
+});
+
+// Host-zone reads, so these discriminate only on the pinned Chicago runner, where 2025-11-02
+// is a 25-hour day and 2026-03-08 a 23-hour one. UTC literals are used where a fixture built
+// through the Date constructor would resolve a gap or a repeat the same way the code does.
+describe('secondsIntoDay', function () {
+  it('reads the wall clock, not elapsed time, on a transition day', function () {
+    expect(secondsIntoDay(at('2026-06-21', 10, 30))).toBe(37800);
+    expect(secondsIntoDay(at('2025-11-02', 10, 30))).toBe(37800); // 41400s after midnight
+    expect(secondsIntoDay(at('2026-03-08', 10, 30))).toBe(37800); // 34200s after midnight
+  });
+
+  it('is 0 at midnight and 86399 at the last second', function () {
+    expect(secondsIntoDay(at('2026-06-21'))).toBe(0);
+    expect(secondsIntoDay(at('2026-06-21', 23, 59) + 59)).toBe(86399);
+  });
+});
+
+describe('unixAtSecondsIntoDay', function () {
+  it('inverts secondsIntoDay on ordinary and transition days alike', function () {
+    ['2026-06-21', '2025-11-02', '2026-03-08'].forEach((iso) => {
+      expect(unixAtSecondsIntoDay(d(iso), 37800)).toBe(at(iso, 10, 30));
+      expect(secondsIntoDay(unixAtSecondsIntoDay(d(iso), 37800))).toBe(37800);
+    });
+  });
+
+  it('resolves a time inside the spring-forward gap forward', function () {
+    // 02:30 does not exist on 2026-03-08 in Chicago; the clock goes 01:59 -> 03:00.
+    expect(unixAtSecondsIntoDay(d('2026-03-08'), 9000)).toBe(Date.UTC(2026, 2, 8, 8, 30) / 1000);
+  });
+
+  it('picks the first occurrence of a fall-back repeated hour', function () {
+    // 01:30 happens twice on 2025-11-02 in Chicago: 06:30Z (CDT) and 07:30Z (CST).
+    expect(unixAtSecondsIntoDay(d('2025-11-02'), 5400)).toBe(Date.UTC(2025, 10, 2, 6, 30) / 1000);
+  });
+
+  it('lands 86400 on the next day-start, whatever the day length', function () {
+    ['2026-06-21', '2025-11-02', '2026-03-08'].forEach((iso) => {
+      expect(unixAtSecondsIntoDay(d(iso), 86400)).toBe(nextDayStartUnix(d(iso)));
     });
   });
 });

--- a/app/spec/calendar-date-spec.ts
+++ b/app/spec/calendar-date-spec.ts
@@ -10,7 +10,7 @@ import {
   secondsIntoDay,
   secondsIntoDayUnix,
   firstOccurrenceUnix,
-  nearestOccurrenceUnix,
+  sameOffsetOccurrenceUnix,
 } from '../src/calendar-date';
 
 /** Fixtures read as dates, not epoch-day integers — a failure says 2026-06-21, not 20627 */
@@ -220,26 +220,34 @@ describe('firstOccurrenceUnix', function () {
   });
 });
 
-describe('nearestOccurrenceUnix', function () {
+describe('sameOffsetOccurrenceUnix', function () {
   const cdt130 = Date.UTC(2025, 10, 2, 6, 30) / 1000;
   const cst130 = Date.UTC(2025, 10, 2, 7, 30) / 1000;
   const cst330 = Date.UTC(2025, 10, 2, 9, 30) / 1000;
 
-  it('resolves a repeated reading toward the reference', function () {
-    expect(nearestOccurrenceUnix(cdt130, cst130)).toBe(cst130);
-    expect(nearestOccurrenceUnix(cst130, cdt130)).toBe(cdt130);
-    expect(nearestOccurrenceUnix(cdt130, cst330)).toBe(cst130); // 3:30 CST is nearer the CST 1:30
+  it("resolves a repeated reading to the reference's side of the transition", function () {
+    expect(sameOffsetOccurrenceUnix(cdt130, cst130)).toBe(cst130);
+    expect(sameOffsetOccurrenceUnix(cst130, cdt130)).toBe(cdt130);
+    expect(sameOffsetOccurrenceUnix(cdt130, cst330)).toBe(cst130); // 3:30 CST is on the CST side
+  });
+
+  it('is decided by side, not distance', function () {
+    // 1:00 CST as reference, 1:30 CDT as instant: the CDT and CST 1:30s are equally far, and a
+    // nearest-instant rule would keep CDT — 30 real minutes EARLIER than the gesture.
+    const cst100 = Date.UTC(2025, 10, 2, 7, 0) / 1000;
+    expect(sameOffsetOccurrenceUnix(cdt130, cst100)).toBe(cst130);
+    expect(sameOffsetOccurrenceUnix(cst130, cst100 - 2 * 3600)).toBe(cdt130); // 11:00 PM CDT reference
   });
 
   it('keeps an instant whose reading happens once', function () {
     const ten = at(FALL_BACK_DAY, 10, 30);
-    expect(nearestOccurrenceUnix(ten, ten - 5 * 3600)).toBe(ten);
+    expect(sameOffsetOccurrenceUnix(ten, ten - 5 * 3600)).toBe(ten);
     const gapEdge = at(SPRING_FORWARD_DAY, 3, 30); // 2:30 does not exist; 3:30 happens once
-    expect(nearestOccurrenceUnix(gapEdge, gapEdge - 3600)).toBe(gapEdge);
+    expect(sameOffsetOccurrenceUnix(gapEdge, gapEdge - 3600)).toBe(gapEdge);
   });
 
-  it('keeps the instant when it is already the nearer occurrence', function () {
-    expect(nearestOccurrenceUnix(cdt130, cdt130 - 600)).toBe(cdt130);
+  it('keeps the instant when it is already on the reference side', function () {
+    expect(sameOffsetOccurrenceUnix(cdt130, cdt130 - 600)).toBe(cdt130);
   });
 });
 

--- a/app/spec/calendar-date-spec.ts
+++ b/app/spec/calendar-date-spec.ts
@@ -15,9 +15,9 @@ import {
 const d = (iso: string): CalendarDate => parseCalendarDate(iso);
 
 /** A local instant on the given date, at the given time of day */
-const at = (iso: string, hour = 0, minute = 0): number => {
+const at = (iso: string, hour = 0, minute = 0, second = 0): number => {
   const [y, m, day] = iso.split('-').map(Number);
-  return new Date(y, m - 1, day, hour, minute).getTime() / 1000;
+  return new Date(y, m - 1, day, hour, minute, second).getTime() / 1000;
 };
 
 // Literals, not round-trips: every other assertion here compares the module against itself,
@@ -152,25 +152,30 @@ describe('nextDayStartUnix', function () {
   });
 });
 
-// Host-zone reads, so these discriminate only on the pinned Chicago runner, where 2025-11-02
-// is a 25-hour day and 2026-03-08 a 23-hour one. UTC literals are used where a fixture built
-// through the Date constructor would resolve a gap or a repeat the same way the code does.
+// Host-zone reads, so these discriminate only on the pinned Chicago runner. UTC literals are
+// used where a fixture built through the Date constructor would resolve a gap or a repeat the
+// same way the code does.
+const ORDINARY_DAY = '2026-06-21';
+const FALL_BACK_DAY = '2025-11-02'; // 25 hours in Chicago
+const SPRING_FORWARD_DAY = '2026-03-08'; // 23 hours in Chicago
+const SAMPLE_DAYS = [ORDINARY_DAY, FALL_BACK_DAY, SPRING_FORWARD_DAY];
+
 describe('secondsIntoDay', function () {
   it('reads the wall clock, not elapsed time, on a transition day', function () {
-    expect(secondsIntoDay(at('2026-06-21', 10, 30))).toBe(37800);
-    expect(secondsIntoDay(at('2025-11-02', 10, 30))).toBe(37800); // 41400s after midnight
-    expect(secondsIntoDay(at('2026-03-08', 10, 30))).toBe(37800); // 34200s after midnight
+    expect(secondsIntoDay(at(ORDINARY_DAY, 10, 30))).toBe(37800);
+    expect(secondsIntoDay(at(FALL_BACK_DAY, 10, 30))).toBe(37800); // 41400s after midnight
+    expect(secondsIntoDay(at(SPRING_FORWARD_DAY, 10, 30))).toBe(37800); // 34200s after midnight
   });
 
   it('is 0 at midnight and 86399 at the last second', function () {
-    expect(secondsIntoDay(at('2026-06-21'))).toBe(0);
-    expect(secondsIntoDay(at('2026-06-21', 23, 59) + 59)).toBe(86399);
+    expect(secondsIntoDay(at(ORDINARY_DAY))).toBe(0);
+    expect(secondsIntoDay(at(ORDINARY_DAY, 23, 59, 59))).toBe(86399);
   });
 });
 
 describe('unixAtSecondsIntoDay', function () {
   it('inverts secondsIntoDay on ordinary and transition days alike', function () {
-    ['2026-06-21', '2025-11-02', '2026-03-08'].forEach((iso) => {
+    SAMPLE_DAYS.forEach((iso) => {
       expect(unixAtSecondsIntoDay(d(iso), 37800)).toBe(at(iso, 10, 30));
       expect(secondsIntoDay(unixAtSecondsIntoDay(d(iso), 37800))).toBe(37800);
     });
@@ -178,16 +183,18 @@ describe('unixAtSecondsIntoDay', function () {
 
   it('resolves a time inside the spring-forward gap forward', function () {
     // 02:30 does not exist on 2026-03-08 in Chicago; the clock goes 01:59 -> 03:00.
-    expect(unixAtSecondsIntoDay(d('2026-03-08'), 9000)).toBe(Date.UTC(2026, 2, 8, 8, 30) / 1000);
+    expect(unixAtSecondsIntoDay(d(SPRING_FORWARD_DAY), 9000)).toBe(
+      Date.UTC(2026, 2, 8, 8, 30) / 1000
+    );
   });
 
   it('picks the first occurrence of a fall-back repeated hour', function () {
     // 01:30 happens twice on 2025-11-02 in Chicago: 06:30Z (CDT) and 07:30Z (CST).
-    expect(unixAtSecondsIntoDay(d('2025-11-02'), 5400)).toBe(Date.UTC(2025, 10, 2, 6, 30) / 1000);
+    expect(unixAtSecondsIntoDay(d(FALL_BACK_DAY), 5400)).toBe(Date.UTC(2025, 10, 2, 6, 30) / 1000);
   });
 
   it('lands 86400 on the next day-start, whatever the day length', function () {
-    ['2026-06-21', '2025-11-02', '2026-03-08'].forEach((iso) => {
+    SAMPLE_DAYS.forEach((iso) => {
       expect(unixAtSecondsIntoDay(d(iso), 86400)).toBe(nextDayStartUnix(d(iso)));
     });
   });

--- a/app/spec/calendar-date-spec.ts
+++ b/app/spec/calendar-date-spec.ts
@@ -8,7 +8,7 @@ import {
   formatCalendarDate,
   parseCalendarDate,
   secondsIntoDay,
-  unixAtSecondsIntoDay,
+  secondsIntoDayUnix,
 } from '../src/calendar-date';
 
 /** Fixtures read as dates, not epoch-day integers — a failure says 2026-06-21, not 20627 */
@@ -173,29 +173,29 @@ describe('secondsIntoDay', function () {
   });
 });
 
-describe('unixAtSecondsIntoDay', function () {
+describe('secondsIntoDayUnix', function () {
   it('inverts secondsIntoDay on ordinary and transition days alike', function () {
     SAMPLE_DAYS.forEach((iso) => {
-      expect(unixAtSecondsIntoDay(d(iso), 37800)).toBe(at(iso, 10, 30));
-      expect(secondsIntoDay(unixAtSecondsIntoDay(d(iso), 37800))).toBe(37800);
+      expect(secondsIntoDayUnix(d(iso), 37800)).toBe(at(iso, 10, 30));
+      expect(secondsIntoDay(secondsIntoDayUnix(d(iso), 37800))).toBe(37800);
     });
   });
 
   it('resolves a time inside the spring-forward gap forward', function () {
     // 02:30 does not exist on 2026-03-08 in Chicago; the clock goes 01:59 -> 03:00.
-    expect(unixAtSecondsIntoDay(d(SPRING_FORWARD_DAY), 9000)).toBe(
+    expect(secondsIntoDayUnix(d(SPRING_FORWARD_DAY), 9000)).toBe(
       Date.UTC(2026, 2, 8, 8, 30) / 1000
     );
   });
 
   it('picks the first occurrence of a fall-back repeated hour', function () {
     // 01:30 happens twice on 2025-11-02 in Chicago: 06:30Z (CDT) and 07:30Z (CST).
-    expect(unixAtSecondsIntoDay(d(FALL_BACK_DAY), 5400)).toBe(Date.UTC(2025, 10, 2, 6, 30) / 1000);
+    expect(secondsIntoDayUnix(d(FALL_BACK_DAY), 5400)).toBe(Date.UTC(2025, 10, 2, 6, 30) / 1000);
   });
 
   it('lands 86400 on the next day-start, whatever the day length', function () {
     SAMPLE_DAYS.forEach((iso) => {
-      expect(unixAtSecondsIntoDay(d(iso), 86400)).toBe(nextDayStartUnix(d(iso)));
+      expect(secondsIntoDayUnix(d(iso), 86400)).toBe(nextDayStartUnix(d(iso)));
     });
   });
 });

--- a/app/spec/calendar-drag-utils-spec.ts
+++ b/app/spec/calendar-drag-utils-spec.ts
@@ -251,11 +251,22 @@ describe('updateDragState move with day snapping', function () {
       0,
       MONTH_VIEW_DRAG_CONFIG
     );
-    const dragged = updateDragState(state, mouseTime, 100, 100, containerType, MONTH_VIEW_DRAG_CONFIG);
-    return { start: dragged.previewStart, end: dragged.previewEnd, isAllDay: dragged.previewIsAllDay };
+    const dragged = updateDragState(
+      state,
+      mouseTime,
+      100,
+      100,
+      containerType,
+      MONTH_VIEW_DRAG_CONFIG
+    );
+    return {
+      start: dragged.previewStart,
+      end: dragged.previewEnd,
+      isAllDay: dragged.previewIsAllDay,
+    };
   }
 
-  it('preserves a timed event\'s clock time when moved across month cells', function () {
+  it("preserves a timed event's clock time when moved across month cells", function () {
     // 10-11am on Aug 14, dropped on Aug 20 -> 10-11am on Aug 20, still timed.
     const start = localDay(2026, 8, 14) + 10 * HOUR;
     const end = localDay(2026, 8, 14) + 11 * HOUR;
@@ -353,7 +364,11 @@ describe('updateDragState move converting all-day to timed', function () {
       DEFAULT_DRAG_CONFIG
     );
     const dragged = updateDragState(state, mouseTime, 100, 100, 'day-column', DEFAULT_DRAG_CONFIG);
-    return { start: dragged.previewStart, end: dragged.previewEnd, isAllDay: dragged.previewIsAllDay };
+    return {
+      start: dragged.previewStart,
+      end: dragged.previewEnd,
+      isAllDay: dragged.previewIsAllDay,
+    };
   }
 
   it('converts an all-day event to a timed event at the snapped drop time', function () {
@@ -491,7 +506,6 @@ describe('createDragPreviewEvent', function () {
   });
 });
 
-
 describe('allDayColumnStartUnix', function () {
   // Runner is pinned to America/Chicago (scripts/test.js), so a span across 2025-11-02 includes
   // a 25-hour fall-back day — where a `ceil(seconds/86400)` bucket count and a `start + i*86400`
@@ -513,5 +527,49 @@ describe('allDayColumnStartUnix', function () {
   it('clamps out-of-range fractions to the first and last columns', function () {
     expect(allDayColumnStartUnix(scopeStart, scopeEnd, -0.5)).toBe(dayStartUnix(firstDate));
     expect(allDayColumnStartUnix(scopeStart, scopeEnd, 1.5)).toBe(dayStartUnix(lastDate));
+  });
+});
+
+// The anchor handed to createDragState is the grid's time under the cursor, from the same
+// hit-test that later supplies every drag target, so the two share one coordinate system.
+describe('createDragState anchored on the grid', function () {
+  it('round-trips an event in the second occurrence of a repeated hour', function () {
+    // 01:00 CST on Chicago's fall-back day. The grid maps that pixel to the FIRST occurrence,
+    // 01:00 CDT, an hour earlier; the grab offset absorbs the hour, so a drop in place is a no-op.
+    const cst = Date.UTC(2025, 10, 2, 7, 0) / 1000;
+    const gridTime = cst - HOUR;
+    const state = createDragState(
+      makeOccurrence({ start: cst, end: cst + HOUR / 2 }),
+      { mode: 'move', cursor: 'grab' },
+      gridTime,
+      0,
+      0,
+      DEFAULT_DRAG_CONFIG
+    );
+    const dragged = updateDragState(state, gridTime, 100, 100, 'day-column', DEFAULT_DRAG_CONFIG);
+    expect(dragged.previewStart).toBe(cst);
+    expect(dragged.previewEnd).toBe(cst + HOUR / 2);
+  });
+
+  it('moves by exactly the cursor delta, wherever in the event it was grabbed', function () {
+    const start = Date.UTC(2026, 5, 9, 15, 0) / 1000; // 10:00 CDT
+    const grabbed = start + HOUR / 4; // a quarter of the way down the box
+    const state = createDragState(
+      makeOccurrence({ start, end: start + HOUR }),
+      { mode: 'move', cursor: 'grab' },
+      grabbed,
+      0,
+      0,
+      DEFAULT_DRAG_CONFIG
+    );
+    const dragged = updateDragState(
+      state,
+      grabbed + HOUR,
+      100,
+      100,
+      'day-column',
+      DEFAULT_DRAG_CONFIG
+    );
+    expect(dragged.previewStart).toBe(start + HOUR);
   });
 });

--- a/app/spec/calendar-drag-utils-spec.ts
+++ b/app/spec/calendar-drag-utils-spec.ts
@@ -573,6 +573,27 @@ describe('createDragState anchored on the grid', function () {
     expect(dragged.previewStart).toBe(cst + HOUR);
   });
 
+  it('moves a second-occurrence event later by 30 and 45 minutes within the repeated hour', function () {
+    // The grid hands back the first occurrence for every pixel in the hour; a nearest-instant
+    // rule ties at 30 minutes and lands on CDT, 30 real minutes earlier than the drag.
+    const cst = Date.UTC(2025, 10, 2, 7, 0) / 1000;
+    const state = createDragState(
+      makeOccurrence({ start: cst, end: cst + HOUR / 2 }),
+      { mode: 'move', cursor: 'grab' },
+      cst - HOUR, // grabbed at the top row: the grid says 01:00 CDT
+      0,
+      0,
+      DEFAULT_DRAG_CONFIG
+    );
+    const gridAt = (minutes: number) => cst - HOUR + minutes * 60; // still CDT readings
+    expect(
+      updateDragState(state, gridAt(30), 100, 100, 'day-column', DEFAULT_DRAG_CONFIG).previewStart
+    ).toBe(cst + 30 * 60);
+    expect(
+      updateDragState(state, gridAt(45), 100, 100, 'day-column', DEFAULT_DRAG_CONFIG).previewStart
+    ).toBe(cst + 45 * 60);
+  });
+
   it('lands an event dragged into the repeated hour on its own side of the transition', function () {
     // 03:00 CST dragged up two rows to the 01:00 line: the grid says 01:00 CDT, the event says CST.
     const cst3 = Date.UTC(2025, 10, 2, 9, 0) / 1000;
@@ -611,6 +632,37 @@ describe('createDragState anchored on the grid', function () {
     const dragged = updateDragState(state, start, 100, 100, 'day-column', DEFAULT_DRAG_CONFIG);
     expect(dragged.previewEnd).toBe(end);
     expect(dragged.previewStart).toBe(start);
+  });
+
+  it('shrinks from the top to the minimum duration and no further', function () {
+    const start = Date.UTC(2026, 5, 9, 15, 0) / 1000; // 10:00 CDT
+    const state = createDragState(
+      makeOccurrence({ start, end: start + HOUR }),
+      { mode: 'resize-start', cursor: 'ns-resize' },
+      start,
+      0,
+      0,
+      DEFAULT_DRAG_CONFIG
+    );
+    const past = updateDragState(
+      state,
+      start + 2 * HOUR,
+      100,
+      100,
+      'day-column',
+      DEFAULT_DRAG_CONFIG
+    );
+    expect(past.previewEnd).toBe(start + HOUR);
+    expect(past.previewStart).toBe(start + HOUR - DEFAULT_DRAG_CONFIG.minDuration);
+    const half = updateDragState(
+      state,
+      start + HOUR / 2,
+      100,
+      100,
+      'day-column',
+      DEFAULT_DRAG_CONFIG
+    );
+    expect(half.previewStart).toBe(start + HOUR / 2);
   });
 
   it('moves by exactly the cursor delta, wherever in the event it was grabbed', function () {

--- a/app/spec/calendar-drag-utils-spec.ts
+++ b/app/spec/calendar-drag-utils-spec.ts
@@ -551,6 +551,68 @@ describe('createDragState anchored on the grid', function () {
     expect(dragged.previewEnd).toBe(cst + HOUR / 2);
   });
 
+  it('moves a second-occurrence event one hour when dragged one row out of the repeated hour', function () {
+    // Grabbed at the grid's 01:30 (first occurrence) and released at 02:30, which happens once.
+    const cst = Date.UTC(2025, 10, 2, 7, 0) / 1000;
+    const state = createDragState(
+      makeOccurrence({ start: cst, end: cst + HOUR }),
+      { mode: 'move', cursor: 'grab' },
+      cst - HOUR / 2,
+      0,
+      0,
+      DEFAULT_DRAG_CONFIG
+    );
+    const dragged = updateDragState(
+      state,
+      cst + HOUR + HOUR / 2,
+      100,
+      100,
+      'day-column',
+      DEFAULT_DRAG_CONFIG
+    );
+    expect(dragged.previewStart).toBe(cst + HOUR);
+  });
+
+  it('lands an event dragged into the repeated hour on its own side of the transition', function () {
+    // 03:00 CST dragged up two rows to the 01:00 line: the grid says 01:00 CDT, the event says CST.
+    const cst3 = Date.UTC(2025, 10, 2, 9, 0) / 1000;
+    const state = createDragState(
+      makeOccurrence({ start: cst3, end: cst3 + HOUR }),
+      { mode: 'move', cursor: 'grab' },
+      cst3 + HOUR / 2,
+      0,
+      0,
+      DEFAULT_DRAG_CONFIG
+    );
+    const gridOneThirtyCdt = Date.UTC(2025, 10, 2, 6, 30) / 1000;
+    const dragged = updateDragState(
+      state,
+      gridOneThirtyCdt,
+      100,
+      100,
+      'day-column',
+      DEFAULT_DRAG_CONFIG
+    );
+    expect(dragged.previewStart).toBe(Date.UTC(2025, 10, 2, 7, 0) / 1000);
+  });
+
+  it('keeps an end inside the second occurrence when its edge is grabbed and released in place', function () {
+    // 01:30 CDT to 01:30 CST: the grid reads the end's pixel as 01:30 CDT, an hour before it.
+    const start = Date.UTC(2025, 10, 2, 6, 30) / 1000;
+    const end = start + HOUR;
+    const state = createDragState(
+      makeOccurrence({ start, end }),
+      { mode: 'resize-end', cursor: 'ns-resize' },
+      start,
+      0,
+      0,
+      DEFAULT_DRAG_CONFIG
+    );
+    const dragged = updateDragState(state, start, 100, 100, 'day-column', DEFAULT_DRAG_CONFIG);
+    expect(dragged.previewEnd).toBe(end);
+    expect(dragged.previewStart).toBe(start);
+  });
+
   it('moves by exactly the cursor delta, wherever in the event it was grabbed', function () {
     const start = Date.UTC(2026, 5, 9, 15, 0) / 1000; // 10:00 CDT
     const grabbed = start + HOUR / 4; // a quarter of the way down the box

--- a/app/spec/calendar-event-spec.ts
+++ b/app/spec/calendar-event-spec.ts
@@ -61,7 +61,8 @@ function allDayDimensions(startISO: string, endISO: string) {
 }
 
 // A day column's scope: its own start, and the next day's start as the exclusive end, as
-// `exclusiveDayEnds` supplies them. Chicago runner, so 2025-11-02 is 25 hours long.
+// `exclusiveDayEnds` supplies them. Chicago runner, so 2025-11-02 is 25 hours long and
+// 2026-03-08 is 23.
 function timedDimensions(startISO: string, endISO: string, dayISO: string, nextDayISO: string) {
   const event = {
     ...OCCURRENCE_META,
@@ -73,6 +74,9 @@ function timedDimensions(startISO: string, endISO: string, dayISO: string, nextD
   } as TimedOccurrence;
   return dimensions(event, 'vertical', moment(dayISO).unix(), moment(nextDayISO).unix());
 }
+
+/** Percent of the column a wall-clock hour is at: the gridline the legend labels with it. */
+const hourLine = (hours: number) => (hours / 24) * 100;
 
 describe('CalendarEvent all-day dimensions', function () {
   it('sizes a fully-visible multi-day span by its covered days', function () {
@@ -91,31 +95,65 @@ describe('CalendarEvent all-day dimensions', function () {
   });
 });
 
+// The legend, gridlines and now-line divide every column into 24 equal hours, so an event has
+// to sit on the line its own label names. Elapsed-seconds positioning drifts off it by up to an
+// hour on a transition day (and once put a 23:30 event at 102%, clipped away by
+// `.event-column { overflow: hidden }`).
 describe('CalendarEvent timed dimensions across DST', function () {
-  it('keeps a late event on a 25-hour day inside its column', function () {
-    // Against a hardcoded 86399s scope a 23:30 event computes top 102%, which
-    // `.event-column { overflow: hidden }` clips away entirely.
+  it('keeps a late event on a 25-hour day on its own gridline', function () {
     const { topPct, heightPct } = timedDimensions(
       '2025-11-02 23:30',
       '2025-11-02 23:45',
       '2025-11-02',
       '2025-11-03'
     );
-    expect(topPct).toBeCloseTo((88200 / 90000) * 100, 4);
-    expect(topPct + heightPct).toBeLessThan(100.0001);
+    expect(topPct).toBeCloseTo(hourLine(23.5), 4);
+    expect(topPct + heightPct).toBeCloseTo(hourLine(23.75), 4);
   });
 
-  it('sizes an event against the real length of a 23-hour day', function () {
-    // Proportional to elapsed seconds, which is NOT the wall-clock hour gridline: the
-    // legend and now-line divide the column into 24 equal hours, so on a transition day a
-    // 10:00 event draws ~37 min off its own "10 AM" line. Pre-existing and improved here
-    // (it was a full hour), not fixed — see the backlog's elapsed-vs-wall-clock item.
+  it('draws a 10:00 event on the 10 AM line of a 23-hour day', function () {
+    // Elapsed seconds would put it at 32400/82800 = 39.1%, 37 minutes above the line.
     const { topPct } = timedDimensions(
       '2026-03-08 10:00',
       '2026-03-08 11:00',
       '2026-03-08',
       '2026-03-09'
     );
-    expect(topPct).toBeCloseTo((32400 / 82800) * 100, 4);
+    expect(topPct).toBeCloseTo(hourLine(10), 4);
+  });
+
+  it('spans the hours its label names across a spring-forward gap', function () {
+    // 01:30-03:30 lasts one real hour; the grid still has a 2 AM row, so it draws two tall.
+    const { topPct, heightPct } = timedDimensions(
+      '2026-03-08 01:30',
+      '2026-03-08 03:30',
+      '2026-03-08',
+      '2026-03-09'
+    );
+    expect(topPct).toBeCloseTo(hourLine(1.5), 4);
+    expect(heightPct).toBeCloseTo(hourLine(2), 4);
+  });
+
+  it('reaches the column bottom when it ends at the next midnight', function () {
+    // The end instant's own wall clock reads 00:00; the exclusive scope end is what makes it 100%.
+    const { topPct, heightPct } = timedDimensions(
+      '2025-11-02 22:00',
+      '2025-11-03 00:00',
+      '2025-11-02',
+      '2025-11-03'
+    );
+    expect(topPct).toBeCloseTo(hourLine(22), 4);
+    expect(topPct + heightPct).toBeCloseTo(100, 4);
+  });
+
+  it('clips to the column top when it began the day before', function () {
+    const { topPct, heightPct } = timedDimensions(
+      '2025-11-01 22:00',
+      '2025-11-02 03:00',
+      '2025-11-02',
+      '2025-11-03'
+    );
+    expect(topPct).toBe(0);
+    expect(heightPct).toBeCloseTo(hourLine(3), 4);
   });
 });

--- a/app/spec/calendar-event-spec.ts
+++ b/app/spec/calendar-event-spec.ts
@@ -63,13 +63,15 @@ function allDayDimensions(startISO: string, endISO: string) {
 // A day column's scope: its own start, and the next day's start as the exclusive end, as
 // `exclusiveDayEnds` supplies them. Chicago runner, so 2025-11-02 is 25 hours long and
 // 2026-03-08 is 23.
-function timedDimensions(startISO: string, endISO: string, dayISO: string) {
+// Times are local ISO strings, or unix seconds where the clock reading is ambiguous.
+function timedDimensions(start: string | number, end: string | number, dayISO: string) {
   const day = parseCalendarDate(dayISO);
+  const unix = (t: string | number) => (typeof t === 'number' ? t : moment(t).unix());
   const event = {
     ...OCCURRENCE_META,
     isAllDay: false,
-    start: moment(startISO).unix(),
-    end: moment(endISO).unix(),
+    start: unix(start),
+    end: unix(end),
     startDate: day,
     endDate: day,
   } as TimedOccurrence;
@@ -130,6 +132,17 @@ describe('CalendarEvent timed dimensions across DST', function () {
     );
     expect(topPct).toBeCloseTo(hourLine(1.5), 4);
     expect(heightPct).toBeCloseTo(hourLine(2), 4);
+  });
+
+  it('draws its real duration when its end reads no later than its start', function () {
+    // 01:30 CDT to 01:30 CST is one real hour whose two ends read the same on the clock.
+    const { topPct, heightPct } = timedDimensions(
+      Date.UTC(2025, 10, 2, 6, 30) / 1000,
+      Date.UTC(2025, 10, 2, 7, 30) / 1000,
+      '2025-11-02'
+    );
+    expect(topPct).toBeCloseTo(hourLine(1.5), 4);
+    expect(heightPct).toBeCloseTo(hourLine(1), 4);
   });
 
   it('reaches the column bottom when it ends at the next midnight', function () {

--- a/app/spec/calendar-event-spec.ts
+++ b/app/spec/calendar-event-spec.ts
@@ -63,20 +63,28 @@ function allDayDimensions(startISO: string, endISO: string) {
 // A day column's scope: its own start, and the next day's start as the exclusive end, as
 // `exclusiveDayEnds` supplies them. Chicago runner, so 2025-11-02 is 25 hours long and
 // 2026-03-08 is 23.
-function timedDimensions(startISO: string, endISO: string, dayISO: string, nextDayISO: string) {
+function timedDimensions(startISO: string, endISO: string, dayISO: string) {
+  const day = parseCalendarDate(dayISO);
   const event = {
     ...OCCURRENCE_META,
     isAllDay: false,
     start: moment(startISO).unix(),
     end: moment(endISO).unix(),
-    startDate: parseCalendarDate(dayISO),
-    endDate: parseCalendarDate(dayISO),
+    startDate: day,
+    endDate: day,
   } as TimedOccurrence;
-  return dimensions(event, 'vertical', moment(dayISO).unix(), moment(nextDayISO).unix());
+  return dimensions(
+    event,
+    'vertical',
+    CalendarDateUtils.dayStartUnix(day),
+    CalendarDateUtils.nextDayStartUnix(day)
+  );
 }
 
 /** Percent of the column a wall-clock hour is at: the gridline the legend labels with it. */
-const hourLine = (hours: number) => (hours / 24) * 100;
+function hourLine(hours: number) {
+  return (hours / 24) * 100;
+}
 
 describe('CalendarEvent all-day dimensions', function () {
   it('sizes a fully-visible multi-day span by its covered days', function () {
@@ -96,29 +104,20 @@ describe('CalendarEvent all-day dimensions', function () {
 });
 
 // The legend, gridlines and now-line divide every column into 24 equal hours, so an event has
-// to sit on the line its own label names. Elapsed-seconds positioning drifts off it by up to an
-// hour on a transition day (and once put a 23:30 event at 102%, clipped away by
-// `.event-column { overflow: hidden }`).
+// to sit on the line its own label names; elapsed seconds drift off it by up to an hour.
 describe('CalendarEvent timed dimensions across DST', function () {
   it('keeps a late event on a 25-hour day on its own gridline', function () {
     const { topPct, heightPct } = timedDimensions(
       '2025-11-02 23:30',
       '2025-11-02 23:45',
-      '2025-11-02',
-      '2025-11-03'
+      '2025-11-02'
     );
     expect(topPct).toBeCloseTo(hourLine(23.5), 4);
     expect(topPct + heightPct).toBeCloseTo(hourLine(23.75), 4);
   });
 
   it('draws a 10:00 event on the 10 AM line of a 23-hour day', function () {
-    // Elapsed seconds would put it at 32400/82800 = 39.1%, 37 minutes above the line.
-    const { topPct } = timedDimensions(
-      '2026-03-08 10:00',
-      '2026-03-08 11:00',
-      '2026-03-08',
-      '2026-03-09'
-    );
+    const { topPct } = timedDimensions('2026-03-08 10:00', '2026-03-08 11:00', '2026-03-08');
     expect(topPct).toBeCloseTo(hourLine(10), 4);
   });
 
@@ -127,8 +126,7 @@ describe('CalendarEvent timed dimensions across DST', function () {
     const { topPct, heightPct } = timedDimensions(
       '2026-03-08 01:30',
       '2026-03-08 03:30',
-      '2026-03-08',
-      '2026-03-09'
+      '2026-03-08'
     );
     expect(topPct).toBeCloseTo(hourLine(1.5), 4);
     expect(heightPct).toBeCloseTo(hourLine(2), 4);
@@ -139,8 +137,7 @@ describe('CalendarEvent timed dimensions across DST', function () {
     const { topPct, heightPct } = timedDimensions(
       '2025-11-02 22:00',
       '2025-11-03 00:00',
-      '2025-11-02',
-      '2025-11-03'
+      '2025-11-02'
     );
     expect(topPct).toBeCloseTo(hourLine(22), 4);
     expect(topPct + heightPct).toBeCloseTo(100, 4);
@@ -150,8 +147,7 @@ describe('CalendarEvent timed dimensions across DST', function () {
     const { topPct, heightPct } = timedDimensions(
       '2025-11-01 22:00',
       '2025-11-02 03:00',
-      '2025-11-02',
-      '2025-11-03'
+      '2025-11-02'
     );
     expect(topPct).toBe(0);
     expect(heightPct).toBeCloseTo(hourLine(3), 4);

--- a/app/spec/week-view-helpers-spec.ts
+++ b/app/spec/week-view-helpers-spec.ts
@@ -1,5 +1,6 @@
 // Import directly from the source file; the plugin isn't registered in mailspring-exports.
 import {
+  columnSpan,
   eventsGroupedByDay,
   exclusiveDayEnds,
   overlapForEvents,
@@ -188,5 +189,20 @@ describe('overlapForEvents in a day column', function () {
       [2, 1],
       [2, 2],
     ]);
+  });
+});
+
+describe('columnSpan', function () {
+  const column = { start: at('2026-06-10').unix(), end: at('2026-06-11').unix() };
+
+  it('never returns a bottom above its top, even for an end before its start', function () {
+    const backwards = makeOccurrence(at('2026-06-10 11:00').unix(), at('2026-06-10 10:00').unix());
+    const { top, bottom } = columnSpan(backwards as any, column);
+    expect(bottom).toBe(top);
+  });
+
+  it('caps the bottom at the column end', function () {
+    const span = columnSpan(timedEvent('2026-06-10 23:30', '2026-06-11 00:30') as any, column);
+    expect(span.bottom).toBe(86400);
   });
 });

--- a/app/spec/week-view-helpers-spec.ts
+++ b/app/spec/week-view-helpers-spec.ts
@@ -2,6 +2,7 @@
 import {
   eventsGroupedByDay,
   exclusiveDayEnds,
+  overlapForEvents,
 } from '../internal_packages/main-calendar/lib/core/week-view-helpers';
 import {
   EventOccurrence,
@@ -148,5 +149,44 @@ describe('exclusiveDayEnds', function () {
   it('resolves the final day, which has no successor', function () {
     const days = daysFrom('2026-06-08', 3);
     expect(exclusiveDayEnds(days)[2]).toBe(at('2026-06-11').unix());
+  });
+});
+
+describe('overlapForEvents in a day column', function () {
+  const column = { start: at('2025-11-02').unix(), end: at('2025-11-03').unix() };
+  const utc = (h: number, m: number) => Date.UTC(2025, 10, 2, h, m) / 1000;
+  const stacking = (events: EventOccurrence[]) =>
+    events.map((e) => {
+      const o = overlapForEvents(events, column)[e.id];
+      return [o.concurrentEvents, o.order];
+    });
+
+  it('stacks the two occurrences of a fall-back repeated hour side by side', function () {
+    // Both read 01:30-02:30 on the clock: CDT is 06:30Z, CST an hour later. By instant they
+    // are sequential; on the grid they share a slot.
+    const first = { ...makeOccurrence(utc(6, 30), utc(7, 30)), id: 'cdt' };
+    const second = { ...makeOccurrence(utc(7, 30), utc(8, 30)), id: 'cst' };
+    expect(stacking([first, second])).toEqual([
+      [2, 1],
+      [2, 2],
+    ]);
+  });
+
+  it('keeps events in consecutive slots apart', function () {
+    const ten = { ...timedEvent('2025-11-02 10:00', '2025-11-02 11:00'), id: 'ten' };
+    const eleven = { ...timedEvent('2025-11-02 11:00', '2025-11-02 12:00'), id: 'eleven' };
+    expect(stacking([ten, eleven])).toEqual([
+      [1, 1],
+      [1, 1],
+    ]);
+  });
+
+  it('treats an event carried over from the previous day as filling the top rows', function () {
+    const carried = { ...timedEvent('2025-11-01 22:00', '2025-11-02 03:00'), id: 'carried' };
+    const early = { ...timedEvent('2025-11-02 00:30', '2025-11-02 01:00'), id: 'early' };
+    expect(stacking([carried, early])).toEqual([
+      [2, 1],
+      [2, 2],
+    ]);
   });
 });

--- a/app/spec/week-view-helpers-spec.ts
+++ b/app/spec/week-view-helpers-spec.ts
@@ -182,6 +182,15 @@ describe('overlapForEvents in a day column', function () {
     ]);
   });
 
+  it('sweeps timed events by covered dates when no column is given', function () {
+    // Without rows to place them in, two events on the same day overlap as that day does.
+    const ten = { ...timedEvent('2025-11-02 10:00', '2025-11-02 11:00'), id: 'ten' };
+    const four = { ...timedEvent('2025-11-02 16:00', '2025-11-02 17:00'), id: 'four' };
+    const overlap = overlapForEvents([ten, four]);
+    expect(overlap.ten.concurrentEvents).toBe(2);
+    expect(overlap.four.concurrentEvents).toBe(2);
+  });
+
   it('treats an event carried over from the previous day as filling the top rows', function () {
     const carried = { ...timedEvent('2025-11-01 22:00', '2025-11-02 03:00'), id: 'carried' };
     const early = { ...timedEvent('2025-11-02 00:30', '2025-11-02 01:00'), id: 'early' };

--- a/app/src/calendar-date.ts
+++ b/app/src/calendar-date.ts
@@ -95,6 +95,34 @@ export function secondsIntoDayUnix(date: CalendarDate, seconds: number): number 
 }
 
 /**
+ * The first instant on this instant's date with its clock reading — the instant a wall-clock
+ * grid maps that reading to. Only differs from the instant inside the second occurrence of a
+ * fall-back repeated hour, where it is an hour earlier.
+ */
+export function firstOccurrenceUnix(unixSeconds: number): number {
+  return secondsIntoDayUnix(calendarDateFromUnix(unixSeconds), secondsIntoDay(unixSeconds));
+}
+
+/**
+ * `instant`, or the other instant an hour away with the same clock reading (a fall-back repeated
+ * hour) when that one is nearer to `reference`. Lets a clock reading that names two instants
+ * resolve toward the one an event already had.
+ */
+export function nearestOccurrenceUnix(instant: number, reference: number): number {
+  const reading = secondsIntoDay(instant);
+  let nearest = instant;
+  for (const alt of [instant - 3600, instant + 3600]) {
+    if (
+      secondsIntoDay(alt) === reading &&
+      Math.abs(alt - reference) < Math.abs(nearest - reference)
+    ) {
+      nearest = alt;
+    }
+  }
+  return nearest;
+}
+
+/**
  * The start of the date `days` after the one this instant falls on.
  *
  * A migration bridge for callers that still hold instants. It goes away as they move to

--- a/app/src/calendar-date.ts
+++ b/app/src/calendar-date.ts
@@ -72,6 +72,29 @@ export function nextDayStartUnix(date: CalendarDate): number {
 }
 
 /**
+ * Wall-clock seconds since the local midnight of the date an instant falls on: 10:30 is 37800
+ * on a 23- or 25-hour day too. Not `unix - dayStartUnix(date)`, which is elapsed time and sits
+ * an hour off the clock after a DST transition.
+ */
+export function secondsIntoDay(unixSeconds: number): number {
+  const d = new Date(unixSeconds * 1000);
+  return d.getHours() * 3600 + d.getMinutes() * 60 + d.getSeconds();
+}
+
+/**
+ * The instant at a wall-clock offset into a date, in the local zone. The inverse of
+ * `secondsIntoDay` wherever the clock reading exists once; a time inside a spring-forward gap
+ * resolves forward, and a time the fall-back repeats resolves to its first occurrence.
+ */
+export function unixAtSecondsIntoDay(date: CalendarDate, seconds: number): number {
+  const utc = new Date(date * MS_PER_DAY);
+  return (
+    new Date(utc.getUTCFullYear(), utc.getUTCMonth(), utc.getUTCDate(), 0, 0, seconds).getTime() /
+    1000
+  );
+}
+
+/**
  * The start of the date `days` after the one this instant falls on.
  *
  * A migration bridge for callers that still hold instants. It goes away as they move to

--- a/app/src/calendar-date.ts
+++ b/app/src/calendar-date.ts
@@ -104,22 +104,24 @@ export function firstOccurrenceUnix(unixSeconds: number): number {
 }
 
 /**
- * `instant`, or the other instant an hour away with the same clock reading (a fall-back repeated
- * hour) when that one is nearer to `reference`. Lets a clock reading that names two instants
- * resolve toward the one an event already had.
+ * `instant`, or the other instant with the same clock reading on the reference's side of a
+ * fall-back transition — the one sharing its UTC offset. A repeated reading names two instants;
+ * this picks the one a gesture relative to `reference` means. Candidates half an hour away
+ * cover zones whose DST shift is 30 minutes (Lord Howe Island).
  */
-export function nearestOccurrenceUnix(instant: number, reference: number): number {
+export function sameOffsetOccurrenceUnix(instant: number, reference: number): number {
   const reading = secondsIntoDay(instant);
-  let nearest = instant;
-  for (const alt of [instant - 3600, instant + 3600]) {
-    if (
-      secondsIntoDay(alt) === reading &&
-      Math.abs(alt - reference) < Math.abs(nearest - reference)
-    ) {
-      nearest = alt;
+  const offset = new Date(reference * 1000).getTimezoneOffset();
+  if (new Date(instant * 1000).getTimezoneOffset() === offset) {
+    return instant;
+  }
+  for (const delta of [-3600, -1800, 1800, 3600]) {
+    const alt = instant + delta;
+    if (secondsIntoDay(alt) === reading && new Date(alt * 1000).getTimezoneOffset() === offset) {
+      return alt;
     }
   }
-  return nearest;
+  return instant;
 }
 
 /**

--- a/app/src/calendar-date.ts
+++ b/app/src/calendar-date.ts
@@ -86,7 +86,7 @@ export function secondsIntoDay(unixSeconds: number): number {
  * `secondsIntoDay` wherever the clock reading exists once; a time inside a spring-forward gap
  * resolves forward, and a time the fall-back repeats resolves to its first occurrence.
  */
-export function unixAtSecondsIntoDay(date: CalendarDate, seconds: number): number {
+export function secondsIntoDayUnix(date: CalendarDate, seconds: number): number {
   const utc = new Date(date * MS_PER_DAY);
   return (
     new Date(utc.getUTCFullYear(), utc.getUTCMonth(), utc.getUTCDate(), 0, 0, seconds).getTime() /


### PR DESCRIPTION
The day/week grid's legend, gridlines and now-line divide every column into 24 equal hours, but event layout and the click-to-time mapping used elapsed seconds over the column's real length. On a 23- or 25-hour day the two disagree by up to an hour: an event box sat ~30 minutes off the hour line its label named, and double-clicking on the 10 AM line opened the new-event popover at 9:30.

Layout and hit-testing now read the wall clock. `secondsIntoDay` gives an instant's clock offset (10:30 is 37800 on any day) and `secondsIntoDayUnix` builds the instant at a clock offset on a date; `_getDimensions`, the day-column hit-test, `centerGridScroll` and `CurrentTimeIndicator` all go through them, so the grid has a single coordinate system.

`columnSpan` gives a timed event's rows within one day column, and both layout and the day-column overlap sweep read it, so stacking and drawing cannot disagree. On a fall-back day that puts the two occurrences of the repeated hour side by side, as Apple Calendar does, instead of one hiding the other. An event whose end reads no later than its start on the clock (1:30 CDT to 1:30 CST) is drawn at its real duration rather than at zero height.

Dragging is anchored on the grid rather than on the event's own box: the event's mousedown bubbles to the container, whose hit-test supplies the time under the cursor, so the grab offset and every drop target share one mapping. That fixes the jump when a multi-day event was grabbed in a later column (its box is clipped there, so a box-relative time was hours off), and it makes a repeated-hour event safe to drag: the offset is measured against the grid's reading of the event's start, and a computed start or end whose clock reading happens twice is resolved to the occurrence on the same side of the transition as the event's original (by UTC offset), so a drop in place is a no-op, a one-row move is one hour, and a 30-minute move is 30 minutes. The drag threshold now compares container-frame coordinates on both sides; it used to mix the viewport frame at mousedown with the container frame on move and engage on the first pixel.

Verified in the app on 2025-11-02 and 2026-11-01: a 10:00 event sits at 41.67% on both transition days, double-clicking the 10 AM line opens the popover at 10:00, two 1:00 events in the repeated hour split the column, and with real input events an event at 1:00 CST dropped in place keeps its stored 07:00Z, moves one hour per row, and returns to the CST side when dragged back onto the 1:00 line from 3:00. The DST layout, sweep, drag and calendar-date specs all go red when the helpers are mutated back to elapsed arithmetic, the sweep back to instants, or either occurrence helper to the identity.

Deferred: a zone suffix on time labels inside a repeated hour, since both boxes currently read "1:00"; and two sub-hour edge gestures on events that themselves cross the fall-back transition (shrinking such an event's end to its own start line yields a valid 60-minute event drawn to the next line, and an event drawn at its real duration has its bottom edge anchored an hour off), which need edges anchored on their drawn geometry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
