### PR TITLE
Stop rebuilding the whole calendar view whenever the selection changes

### DIFF
--- a/app/internal_packages/main-calendar/lib/calendar-menu-commands.tsx
+++ b/app/internal_packages/main-calendar/lib/calendar-menu-commands.tsx
@@ -32,12 +32,9 @@ export class CalendarMenuCommands extends React.Component<CalendarMenuCommandsPr
       commands['core:delete-item'] = this.props.onDeleteEvent;
     }
 
-    const key = `calendar-menu-${this.props.hasSelectedEvents}`;
-
-    return (
-      <BindGlobalCommands key={key} commands={commands}>
-        {this.props.children}
-      </BindGlobalCommands>
-    );
+    // No `key` here on purpose: this wraps the whole calendar view, so a key that changes
+    // with the selection makes React rebuild the entire grid on every click.
+    // BindGlobalCommands re-registers when the set of command names changes.
+    return <BindGlobalCommands commands={commands}>{this.props.children}</BindGlobalCommands>;
   }
 }

--- a/app/spec/bind-global-commands-spec.tsx
+++ b/app/spec/bind-global-commands-spec.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { render, cleanup } from '@testing-library/react';
+
+import BindGlobalCommands from '../src/components/bind-global-commands';
+
+// The registry attaches listeners to document.body and dispatch() fires a bubbling event from
+// document.activeElement, so these exercise the real registration rather than a stub.
+describe('BindGlobalCommands', function () {
+  afterEach(cleanup);
+
+  const mount = (commands: { [name: string]: () => void }) =>
+    render(
+      <BindGlobalCommands commands={commands}>
+        <div />
+      </BindGlobalCommands>
+    );
+
+  const remount = (rerender, commands: { [name: string]: () => void }) =>
+    rerender(
+      <BindGlobalCommands commands={commands}>
+        <div />
+      </BindGlobalCommands>
+    );
+
+  it('runs the handler registered on mount', function () {
+    const alpha = jasmine.createSpy('alpha');
+    mount({ 'test:alpha': alpha });
+
+    AppEnv.commands.dispatch('test:alpha');
+
+    expect(alpha.calls.length).toBe(1);
+  });
+
+  it('runs the current handler after a re-render replaces the closures', function () {
+    // The calendar rebuilds its commands object on every render, so the handler bound at
+    // mount is stale immediately. Keeping it bound is what the removed `key` was hiding.
+    const first = jasmine.createSpy('first');
+    const second = jasmine.createSpy('second');
+    const { rerender } = mount({ 'test:alpha': first });
+
+    remount(rerender, { 'test:alpha': second });
+    AppEnv.commands.dispatch('test:alpha');
+
+    expect(second.calls.length).toBe(1);
+    expect(first.calls.length).toBe(0);
+  });
+
+  it('picks up a command added after mount', function () {
+    const beta = jasmine.createSpy('beta');
+    const { rerender } = mount({ 'test:alpha': () => {} });
+
+    remount(rerender, { 'test:alpha': () => {}, 'test:beta': beta });
+    AppEnv.commands.dispatch('test:beta');
+
+    expect(beta.calls.length).toBe(1);
+  });
+
+  it('drops a command removed after mount', function () {
+    const beta = jasmine.createSpy('beta');
+    const { rerender } = mount({ 'test:alpha': () => {}, 'test:beta': beta });
+
+    remount(rerender, { 'test:alpha': () => {} });
+    AppEnv.commands.dispatch('test:beta');
+
+    expect(beta.calls.length).toBe(0);
+  });
+
+  it('runs a handler once per dispatch however many times it re-renders', function () {
+    // Re-binding without disposing first would stack duplicate listeners on document.body.
+    const alpha = jasmine.createSpy('alpha');
+    const { rerender } = mount({ 'test:alpha': alpha });
+
+    remount(rerender, { 'test:alpha': alpha });
+    remount(rerender, { 'test:alpha': alpha });
+    remount(rerender, { 'test:alpha': alpha });
+    AppEnv.commands.dispatch('test:alpha');
+
+    expect(alpha.calls.length).toBe(1);
+  });
+
+  it('unregisters when it unmounts', function () {
+    const alpha = jasmine.createSpy('alpha');
+    const { unmount } = mount({ 'test:alpha': alpha });
+
+    unmount();
+    AppEnv.commands.dispatch('test:alpha');
+
+    expect(alpha.calls.length).toBe(0);
+  });
+});

