### PR TITLE
Keep a timed event's time of day when its edge is dragged in month view

### DIFF
--- a/app/internal_packages/main-calendar/lib/core/calendar-drag-utils.ts
+++ b/app/internal_packages/main-calendar/lib/core/calendar-drag-utils.ts
@@ -14,7 +14,10 @@ import {
 } from './calendar-data-source';
 import { CalendarDateUtils } from 'mailspring-exports';
 import { inclusiveAllDayEnd } from './calendar-helpers';
-import { DEFAULT_TIMED_EVENT_DURATION_SECONDS } from './calendar-constants';
+import {
+  DEFAULT_TIMED_EVENT_DURATION_SECONDS,
+  MIN_EVENT_DURATION_SECONDS,
+} from './calendar-constants';
 
 /**
  * Snap a timestamp to the nearest interval
@@ -74,6 +77,25 @@ function exclusiveDayEnd(end: number, floor: number): number {
   return CalendarDateUtils.nextDayStartUnix(
     CalendarDateUtils.calendarDateFromUnix(Math.max(inclusiveAllDayEnd(end), floor))
   );
+}
+
+/**
+ * Moves an instant onto the calendar day under the cursor without touching its clock time.
+ *
+ * Whole calendar days rather than a seconds delta: moment's add() holds 2pm at 2pm across a
+ * DST transition, where adding 86400 seconds lands an hour out.
+ *
+ * @param instant The instant to move
+ * @param drawnAt The day that instant is drawn on, which is the one being dragged from
+ * @param mouseTime Any instant on the day under the cursor
+ * @returns The moved instant, as a unix timestamp
+ */
+function shiftDateKeepingClock(instant: number, drawnAt: number, mouseTime: number): number {
+  const daysDelta = CalendarDateUtils.calendarDaysBetween(
+    CalendarDateUtils.calendarDateFromUnix(drawnAt),
+    CalendarDateUtils.calendarDateFromUnix(mouseTime)
+  );
+  return moment.unix(instant).add(daysDelta, 'days').unix();
 }
 
 /**
@@ -282,7 +304,6 @@ export function updateDragState(
   // - all-day-area, month-cell: full day intervals
   const usesDaySnap = containerType !== 'day-column';
   const snapInterval = usesDaySnap ? 86400 : config.snapInterval; // 86400 = 1 day in seconds
-  const minDuration = usesDaySnap ? 86400 : config.minDuration;
   // A move converts between kinds when the drop container disagrees with the event: the all-day
   // row makes a timed event all-day, the timed grid (day-column) makes an all-day event timed. A
   // month cell preserves the event's kind. Recurring events are NOT converted yet:
@@ -296,6 +317,10 @@ export function updateDragState(
       : containerType === 'day-column'
         ? state.event.isAllDay && !canConvert
         : state.event.isAllDay;
+  // A day-granular config carries the all-day rule, one whole day. A timed event resized on
+  // such a surface keeps its clock time, so its floor is the ordinary shortest event.
+  const minDuration =
+    usesDaySnap && !previewIsAllDay ? MIN_EVENT_DURATION_SECONDS : config.minDuration;
 
   switch (state.mode) {
     case 'move': {
@@ -339,7 +364,17 @@ export function updateDragState(
       break;
     }
     case 'resize-start': {
-      if (usesDaySnap) {
+      if (usesDaySnap && !previewIsAllDay) {
+        // A timed event on a day-granular surface - a month cell - resizes by whole days,
+        // but 2pm is still 2pm afterwards: only the date of its start moves. Snapping it to
+        // midnight the way an all-day event is snapped would silently discard the meeting's
+        // time of day, since a timed preview is persisted exactly as it stands here.
+        previewEnd = state.originalEnd;
+        previewStart = shiftDateKeepingClock(state.originalStart, state.originalStart, mouseTime);
+        if (previewEnd - previewStart < minDuration) {
+          previewStart = previewEnd - minDuration;
+        }
+      } else if (usesDaySnap) {
         // Clamp to the last day covered rather than subtracting seconds: one calendar day
         // is 82800s on a spring-forward day, so a seconds floor lands off midnight.
         const lastDay = inclusiveAllDayEnd(state.originalEnd);
@@ -359,7 +394,20 @@ export function updateDragState(
       break;
     }
     case 'resize-end': {
-      if (usesDaySnap) {
+      if (usesDaySnap && !previewIsAllDay) {
+        // As in resize-start: whole days of movement, unchanged clock time. The end's own
+        // day is the last one it covers, so an event ending at midnight is dragged from the
+        // day it is drawn on rather than from the day after.
+        previewStart = state.originalStart;
+        previewEnd = shiftDateKeepingClock(
+          state.originalEnd,
+          inclusiveAllDayEnd(state.originalEnd),
+          mouseTime
+        );
+        if (previewEnd - previewStart < minDuration) {
+          previewEnd = previewStart + minDuration;
+        }
+      } else if (usesDaySnap) {
         // mouseTime is the day under the cursor, not an end, so it must not go through
         // inclusiveAllDayEnd — containers hand over an exact midnight and the -1s there
         // would drop the cursor's own day. Include that day, then take the next midnight.

--- a/app/spec/calendar-drag-utils-spec.ts
+++ b/app/spec/calendar-drag-utils-spec.ts
@@ -192,6 +192,147 @@ describe('updateDragState with day snapping', function () {
   });
 });
 
+/*
+Resizing a *timed* event in a month cell. The month grid snaps to whole days, but a 1pm
+meeting is still a 1pm meeting after its edge is dragged: only the date moves. The preview
+of a timed event is persisted exactly as it stands, so snapping these to midnight the way an
+all-day span is snapped writes away the meeting's time of day.
+*/
+describe('updateDragState resizing a timed event in a month cell', function () {
+  const localDay = (y: number, m: number, d: number) => new Date(y, m - 1, d).getTime() / 1000;
+
+  function dragTimedEdge(
+    start: number,
+    end: number,
+    mode: 'resize-start' | 'resize-end',
+    mouseTime: number,
+    containerType: 'month-cell' | 'all-day-area' = 'month-cell'
+  ) {
+    const event = makeOccurrence({ isAllDay: false, start, end });
+    const state = createDragState(
+      event,
+      { mode, cursor: 'ew-resize' },
+      mouseTime,
+      0,
+      0,
+      MONTH_VIEW_DRAG_CONFIG
+    );
+    const dragged = updateDragState(
+      state,
+      mouseTime,
+      100,
+      100,
+      containerType,
+      MONTH_VIEW_DRAG_CONFIG
+    );
+    return {
+      start: dragged.previewStart,
+      end: dragged.previewEnd,
+      isAllDay: dragged.previewIsAllDay,
+    };
+  }
+
+  it('moves the end onto the cursor day and keeps its clock time', function () {
+    // 1-2pm on Aug 14, right edge dragged to Aug 16 -> Aug 14 1pm to Aug 16 2pm.
+    const start = localDay(2026, 8, 14) + 13 * HOUR;
+    const end = localDay(2026, 8, 14) + 14 * HOUR;
+    expect(dragTimedEdge(start, end, 'resize-end', localDay(2026, 8, 16))).toEqual({
+      start,
+      end: localDay(2026, 8, 16) + 14 * HOUR,
+      isAllDay: false,
+    });
+  });
+
+  it('moves the start onto the cursor day and keeps its clock time', function () {
+    // Aug 14 1pm to Aug 16 2pm, left edge dragged back to Aug 12.
+    const start = localDay(2026, 8, 14) + 13 * HOUR;
+    const end = localDay(2026, 8, 16) + 14 * HOUR;
+    expect(dragTimedEdge(start, end, 'resize-start', localDay(2026, 8, 12))).toEqual({
+      start: localDay(2026, 8, 12) + 13 * HOUR,
+      end,
+      isAllDay: false,
+    });
+  });
+
+  it('drags the end from the day the event is drawn on, not the midnight it ends at', function () {
+    // 11pm Aug 14 to midnight Aug 15 is drawn on the 14th alone. Dragging its edge onto the
+    // 15th must add a day, which a delta measured from the DTEND would read as no movement.
+    const start = localDay(2026, 8, 14) + 23 * HOUR;
+    const end = localDay(2026, 8, 15);
+    expect(dragTimedEdge(start, end, 'resize-end', localDay(2026, 8, 15))).toEqual({
+      start,
+      end: localDay(2026, 8, 16),
+      isAllDay: false,
+    });
+  });
+
+  it('holds the shortest timed event, not a whole day, when the edges cross', function () {
+    const start = localDay(2026, 8, 14) + 13 * HOUR;
+    const end = localDay(2026, 8, 14) + 14 * HOUR;
+    expect(dragTimedEdge(start, end, 'resize-end', localDay(2026, 8, 11))).toEqual({
+      start,
+      end: start + 900,
+      isAllDay: false,
+    });
+  });
+
+  it('holds the shortest timed event when the start is dragged past the end', function () {
+    const start = localDay(2026, 8, 14) + 13 * HOUR;
+    const end = localDay(2026, 8, 14) + 14 * HOUR;
+    expect(dragTimedEdge(start, end, 'resize-start', localDay(2026, 8, 20))).toEqual({
+      start: end - 900,
+      end,
+      isAllDay: false,
+    });
+  });
+
+  // The whole point of moving whole calendar days rather than a seconds delta. The runner pins
+  // America/Chicago (scripts/test.js), where 2026-03-08 is 23 hours and 2026-11-01 is 25: a
+  // `+ days * 86400` lands an hour either side of the clock time these assert.
+  it('keeps the clock time when the end is dragged across a spring-forward day', function () {
+    const start = localDay(2026, 3, 7) + 13 * HOUR;
+    const end = localDay(2026, 3, 7) + 14 * HOUR;
+    expect(dragTimedEdge(start, end, 'resize-end', localDay(2026, 3, 9))).toEqual({
+      start,
+      end: localDay(2026, 3, 9) + 14 * HOUR,
+      isAllDay: false,
+    });
+  });
+
+  it('keeps the clock time when the end is dragged across a fall-back day', function () {
+    const start = localDay(2026, 10, 31) + 13 * HOUR;
+    const end = localDay(2026, 10, 31) + 14 * HOUR;
+    expect(dragTimedEdge(start, end, 'resize-end', localDay(2026, 11, 2))).toEqual({
+      start,
+      end: localDay(2026, 11, 2) + 14 * HOUR,
+      isAllDay: false,
+    });
+  });
+
+  it('keeps the clock time when the start is dragged back across a spring-forward day', function () {
+    const start = localDay(2026, 3, 9) + 13 * HOUR;
+    const end = localDay(2026, 3, 9) + 14 * HOUR;
+    expect(dragTimedEdge(start, end, 'resize-start', localDay(2026, 3, 7))).toEqual({
+      start: localDay(2026, 3, 7) + 13 * HOUR,
+      end,
+      isAllDay: false,
+    });
+  });
+
+  // The all-day row is the other day-granular surface, reachable by dragging a timed event's
+  // edge out of the week grid and into it. It converts on a MOVE but not on a resize, so the
+  // preview stays timed and takes the same whole-day treatment as a month cell.
+  it('treats the all-day row like a month cell, without converting the event', function () {
+    const start = localDay(2026, 8, 14) + 13 * HOUR;
+    const end = localDay(2026, 8, 14) + 14 * HOUR;
+    expect(dragTimedEdge(start, end, 'resize-end', localDay(2026, 8, 16), 'all-day-area')).toEqual({
+      start,
+      end: localDay(2026, 8, 16) + 14 * HOUR,
+      isAllDay: false,
+    });
+  });
+});
+
 describe('updateDragState move with day snapping', function () {
   const localDay = (y: number, m: number, d: number) => new Date(y, m - 1, d).getTime() / 1000;
 


### PR DESCRIPTION
In month view, dragging the edge of a **timed** event silently discards its time of day. A 1:00–1:20pm meeting whose right edge is dragged two days later becomes a midnight-to-midnight span — and is still stored as a timed event, so nothing downstream restores the clock time.

#2812 fixed this for the *move* path (a timed event dragged to another month cell keeps its clock time). This is the same bug on the *resize* path, which #2812 did not reach.

### Measured on master (`f1a64fe0c`)

Live app, real account, month view. `Devin/Brian 1:1`, Tue Sep 1 **13:00–13:20**, right edge (`hitZone: resize-end`) dragged to the Thu Sep 3 cell. The drag state at the drop point:

```
previewStart: Tue Sep 01 2026 00:00:00     (was 13:00 — the START moved, though only the end was dragged)
previewEnd:   Fri Sep 04 2026 00:00:00     (was 13:20)
previewIsAllDay: false
```

### Cause

`updateDragState` treats every day-granular surface as if the event were all-day: with `usesDaySnap` set, both `resize-start` and `resize-end` snap to `startOf('day')` / next midnight and impose the all-day floor of one whole day. `previewIsAllDay` stays `false` throughout, and a timed preview is persisted exactly as it stands.

### Fix

When a **timed** event is resized on a day-granular surface, move only the *date* of the edge being dragged and keep its clock time. Movement is in whole calendar days via `moment.add(n, 'days')`, not a seconds delta, so 2pm stays 2pm across a DST transition. The end is dragged from the day it is drawn on (`inclusiveAllDayEnd`) rather than from its DTEND, so an event ending at midnight extends from the day the user sees it on. The floor is `MIN_EVENT_DURATION_SECONDS` (15 min), not a day. All-day events are untouched: they still take the existing whole-day path.

Same measurement with this change:

```
previewStart: Tue Sep 01 2026 13:00:00
previewEnd:   Thu Sep 03 2026 13:20:00      tooltip: "1:00 PM - 1:20 PM"
previewIsAllDay: false
```

Dragging back to the original cell restores the exact original instants and the release takes the existing no-change branch (no task queued). Committing the drop produces the expected `SyncbackEventTask` (captured before the sync engine, never sent): for *this occurrence*, a new exception `DTSTART …20260901T130000` / `DTEND …20260903T132000`, `RECURRENCE-ID` on the Sep 1 occurrence, `SEQUENCE` 8→9, RRULE and all existing EXDATEs/exceptions preserved verbatim; for *all occurrences*, the series master's `DTEND` moves two days with `DTSTART` untouched.

### Scope

`usesDaySnap` covers both day-granular containers, so the all-day row behaves the same way when a timed event's edge is dragged into it from the week grid: previously it flattened to a midnight span, now the preview stays timed and moves by whole days. That case is covered by spec (below) but was not exercised live.

### Specs

Nine new cases in `calendar-drag-utils-spec.ts`: both edges, the midnight-end case, both min-duration floors, three DST transitions (the runner pins `America/Chicago`, where 2026-03-08 is 23h and 2026-11-01 is 25h), and the all-day-row case.

- Plain master + these specs: **9 failing**, 1752 passing.
- With the change: **1761 passing**, 0 failing. `lint:check` and `typecheck` clean.
- The three DST specs discriminate: rewriting the helper as `instant + days * 86400` fails exactly those three and nothing else.

Fork CI on this exact SHA (green): https://github.com/brhellman/Mailspring/actions/runs/34263410893
