### PR TITLE
Fix unhandled rejection when opening identity links while signed out

### DIFF
--- a/app/src/components/evented-iframe.tsx
+++ b/app/src/components/evented-iframe.tsx
@@ -227,9 +227,16 @@ export class EventedIFrame extends React.Component<
       // just following the link directly
       if (rawHref.startsWith(rootURLForServer('identity'))) {
         const path = rawHref.split(rootURLForServer('identity')).pop();
-        IdentityStore.fetchSingleSignOnURL(path, { source: 'SingleSignOnEmail' }).then((href) => {
-          AppEnv.windowEventHandler.openLink({ href, metaKey: e.metaKey });
-        });
+        IdentityStore.fetchSingleSignOnURL(path, { source: 'SingleSignOnEmail' }).then(
+          (href) => {
+            AppEnv.windowEventHandler.openLink({ href, metaKey: e.metaKey });
+          },
+          () => {
+            // No identity is set (eg. the user is signed out) - fall back to opening
+            // the link directly rather than dropping the click on the floor.
+            AppEnv.windowEventHandler.openLink({ href: rawHref, metaKey: e.metaKey });
+          }
+        );
         return;
       }
 

--- a/app/src/components/open-identity-page-button.tsx
+++ b/app/src/components/open-identity-page-button.tsx
@@ -33,12 +33,20 @@ export default class OpenIdentityPageButton extends React.Component<
       source: this.props.source,
       campaign: this.props.campaign,
       content: this.props.label,
-    }).then((url) => {
-      this.setState({ loading: false });
-      if (/^https?:\/\/.+/i.test(url)) {
-        shell.openExternal(url);
+    }).then(
+      (url) => {
+        this.setState({ loading: false });
+        if (/^https?:\/\/.+/i.test(url)) {
+          shell.openExternal(url);
+        }
+      },
+      () => {
+        // No identity is set (eg. the user is signed out) - stop showing the
+        // loading spinner rather than leaving it stuck and letting the
+        // rejection go unhandled.
+        this.setState({ loading: false });
       }
-    });
+    );
   };
 
   render() {


### PR DESCRIPTION
## Summary

Fixes [MAILSPRING-CLIENT-35](https://foundry-376-llc.sentry.io/issues/MAILSPRING-CLIENT-35) — `Error: fetchSingleSignOnURL: no identity set.` (41 users impacted, 321 occurrences over the last release).

**What I observed:** `IdentityStore.fetchSingleSignOnURL()` (`app/src/flux/stores/identity-store.ts:174-180`) rejects with this exact error whenever `this._identity` is `null` — i.e. the user is signed out or the identity hasn't loaded yet. Two call sites consumed this promise with `.then()` only and no rejection handler:

- `EventedIFrame._onIFrameClick` in `app/src/components/evented-iframe.tsx` — fires whenever a user clicks a link inside a message body that points at the Mailspring billing/identity site, so it can attempt single sign-on before opening the link.
- `OpenIdentityPageButton._onClick` in `app/src/components/open-identity-page-button.tsx` — used by in-app upsell/billing buttons.

With no identity set, the rejection went unhandled and Node reported it as an uncaught exception, which is what Sentry captured. Interestingly, `identity-store.ts` already has a comment/pattern for exactly this class of bug on its background poll (`_fetchAndPollRemoteIdentity`), but these two UI call sites were missed.

**Fix:** Add a rejection handler at both call sites:
- In `evented-iframe.tsx`, fall back to opening the raw link directly (without SSO) instead of silently dropping the click.
- In `open-identity-page-button.tsx`, just clear the `loading` state instead of leaving the button stuck in a spinner and the rejection unhandled.

## Test plan

- Read through both call sites and confirmed the fix mirrors the existing `.catch()` pattern already used elsewhere in `identity-store.ts` for the same rejection.
- Could not run the full test suite / lint in this sandbox (no `node_modules` installed), so please run `npm run lint` and the relevant Jasmine specs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rm8MsCZiT58TXF6SFrFbs7

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rm8MsCZiT58TXF6SFrFbs7)_