### PR TITLE
Fix missing Linux tray icon on non-Unity desktops (Hyprland, Sway, etc.)

### DIFF
--- a/app/src/browser/system-tray-manager.ts
+++ b/app/src/browser/system-tray-manager.ts
@@ -43,6 +43,37 @@ function _getIcon(iconPath: string) {
   return nativeImage.createFromPath(iconPath);
 }
 
+// Chromium's tray backend only picks the AppIndicator/StatusNotifierItem
+// implementation when XDG_CURRENT_DESKTOP matches one of these values (a
+// holdover from Ubuntu Unity). Every other desktop, including compositors
+// that implement the StatusNotifierItem host themselves (Hyprland, Sway,
+// i3+snixembed, etc.), falls back to the legacy X11 XEmbed tray icon, which
+// has no XEmbed manager to embed into on Wayland — so the icon silently
+// never appears. Reporting as Unity just for the Tray() construction call
+// gets Chromium to use the SNI backend without touching the real
+// XDG_CURRENT_DESKTOP value that the rest of the app (dark-panel icon
+// selection, DND detection) still relies on to identify the actual desktop.
+const APPINDICATOR_DESKTOPS = ['GNOME', 'UNITY'];
+
+function _withAppIndicatorDesktop<T>(fn: () => T): T {
+  if (process.platform !== 'linux') return fn();
+
+  const original = process.env.XDG_CURRENT_DESKTOP;
+  const current = (original || '').toUpperCase();
+  if (APPINDICATOR_DESKTOPS.some((d) => current.includes(d))) return fn();
+
+  process.env.XDG_CURRENT_DESKTOP = 'Unity';
+  try {
+    return fn();
+  } finally {
+    if (original === undefined) {
+      delete process.env.XDG_CURRENT_DESKTOP;
+    } else {
+      process.env.XDG_CURRENT_DESKTOP = original;
+    }
+  }
+}
+
 class SystemTrayManager {
   _iconPath = null;
   _unreadString = null;
@@ -101,12 +132,14 @@ class SystemTrayManager {
     const created = this._tray !== null;
 
     if (enabled && !created) {
-      this._tray = new Tray(_getIcon(this._iconPath || this._defaultIconPath()));
-      this._tray.setToolTip(_getTooltip(this._unreadString));
-      this._tray.addListener('click', this._onClick);
-      this._tray.setContextMenu(
-        Menu.buildFromTemplate(_getMenuTemplate(this._platform, this._application) as any)
-      );
+      _withAppIndicatorDesktop(() => {
+        this._tray = new Tray(_getIcon(this._iconPath || this._defaultIconPath()));
+        this._tray.setToolTip(_getTooltip(this._unreadString));
+        this._tray.addListener('click', this._onClick);
+        this._tray.setContextMenu(
+          Menu.buildFromTemplate(_getMenuTemplate(this._platform, this._application) as any)
+        );
+      });
     }
   }
 


### PR DESCRIPTION
## Problem

On Linux desktops other than GNOME/Unity, Mailspring's system tray icon silently never appears — even with `core.workspace.systemTray` enabled and `Tray()` constructing without error. This has been a known issue since #155 (2017), where the only documented fix is manually launching with `env XDG_CURRENT_DESKTOP=Unity mailspring`.

## Root cause

Chromium's Linux tray implementation only selects the AppIndicator/StatusNotifierItem (SNI) backend when `XDG_CURRENT_DESKTOP` matches `GNOME` or `Unity` — a holdover from the Ubuntu Unity era. Every other desktop falls back to the legacy X11 XEmbed tray icon. On modern Wayland compositors that implement the StatusNotifierItem host protocol themselves (Hyprland, Sway, i3 with snixembed, etc.), there's no XEmbed tray manager to embed into, so the icon is created but never registers with anything and never becomes visible — with no error surfaced to the user.

I confirmed this concretely on Hyprland with a SNI-based bar (noctalia): `busctl --user get-property org.kde.StatusNotifierWatcher /StatusNotifierWatcher org.kde.StatusNotifierWatcher RegisteredStatusNotifierItems` returned an empty array while Mailspring was running with the tray enabled, and the Electron log repeatedly showed:
```
Gtk: gtk_widget_get_scale_factor: assertion 'GTK_IS_WIDGET (widget)' failed
```
which is the classic signature of GTK attempting to build the XEmbed status icon widget with no tray manager present. Manually launching with `env XDG_CURRENT_DESKTOP=Unity mailspring` immediately fixed it — the icon registered as a proper StatusNotifierItem.

## Fix

Rather than requiring users to set this env var for the whole process (which would also affect the dark-panel icon heuristic and DND detection in this codebase, both of which key off the real `XDG_CURRENT_DESKTOP` value), this scopes the override to just the `Tray()` construction call in `SystemTrayManager.initTray()`. If `XDG_CURRENT_DESKTOP` doesn't already match a desktop Chromium recognizes for the SNI backend, it's temporarily reported as `Unity` only for that call, then restored immediately afterward (`try`/`finally`).

This means:
- GNOME/Unity users: no behavior change (already matched, override is a no-op).
- Everyone else (Hyprland, Sway, i3, XFCE, KDE, etc.): gets a working tray icon automatically, no launch flags needed.
- Existing dark-panel icon selection and Do Not Disturb detection elsewhere in the app continue to see the real desktop value.

## Testing

I don't have a local build environment set up for this repo (no Node toolchain in my current sandbox), so I wasn't able to run the full app build. I did:
- Verify the change compiles as valid TypeScript by inspection against the existing patterns in the same file (e.g. the `_defaultIconPath` dark-icon detection already does an equivalent `XDG_CURRENT_DESKTOP` string check).
- Confirm via `busctl` that no `StatusNotifierItem` was registered before the fix and that manually exporting `XDG_CURRENT_DESKTOP=Unity` for the whole process (the existing documented workaround) does register one, which is what this change automates narrowly.

I'd appreciate a maintainer test-running this on an actual build before merge, since I couldn't verify end-to-end myself in this environment. Happy to adjust based on feedback.

Related: #155