### PR TITLE
Make "Refresh Calendars" actually sync calendars

### DIFF
--- a/app/internal_packages/main-calendar/lib/core/mailspring-calendar.tsx
+++ b/app/internal_packages/main-calendar/lib/core/mailspring-calendar.tsx
@@ -1,5 +1,6 @@
 import moment, { Moment } from 'moment';
 import React from 'react';
+import { ipcRenderer } from 'electron';
 import {
   Rx,
   DatabaseStore,
@@ -870,11 +871,8 @@ export class MailspringCalendar extends React.Component<
     AppEnv.config.set(CALENDAR_LIST_VISIBLE, visible);
   };
 
-  /**
-   * Refresh calendars by triggering a sync.
-   */
   _onRefreshCalendars = () => {
-    AppEnv.mailsyncBridge.sendSyncMailNow();
+    ipcRenderer.send('command', 'application:sync-calendar');
   };
 
   _shouldShowEmptyState() {

--- a/app/src/browser/application.ts
+++ b/app/src/browser/application.ts
@@ -434,10 +434,13 @@ export default class Application extends EventEmitter {
 
     this.on('application:show-calendar', () => {
       this.windowManager.ensureWindow(WindowManager.CALENDAR_WINDOW, {});
-      const main = this.windowManager.get(WindowManager.MAIN_WINDOW);
-      if (main) {
-        main.sendMessage('run-calendar-sync');
-      }
+      this.sendCalendarSync();
+    });
+
+    // The calendar window's MailsyncBridge has no sync clients, so a manual
+    // refresh has to be routed through the main window's bridge.
+    this.on('application:sync-calendar', () => {
+      this.sendCalendarSync();
     });
 
     this.on('application:show-contacts', () => {
@@ -890,6 +893,13 @@ export default class Application extends EventEmitter {
 
     registerQuickpreviewIPCHandlers(ipcMain);
     registerNotificationIPCHandlers(ipcMain);
+  }
+
+  sendCalendarSync() {
+    const main = this.windowManager.get(WindowManager.MAIN_WINDOW);
+    if (main) {
+      main.sendMessage('run-calendar-sync');
+    }
   }
 
   // Public: Executes the given command.


### PR DESCRIPTION
The Refresh Calendars menu command (⌘⇧R) never synced calendars.

`_onRefreshCalendars` called `AppEnv.mailsyncBridge.sendSyncMailNow()`, which is wrong twice over:

1. It sends `wake-workers` — a **mail** sync, not a calendar one.
2. It is a no-op regardless. `MailsyncBridge`'s constructor returns early for non-main windows, so the calendar window's bridge has an empty `_clients` map and sends nothing at all.

Confirmed in `mailsync-cfcd9cd5.log`: a refresh produced only "Syncing folder list...".

The working path already existed but had exactly one trigger. `application:show-calendar` asks the main window's bridge to send `{type: 'sync-calendar'}` to every client, so **opening the calendar window was the only thing that ever synced it** — which is why a newly-created Google event could sit there for 18 minutes with the refresh command doing nothing.

## Change

Extract that main-window hop into `Application#sendCalendarSync()` and give the refresh command its own entry point through it, as `application:sync-calendar`. `application:show-calendar` now calls the same helper, so there is one definition of "ask the main window to sync calendars" instead of two.

The renderer side dispatches with `ipcRenderer.send('command', 'application:sync-calendar')` — the same route the other `application:*` commands use from non-main windows.

## Testing

- `npm test` — 1746 specs passing.
- `tsc --noEmit` clean.
- Verified by hand in the dev app: ⌘⇧R in the calendar window now triggers a real calendar sync.

No spec added — the behavior is entirely main-process IPC wiring with no existing harness, so a test would have to mock `windowManager` and would assert the wiring rather than the bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)