### PR TITLE
Stop reporting ContextifyScript compile errors with no first-party frames to Sentry

### DIFF
--- a/app/src/error-logger-extensions/sentry-error-reporter.js
+++ b/app/src/error-logger-extensions/sentry-error-reporter.js
@@ -84,10 +84,26 @@ function parseStack(stack) {
   return frames.reverse();
 }
 
-function buildEvent({ err, extra, deviceHash, release, tags }) {
+// V8 throws this when it fails to compile a module's source text (see
+// node:internal/vm makeContextifyScript). Every report we've seen
+// (MAILSPRING-CLIENT-9C) has its entire stack inside node/electron
+// internals and node_modules — e.g. loading react-dom's bundled CJS file
+// out of app.asar — with no application code involved. That points to the
+// installed files themselves being corrupted or altered on disk (AV
+// software rewriting files it scans, a bad disk sector, a partial
+// extraction/update) rather than a bug we can fix here, and repeated
+// occurrences per launch (one per window that requires the damaged file)
+// make it noisy. Only skip it when nothing in_app is on the stack, so a
+// genuine syntax error in our own code still gets reported.
+const CONTEXTIFY_SCRIPT_ERROR = /^Failed to construct 'ContextifyScript':/;
+
+function isUnactionableCorruptionError(err, frames) {
+  return CONTEXTIFY_SCRIPT_ERROR.test(err.message || '') && frames.every(f => !f.in_app);
+}
+
+function buildEvent({ err, frames, extra, deviceHash, release, tags }) {
   const message = err.message || 'Unknown error';
   const name = err.name || 'Error';
-  const frames = parseStack(err.stack);
   // Sentry's Relay rejects events whose stacktrace.frames is empty
   // (it's marked nonempty in the schema), so omit stacktrace entirely
   // when we couldn't parse any frames.
@@ -194,9 +210,16 @@ module.exports = class SentryErrorReporter {
       err = new Error(message);
     }
 
+    const frames = parseStack(err.stack);
+    if (isUnactionableCorruptionError(err, frames)) {
+      safeLog(`Sentry: skipped unactionable error: ${err.message}`);
+      return;
+    }
+
     const release = this.getRelease();
     const event = buildEvent({
       err,
+      frames,
       extra,
       deviceHash: this.deviceHash,
       release,


### PR DESCRIPTION
Fixes [MAILSPRING-CLIENT-9C](https://foundry-376-llc.sentry.io/issues/MAILSPRING-CLIENT-9C) — `Error: Failed to construct 'ContextifyScript': Unexpected token '.'` (11 users, 154 events over the last 3 months, all releases from 1.21 through 1.23).

## What I observed

Every event in this Sentry group is the same V8 error, thrown by `makeContextifyScript` (`node:internal/vm`) when Node fails to compile a module's source text. Looking across the 30 most recent events:

- The message's "unexpected token" varies between events (`.`, `:`, generic "Invalid or unexpected token"), which points at corrupted bytes at different offsets rather than a deterministic syntax bug.
- Every stack frame is inside Node/Electron internals (`Module._load`, `Module._compile`, `wrapSafe`, `makeContextifyScript`, etc.) or `node_modules` — never Mailspring's own code. One event's `extra.url` shows the file that failed to compile was `app.asar\node_modules\react-dom\cjs\react-dom.production.min.js`, a file Mailspring ships unmodified and never touches at runtime.
- Multiple identical events land within the same second on each occurrence, consistent with several windows independently `require()`-ing the same damaged file at startup.

Since the file that fails to parse is a vendored dependency bundled verbatim into `app.asar`, and Mailspring never generates or writes to it, the only way it ends up with a stray/corrupted byte is if something outside the app touched the installed files after packaging — e.g. antivirus software rewriting scanned files in place, a bad disk sector, or an interrupted install/update. There's no code path in this repo that could produce this error, and no first-party frame to fix.

## The fix

`app/src/error-logger-extensions/sentry-error-reporter.js` is the single choke point both renderer and main-process errors funnel through before being sent to Sentry (renderer errors hit it via the `report-error` IPC handler in `application.ts`, mirroring the existing precedent there of filtering out unactionable LESS compile errors).

I added a targeted filter: when an error's message matches `Failed to construct 'ContextifyScript':` **and** every parsed stack frame is non-`in_app` (i.e. no application code involved), we skip sending it to Sentry and just log locally. If a genuine syntax error ever originates from our own code (a corrupted theme/plugin file, say), at least one frame would be `in_app` and the error still gets reported — this only suppresses the specific case where there's nothing actionable for us to fix.

## Testing

No existing spec coverage for this file (it isn't wired into the Jasmine specs, and its dependencies — `electron`, `@electron/remote`, `getmac` — aren't available outside the packaged app). I verified the filtering logic in isolation against the real stack trace from the Sentry event, a hypothetical first-party variant (correctly *not* filtered), and an unrelated error message (correctly *not* filtered). Also confirmed the file is syntactically valid with `node --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZsF5SF3gsgWEaNyz5ezFj

---
_Generated by [Claude Code](https://claude.ai/code/session_01BZsF5SF3gsgWEaNyz5ezFj)_