### PR TITLE
Recognize crash mid OAuth2 token fetch as a network error

### DIFF
--- a/app/spec/mailsync-process-spec.ts
+++ b/app/spec/mailsync-process-spec.ts
@@ -1,0 +1,43 @@
+import { MailsyncProcess } from '../src/mailsync-process';
+
+describe('MailsyncProcess._buildCrashError', () => {
+  let proc: MailsyncProcess;
+
+  beforeEach(() => {
+    proc = new MailsyncProcess({ configDirPath: '/tmp', resourcePath: '/tmp', verbose: false });
+  });
+
+  it('flags a crash with the offline marker during test mode as a network error', () => {
+    const rawLog = 'Testing connection\n{"offline":true,"retryable":true}\n';
+    const error: any = proc._buildCrashError('test', 1, null, rawLog);
+    expect(error.isNetworkError).toBe(true);
+    expect(error.message).not.toContain('unknown error');
+  });
+
+  it('flags a crash mid OAuth2 token fetch (SEH 0xE06D7363) during test mode as a network error', () => {
+    const rawLog =
+      'Waiting for Account JSON:\n\nWaiting for Identity JSON:\ninfo: Identity created at 123 - using ID Schema 1\ninfo: Fetching XOAuth2 access token (gmail) for abc123\n';
+    const error: any = proc._buildCrashError('test', 0xe06d7363, null, rawLog);
+    expect(error.isNetworkError).toBe(true);
+    expect(error.message).not.toContain('unknown error');
+  });
+
+  it('does not flag the same OAuth2 crash outside of test mode', () => {
+    const rawLog = 'info: Fetching XOAuth2 access token (gmail) for abc123\n';
+    const error: any = proc._buildCrashError('sync', 0xe06d7363, null, rawLog);
+    expect(error.isNetworkError).toBe(false);
+  });
+
+  it('does not flag an unrelated crash with the same exit code as a network error', () => {
+    const rawLog = 'Some other crash entirely, nothing about OAuth2\n';
+    const error: any = proc._buildCrashError('test', 0xe06d7363, null, rawLog);
+    expect(error.isNetworkError).toBe(false);
+    expect(error.message).toContain('unknown error');
+  });
+
+  it('reports a signal-terminated crash with the exit description in the message', () => {
+    const error: any = proc._buildCrashError('sync', null, 'SIGKILL' as NodeJS.Signals, 'crashed');
+    expect(error.isNetworkError).toBe(false);
+    expect(error.message).toContain('signal SIGKILL');
+  });
+});

--- a/app/src/mailsync-process.ts
+++ b/app/src/mailsync-process.ts
@@ -325,13 +325,25 @@ export class MailsyncProcess extends EventEmitter {
   // requests and shouldn't have unrelated crashes reclassified this way - and
   // surface a friendly, localized, network-flagged error so callers can avoid
   // reporting it to Sentry.
+  //
+  // A second signature covers the same TLS-interception scenario when mailsync
+  // doesn't get a chance to log the offline marker at all: on Windows, security
+  // software that intercepts TLS (corporate antivirus, proxies, etc.) can make
+  // the HTTPS client throw an uncaught C++ exception mid-request, which crashes
+  // the process with SEH code 0xE06D7363 - the MSVC runtime's signature for an
+  // unhandled C++ exception - right after mailsync logs that it's about to fetch
+  // an OAuth2 access token (see MAILSPRING-CLIENT-DH, ~100 Windows users hitting
+  // this exact exit code while linking a new Gmail/Outlook account).
   _buildCrashError(
     mode: string,
     code: number | null,
     signal: NodeJS.Signals | null,
     rawLog: string
   ) {
-    const isNetworkFailure = mode === 'test' && /"offline"\s*:\s*true/.test(rawLog);
+    const hasOfflineMarker = /"offline"\s*:\s*true/.test(rawLog);
+    const crashedFetchingOAuthToken =
+      code === 0xe06d7363 && /Fetching XOAuth2 access token/.test(rawLog);
+    const isNetworkFailure = mode === 'test' && (hasOfflineMarker || crashedFetchingOAuthToken);
     const exitDescription = signal ? `signal ${signal}` : `${code}`;
     const error = isNetworkFailure
       ? new Error(LocalizedErrorStrings.ErrorConnection)


### PR DESCRIPTION
Fixes https://foundry-376-llc.sentry.io/issues/MAILSPRING-CLIENT-DH

## What I observed

[MAILSPRING-CLIENT-DH](https://foundry-376-llc.sentry.io/issues/MAILSPRING-CLIENT-DH) is "An unknown error has occurred mailsync: 3765269347" — 116 users impacted, 240 events, all on Windows. Every single sampled event (25/25) has the identical shape:

```
Waiting for Account JSON:

Waiting for Identity JSON:
info: Identity created at <ts> - using ID Schema 1
info: Fetching XOAuth2 access token (gmail) for <accountId>
```
...with mailsync exiting with code `3765269347`, which is exactly `0xE06D7363` — the well-known Microsoft Visual C++ runtime SEH code that signals an uncaught C++ exception. This always happens in `test` mode, which is used by `finalizeAndValidateAccount()` (`app/internal_packages/onboarding/lib/onboarding-helpers.ts`) right after the user finishes the OAuth flow for a new Gmail/Outlook account.

So the pattern is: mailsync logs that it's about to fetch an OAuth2 access token, and then the process dies with a native C++ exception before it can log anything else — most likely because Windows security software that intercepts TLS (corporate antivirus, proxies, etc.) causes the HTTPS client to throw mid-request instead of failing gracefully.

`MailsyncProcess._buildCrashError` already has a heuristic for this exact class of problem (TLS interception during `test` mode), but it only fires when mailsync manages to log a `{"offline":true}` JSON marker before crashing. Here the crash happens too early for that marker to ever be written, so the heuristic never fires, and:
- Users see an unhelpful "unknown error ... 3765269347" message instead of "Connection Error - check your internet connection."
- `oauth-signin-page.tsx`'s `_onError` only skips reporting to Sentry when `err.isNetworkError` (or `isUserError`) is set, so this crash — which isn't a fixable Mailspring bug — keeps flooding error tracking.

The actual native crash lives in the C++ sync engine (a separate repo), so it can't be root-caused or fixed from this codebase.

## The fix

Widen `_buildCrashError` in `app/src/mailsync-process.ts` to also recognize this fingerprint: `test` mode, exit code `0xE06D7363`, and a log tail showing the crash happened while fetching an OAuth2 token. When matched, it's classified the same way as the existing `{"offline":true}` case — the user gets the friendly, localized connection-error message, and the error is no longer reported to Sentry as an unexplained crash.

Added `app/spec/mailsync-process-spec.ts` covering both the existing offline-marker case and the new OAuth2-crash fingerprint (including that it's scoped to `test` mode and doesn't misclassify unrelated crashes that happen to share the same exit code).

## Test plan

- [x] Added unit tests for `_buildCrashError` covering both network-failure signatures and the negative cases (wrong mode, unrelated crash with the same exit code)
- [ ] Could not run the full Jasmine suite in this environment (no `node_modules` installed); verified the change compiles cleanly via an isolated `tsc` check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BfBhpanbqfLKX7csCsArzN

---
_Generated by [Claude Code](https://claude.ai/code/session_01BfBhpanbqfLKX7csCsArzN)_