### PR TITLE
Stop crash when preferredRemovalDestination() returns an unexpected type

### DIFF
--- a/app/internal_packages/thread-search/lib/search-mailbox-perspective.tsx
+++ b/app/internal_packages/thread-search/lib/search-mailbox-perspective.tsx
@@ -113,15 +113,12 @@ class SearchMailboxPerspective extends MailboxPerspective {
       // a falsy value, so this should be unreachable. Rather than crash the remove/
       // archive action (MAILSPRING-CLIENT-2J), report it with enough context to
       // diagnose what category shape actually slipped through and no-op.
-      AppEnv.reportError(
-        new Error('Unexpected type returned from preferredRemovalDestination()'),
-        {
-          accountId,
-          accountProvider: account.provider,
-          destConstructorName: dest?.constructor?.name,
-          destRole: (dest as any)?.role,
-        }
-      );
+      AppEnv.reportError(new Error('Unexpected type returned from preferredRemovalDestination()'), {
+        accountId,
+        accountProvider: account.provider,
+        destConstructorName: dest?.constructor?.name,
+        destRole: (dest as any)?.role,
+      });
       return [];
     });
   }

--- a/app/internal_packages/thread-search/lib/search-mailbox-perspective.tsx
+++ b/app/internal_packages/thread-search/lib/search-mailbox-perspective.tsx
@@ -109,9 +109,20 @@ class SearchMailboxPerspective extends MailboxPerspective {
           labelsToRemove: [CategoryStore.getInboxCategory(accountId)],
         });
       }
-      throw new Error(
-        `Unexpected type returned from preferredRemovalDestination(): ${dest.constructor.name}`
+      // preferredRemovalDestination() is documented to return a Folder, a Label, or
+      // a falsy value, so this should be unreachable. Rather than crash the remove/
+      // archive action (MAILSPRING-CLIENT-2J), report it with enough context to
+      // diagnose what category shape actually slipped through and no-op.
+      AppEnv.reportError(
+        new Error('Unexpected type returned from preferredRemovalDestination()'),
+        {
+          accountId,
+          accountProvider: account.provider,
+          destConstructorName: dest?.constructor?.name,
+          destRole: (dest as any)?.role,
+        }
       );
+      return [];
     });
   }
 }


### PR DESCRIPTION
## Summary

Fixes [MAILSPRING-CLIENT-2J](https://foundry-376-llc.sentry.io/issues/MAILSPRING-CLIENT-2J) — `Error: Unexpected destination returned from preferredRemovalDestination()`, unresolved, 3 users / 252 events since May.

### What I observed

The stack trace points at `SearchMailboxPerspective.tasksForRemovingItems()` (`app/internal_packages/thread-search/lib/search-mailbox-perspective.tsx`), reached via the "remove from view" keyboard shortcut (`thread-toolbar-buttons.tsx` → `_onRemoveFromView` → `TaskFactory.tasksForThreadsByAccountId`) while viewing search results.

That method calls `account.preferredRemovalDestination()`, which is documented to return a `Folder`, a `Label`, or a falsy value (`app/src/flux/models/account.ts`, backed by `CategoryStore.getArchiveCategory`/`getTrashCategory`, both of which are populated from `DatabaseStore.findAll(Folder)` / `findAll(Label)` query results). `tasksForRemovingItems()` only had branches for `dest instanceof Folder` and `dest instanceof Label`; anything else fell through to an unconditional `throw`, crashing the shortcut instead of degrading gracefully.

### Root cause

This is a defensive "should never happen" assertion — under the current `CategoryStore`/`Account` implementation, `preferredRemovalDestination()` can't return anything other than those three shapes, and I couldn't reproduce a path that does. (Notably, the exact message text stored in this Sentry issue's release, `1.21.1-ae68e881`, doesn't match any version of this file in the repo's git history, and that release commit isn't reachable from current history either — so this may predate a since-lost/rewritten build. Whatever changed, the underlying "unhandled case throws" shape is still present in current `master`.) Given that, I couldn't pin down a concrete trigger to fix at the source. Per the sibling case just above it in the same function (`if (!dest) return [];`), an unexpected/unrecognized destination should behave the same way: skip the account rather than crash the whole action.

### Fix

Replace the `throw` with `AppEnv.reportError()` (the codebase's standard pattern for reporting-without-crashing, e.g. `app/src/mailbox-perspective.ts:88`) carrying the account provider and the unexpected `dest`'s constructor name/role, then return `[]` like the `!dest` branch. This stops the user-facing crash and keeps the account's other categories being an actionable Folder/Label the primary path, while giving any future recurrence enough `extra` context in Sentry to actually diagnose what shape of object `dest` was.

## Test plan

- [x] Read through `preferredRemovalDestination()`, `CategoryStore.getArchiveCategory`/`getTrashCategory`/`getCategoryByRole`, and `mailspring-observables.ts`'s `Categories.forAllAccounts()` to confirm `dest` should always be a genuine `Folder`/`Label` instance from the same module graph as this file (internal_packages share the core `require` cache via `mailspring-exports`, no separate bundling).
- [ ] `node_modules` wasn't installed in this sandbox, so `npm run lint` / `tsc` could not be run here — please confirm CI lints/type-checks pass.
- [ ] Not manually reproduced (the triggering category shape is unknown); this is a defensive graceful-degradation + diagnostics fix rather than a targeted repro-based fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RMF7nTumxpAR47nF5WsMJb

---
_Generated by [Claude Code](https://claude.ai/code/session_01RMF7nTumxpAR47nF5WsMJb)_