### PR TITLE
Time out qlmanage thumbnail generation so it can't leak

### DIFF
--- a/app/src/quickpreview/index.ts
+++ b/app/src/quickpreview/index.ts
@@ -40,6 +40,8 @@ const filesRoot = __dirname.replace('app.asar', 'app.asar.unpacked');
 
 const FileSizeLimit = 5 * 1024 * 1024;
 const ThumbnailWidth = 320 * (11 / 8.5);
+// Budget for generating a single thumbnail, shared by both strategies.
+const PreviewTimeout = 5000;
 const QuicklookIsAvailable = process.platform === 'darwin';
 const PDFJSRoot = path.join(filesRoot, 'pdfjs-4.3.136');
 
@@ -419,7 +421,7 @@ async function _generateNextCrossplatformPreview() {
   const timer = setTimeout(() => {
     console.warn(`Thumbnail generation timed out for ${filePath}`);
     onFinalize(false);
-  }, 5000);
+  }, PreviewTimeout);
 
   const onRendererSuccess = () => {
     onFinalize(true);
@@ -459,18 +461,32 @@ async function _generateQuicklookPreview({ filePath }: { filePath: string }) {
       pathQuoted,
     ];
 
-    execFile(cmd, args, (error, stdout, stderr) => {
-      // Note: sometimes qlmanage outputs to stderr but still successfully
-      // produces a thumbnail. It complains about bad plugins pretty often.
-      if (
-        error ||
-        stdout.match(/No thumbnail created/i) ||
-        (stderr && !stdout.includes('produced one thumbnail'))
-      ) {
-        resolve(false);
-      } else {
-        resolve(true);
+    // qlmanage can hang indefinitely rather than failing -- an attachment saved
+    // without an extension is enough to do it, and Mailspring writes those out
+    // as "noname". Without a timeout the callback never fires and the child is
+    // never reaped, so each one leaks holding a pkd connection open; enough of
+    // them exhausts pkd's thread pool and every app that builds a Share menu
+    // then deadlocks on a synchronous XPC call to it.
+    // SIGKILL rather than the default SIGTERM: qlmanage handles SIGTERM and
+    // exits 0, so the timeout would look like a success and we would report a
+    // thumbnail that was never written.
+    execFile(
+      cmd,
+      args,
+      { timeout: PreviewTimeout, killSignal: 'SIGKILL' },
+      (error, stdout, stderr) => {
+        // Note: sometimes qlmanage outputs to stderr but still successfully
+        // produces a thumbnail. It complains about bad plugins pretty often.
+        if (
+          error ||
+          stdout.match(/No thumbnail created/i) ||
+          (stderr && !stdout.includes('produced one thumbnail'))
+        ) {
+          resolve(false);
+        } else {
+          resolve(true);
+        }
       }
-    });
+    );
   });
 }


### PR DESCRIPTION
_generateQuicklookPreview shells out to qlmanage with no timeout, so a qlmanage that hangs instead of failing never fires the callback and the child is never reaped. An attachment saved without an extension is enough to trigger it, and that is exactly what we hand it: the file is written out as "noname", strategyForPreviewing('') finds no crossplatform strategy and '' is not in QuicklookBlacklist, so every extensionless attachment takes the quicklook path.

Each leaked helper holds a pkd (PlugInKit) connection open. On one machine 735 had accumulated over ~4 days and pkd had 512 live "per-connection queue for qlmanage" dispatch queues — its entire thread pool, every one a dead client. pkd could then no longer answer any extension query, so every app that populates a Share menu deadlocked on the synchronous XPC call behind +[NSSharingService sharingServicesForItems:]. Brave was the visible casualty; Mailspring itself looked fine.

_generateNextCrossplatformPreview already guards itself with a 5s timer for the same reason ("We don't want this to hang forever"); this gives the quicklook path the same budget, via a shared PreviewTimeout constant.

SIGKILL rather than execFile's default SIGTERM: qlmanage installs a handler and exits 0 on SIGTERM, so Node reports no error, stdout/stderr are empty, and the existing success check would resolve(true) — telling the caller a thumbnail exists at previewPath when nothing was written, leaving a broken image in the attachment list. With SIGKILL the callback gets a killed error and correctly resolves(false).

Verified against a real hanging file: the helper is killed at ~5s and resolves false, no process is left behind, and a normal attachment still resolves true in ~240ms.