--- a/app/src/components/bind-global-commands.ts
+++ b/app/src/components/bind-global-commands.ts
@@ -3,13 +3,15 @@ import { Disposable } from 'event-kit';
 
 /*
 A simple component that, when placed in the render tree, registers
-a handler for a global command / shortcut. Note that this class does
-not implement componentWillReceiveProps and assumes the provided
-commands are static. Just use a `key` prop to prevent re-use if
-the commands change.
+a handler for a global command / shortcut.
 
 Registering a handler for a command in the `global` scope enables the
 corresponding item in the app's menu.
+
+Handlers are registered once as stable dispatchers that read `props` when the
+command fires, so a re-render with fresh closures needs no re-binding. Only a
+change to the *set* of command names re-registers, because that set is what
+decides which menu items are enabled.
 
 BG: I wrote this rather than using KeyCommandRegion because the region
 class is ancient and actually creates a <div> which disrupts the toolbar
@@ -19,8 +21,16 @@ export default class BindGlobalCommands extends React.Component<{
   commands: { [command: string]: () => void };
 }> {
   _shortcutDisposable?: Disposable;
+  _boundNames = '';
+
   componentDidMount() {
-    this._shortcutDisposable = AppEnv.commands.add(document.body, this.props.commands);
+    this._bind();
+  }
+
+  componentDidUpdate() {
+    if (this._namesOf(this.props.commands) !== this._boundNames) {
+      this._bind();
+    }
   }
 
   componentWillUnmount() {
@@ -28,6 +38,27 @@ export default class BindGlobalCommands extends React.Component<{
       this._shortcutDisposable.dispose();
       this._shortcutDisposable = null;
     }
+  }
+
+  _namesOf(commands: { [command: string]: () => void }) {
+    return Object.keys(commands).sort().join('\n');
+  }
+
+  _bind() {
+    if (this._shortcutDisposable) {
+      this._shortcutDisposable.dispose();
+    }
+    const dispatchers: { [command: string]: () => void } = {};
+    for (const name of Object.keys(this.props.commands)) {
+      // Reads the handler at call time, so the registration survives re-renders that
+      // rebuild the commands object with new closures.
+      dispatchers[name] = () => {
+        const handler = this.props.commands[name];
+        if (handler) handler();
+      };
+    }
+    this._boundNames = this._namesOf(this.props.commands);
+    this._shortcutDisposable = AppEnv.commands.add(document.body, dispatchers);
   }
 
   render() {


### PR DESCRIPTION
Clicking a calendar event for the first time scrolls the view.

Measured on a real account, week view, one click on one event — same config, same target, only the source differing:

| | scroll offset | day column | selected |
|---|---|---|---|
| master `29d3b0216` | 485.25 → **384** | −216 → −115 | 0 → 1 |
| with this change | 485.25 → **485.25** | −216 → −216 | 0 → 1 |

The grid jumps about 101px. It only happens on the *transition* — clicking a second event, or the same one again, leaves the view alone — which is what makes it feel arbitrary rather than reproducible. It was reported to me as "it shifted the first time but not subsequent", which is exactly that.

### Cause

`CalendarMenuCommands` wraps the entire calendar in a `BindGlobalCommands` keyed on whether an event is selected:

```js
const key = `calendar-menu-${this.props.hasSelectedEvents}`;
```

Selecting the first event flips that, the key changes, and React discards and rebuilds the subtree. Snapshotting every element in `.key-commands-region.mailspring-calendar` and clicking once: **0 of 698 survive**.

The scroll offset is not simply lost with the old nodes, which is why it lands on 384 rather than 0. The replacement `WeekView` runs `componentDidMount`, which arms `_pendingInitialCenter` and calls `_setIntervalHeight`; that `setState` callback then runs `centerGridScroll(viewportEl, selectedEvents[0])` (`week-view.tsx:56-67`, `:183-202`). The remount happens *after* the click, so the fresh view mounts with the event already selected and re-centers on the event just clicked. Deselecting takes the same path with no timed selection and lands on `centerGridScroll`'s midday default.

`BindGlobalCommands` documented that key as the way to handle changing commands, and around a toolbar button it is harmless — it is the size of what it wraps here that makes it expensive.

### Change

`BindGlobalCommands` handles a changing command set itself. Handlers are registered once as dispatchers that read `props` when the command fires, so re-renders with fresh closures need no re-binding; only a change to the *set* of command names re-registers, that set being what decides which menu items are enabled.

Passing a `key` still forces a remount, so the other **14** call sites are unaffected. Six pass one today and keep their existing remount behaviour:

| | |
|---|---|
| `thread-toolbar-buttons.tsx` | `:179`, `:229`, `:255`, `:344` |
| `ContactDetailToolbar.tsx` | `:103` |
| `AddContactToolbar.tsx` | `:41` |

The remaining eight pass no key, and every one of them registers a statically-written name set, so `_namesOf` never changes and they do not re-bind either way.

### Tests

Six specs on `BindGlobalCommands`, exercising the real registry rather than a stub (it attaches to `document.body` and `dispatch` fires a bubbling event, so the registration is genuinely exercised). Three fail on master:

- runs the current handler after a re-render replaces the closures
- picks up a command added after mount
- drops a command removed after mount

The other three — registering on mount, firing once per dispatch however often it re-renders, and unregistering on unmount — pass either way and are there as guards.

`npm test` 1752 passing, typecheck and lint clean.

CI here is held at `action_required` as usual for runs from a fork, so here is the same commit green in mine: https://github.com/brhellman/Mailspring/actions/runs/34162112952

### Scope

I am not claiming this fixes anything about double-click. I checked, and double-click works on master; the remount is a separate defect that happens to live in the same place.

