### PR TITLE
Fix tray icon on Linux by waiting for StatusNotifierHost

### DIFF
--- a/app/spec/sni-host-spec.ts
+++ b/app/spec/sni-host-spec.ts
@@ -1,0 +1,97 @@
+import proxyquire from 'proxyquire';
+
+// proxyquire injects the mock before the module is evaluated, so the
+// destructured `execFile` binding is mocked.
+let execFileSpy: jasmine.Spy;
+let waitForStatusNotifierHost: () => Promise<void>;
+
+function loadModule() {
+  execFileSpy = jasmine.createSpy('execFile');
+  const mod = proxyquire('../src/browser/sni-host', {
+    child_process: { execFile: execFileSpy, '@noCallThru': false },
+  });
+  waitForStatusNotifierHost = mod.waitForStatusNotifierHost;
+}
+
+function respondWith(responses: Array<string | null>) {
+  let call = 0;
+  execFileSpy.andCallFake(
+    (
+      _cmd: string,
+      _args: string[],
+      _opts: any,
+      callback: (err: Error | null, stdout: string) => void
+    ) => {
+      const value = responses[Math.min(call, responses.length - 1)];
+      call += 1;
+      if (value === null) callback(new Error('no such name'), '');
+      else callback(null, value);
+    }
+  );
+}
+
+const HOST_UP = 'method return ...\n   variant       boolean true\n';
+const HOST_DOWN = 'method return ...\n   variant       boolean false\n';
+
+describe('sni-host', () => {
+  let originalSessionType;
+  let originalWaylandDisplay;
+  let originalPlatform;
+
+  beforeEach(() => {
+    originalSessionType = process.env.XDG_SESSION_TYPE;
+    originalWaylandDisplay = process.env.WAYLAND_DISPLAY;
+    originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+    Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+    delete process.env.XDG_SESSION_TYPE;
+    delete process.env.WAYLAND_DISPLAY;
+    loadModule();
+  });
+
+  afterEach(() => {
+    if (originalSessionType === undefined) delete process.env.XDG_SESSION_TYPE;
+    else process.env.XDG_SESSION_TYPE = originalSessionType;
+    if (originalWaylandDisplay === undefined) delete process.env.WAYLAND_DISPLAY;
+    else process.env.WAYLAND_DISPLAY = originalWaylandDisplay;
+    Object.defineProperty(process, 'platform', originalPlatform);
+  });
+
+  it('returns immediately when a host is already registered', async () => {
+    respondWith([HOST_UP]);
+    const started = Date.now();
+    await waitForStatusNotifierHost();
+    expect(execFileSpy.calls.length).toBe(1);
+    expect(Date.now() - started).toBeLessThan(400);
+  });
+
+  it('queries the IsStatusNotifierHostRegistered property over the session bus', async () => {
+    respondWith([HOST_UP]);
+    await waitForStatusNotifierHost();
+    const [cmd, args] = execFileSpy.calls[0].args;
+    expect(cmd).toBe('dbus-send');
+    expect(args).toContain('--session');
+    expect(args).toContain('--dest=org.kde.StatusNotifierWatcher');
+    expect(args).toContain('string:IsStatusNotifierHostRegistered');
+  });
+
+  it('keeps polling until a late-starting host registers', async () => {
+    respondWith([HOST_DOWN, HOST_DOWN, HOST_UP]);
+    await waitForStatusNotifierHost();
+    expect(execFileSpy.calls.length).toBe(3);
+  });
+
+  it('keeps polling while the watcher name has no owner', async () => {
+    respondWith([null, null, HOST_UP]);
+    await waitForStatusNotifierHost();
+    expect(execFileSpy.calls.length).toBe(3);
+  });
+
+  it('gives up quickly on X11, where an XEmbed tray is still a valid target', async () => {
+    respondWith([HOST_DOWN]);
+    const started = Date.now();
+    await waitForStatusNotifierHost();
+    const elapsed = Date.now() - started;
+    expect(elapsed).toBeGreaterThan(2500);
+    expect(elapsed).toBeLessThan(6000);
+  });
+});

--- a/app/spec/sni-host-spec.ts
+++ b/app/spec/sni-host-spec.ts
@@ -3,7 +3,12 @@ import proxyquire from 'proxyquire';
 // proxyquire injects the mock before the module is evaluated, so the
 // destructured `execFile` binding is mocked.
 let execFileSpy: jasmine.Spy;
-let waitForStatusNotifierHost: () => Promise<void>;
+let waitForStatusNotifierHost: (sleep?: (ms: number) => Promise<void>) => Promise<void>;
+let statusNotifierWaitBudgetMs: () => number;
+
+// The spec harness replaces setTimeout with a manually advanced clock, so the
+// poll loop is driven with a sleep that resolves immediately instead.
+const noSleep = () => Promise.resolve();
 
 function loadModule() {
   execFileSpy = jasmine.createSpy('execFile');
@@ -11,6 +16,7 @@ function loadModule() {
     child_process: { execFile: execFileSpy, '@noCallThru': false },
   });
   waitForStatusNotifierHost = mod.waitForStatusNotifierHost;
+  statusNotifierWaitBudgetMs = mod.statusNotifierWaitBudgetMs;
 }
 
 function respondWith(responses: Array<string | null>) {
@@ -58,15 +64,13 @@ describe('sni-host', () => {
 
   it('returns immediately when a host is already registered', async () => {
     respondWith([HOST_UP]);
-    const started = Date.now();
-    await waitForStatusNotifierHost();
+    await waitForStatusNotifierHost(noSleep);
     expect(execFileSpy.calls.length).toBe(1);
-    expect(Date.now() - started).toBeLessThan(400);
   });
 
   it('queries the IsStatusNotifierHostRegistered property over the session bus', async () => {
     respondWith([HOST_UP]);
-    await waitForStatusNotifierHost();
+    await waitForStatusNotifierHost(noSleep);
     const [cmd, args] = execFileSpy.calls[0].args;
     expect(cmd).toBe('dbus-send');
     expect(args).toContain('--session');
@@ -76,22 +80,22 @@ describe('sni-host', () => {
 
   it('keeps polling until a late-starting host registers', async () => {
     respondWith([HOST_DOWN, HOST_DOWN, HOST_UP]);
-    await waitForStatusNotifierHost();
+    await waitForStatusNotifierHost(noSleep);
     expect(execFileSpy.calls.length).toBe(3);
   });
 
   it('keeps polling while the watcher name has no owner', async () => {
     respondWith([null, null, HOST_UP]);
-    await waitForStatusNotifierHost();
+    await waitForStatusNotifierHost(noSleep);
     expect(execFileSpy.calls.length).toBe(3);
   });
 
-  it('gives up quickly on X11, where an XEmbed tray is still a valid target', async () => {
-    respondWith([HOST_DOWN]);
-    const started = Date.now();
-    await waitForStatusNotifierHost();
-    const elapsed = Date.now() - started;
-    expect(elapsed).toBeGreaterThan(2500);
-    expect(elapsed).toBeLessThan(6000);
+  it('gives up quickly on X11, where an XEmbed tray is still a valid target', () => {
+    expect(statusNotifierWaitBudgetMs()).toBe(3000);
+  });
+
+  it('waits far longer on Wayland, which has no XEmbed tray to fall back to', () => {
+    process.env.XDG_SESSION_TYPE = 'wayland';
+    expect(statusNotifierWaitBudgetMs()).toBe(15000);
   });
 });

--- a/app/src/browser/sni-host.ts
+++ b/app/src/browser/sni-host.ts
@@ -52,11 +52,22 @@ function isStatusNotifierHostRegistered(): Promise<boolean> {
  * available to us, since the icon cannot be destroyed and recreated on Linux
  * (electron/electron#17622).
  */
-export async function waitForStatusNotifierHost(): Promise<void> {
-  const deadline = Date.now() + (isWaylandSession() ? SNI_WAIT_WAYLAND_MS : SNI_WAIT_X11_MS);
+export function statusNotifierWaitBudgetMs(): number {
+  return isWaylandSession() ? SNI_WAIT_WAYLAND_MS : SNI_WAIT_X11_MS;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// `sleep` is injectable only so specs can drive the poll loop: the spec
+// harness replaces the global setTimeout with a manually advanced clock, so a
+// real delay never resolves under test.
+export async function waitForStatusNotifierHost(sleep = delay): Promise<void> {
+  const deadline = Date.now() + statusNotifierWaitBudgetMs();
   let ready = await isStatusNotifierHostRegistered();
   while (!ready && Date.now() < deadline) {
-    await new Promise((resolve) => setTimeout(resolve, SNI_PROBE_INTERVAL_MS));
+    await sleep(SNI_PROBE_INTERVAL_MS);
     ready = await isStatusNotifierHostRegistered();
   }
 }

--- a/app/src/browser/sni-host.ts
+++ b/app/src/browser/sni-host.ts
@@ -1,0 +1,62 @@
+import { execFile } from 'child_process';
+import { isWaylandSession } from './is-wayland';
+
+const SNI_WATCHER_SERVICE = 'org.kde.StatusNotifierWatcher';
+const SNI_WATCHER_PATH = '/StatusNotifierWatcher';
+const SNI_PROBE_INTERVAL_MS = 500;
+const DBUS_SEND_TIMEOUT_MS = 2000;
+
+// Wayland has no XEmbed tray manager to fall back to, so waiting longer for a
+// StatusNotifierHost is always better than giving up. On X11 an XEmbed-only
+// tray (trayer, stalonetray, older XFCE) is a legitimate target, so give up
+// quickly rather than delay the icon for users who will never have a host.
+const SNI_WAIT_WAYLAND_MS = 15000;
+const SNI_WAIT_X11_MS = 3000;
+
+function isStatusNotifierHostRegistered(): Promise<boolean> {
+  return new Promise((resolve) => {
+    execFile(
+      'dbus-send',
+      [
+        '--session',
+        '--print-reply',
+        `--dest=${SNI_WATCHER_SERVICE}`,
+        SNI_WATCHER_PATH,
+        'org.freedesktop.DBus.Properties.Get',
+        `string:${SNI_WATCHER_SERVICE}`,
+        'string:IsStatusNotifierHostRegistered',
+      ],
+      { timeout: DBUS_SEND_TIMEOUT_MS },
+      (error, stdout) => {
+        // An error means no watcher owns the name yet, or it does not implement
+        // the property — either way there is no host to register with.
+        resolve(!error && stdout.toString().includes('boolean true'));
+      }
+    );
+  });
+}
+
+/**
+ * Electron's Linux tray tries the StatusNotifierItem (D-Bus) backend first and
+ * falls back to the legacy XEmbed icon — permanently, for the life of the
+ * process — if `org.kde.StatusNotifierWatcher` has no owner or reports
+ * `IsStatusNotifierHostRegistered = false` at the moment `Tray()` is
+ * constructed. The retry it installs on NameOwnerChanged is only wired up
+ * after both of those checks have already passed, so losing the race is not
+ * recoverable (chromium `StatusIconLinuxDbus::OnNameHasOwnerResponse` and
+ * `::OnHostRegisteredResponse`).
+ *
+ * Compositor bars routinely claim the name a second or two into the session,
+ * which is why the tray icon never appears on Hyprland/Sway but works after a
+ * relaunch. Waiting for the host before constructing the tray is the only fix
+ * available to us, since the icon cannot be destroyed and recreated on Linux
+ * (electron/electron#17622).
+ */
+export async function waitForStatusNotifierHost(): Promise<void> {
+  const deadline = Date.now() + (isWaylandSession() ? SNI_WAIT_WAYLAND_MS : SNI_WAIT_X11_MS);
+  let ready = await isStatusNotifierHostRegistered();
+  while (!ready && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, SNI_PROBE_INTERVAL_MS));
+    ready = await isStatusNotifierHostRegistered();
+  }
+}

--- a/app/src/browser/system-tray-manager.ts
+++ b/app/src/browser/system-tray-manager.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import { Tray, Menu, nativeImage, nativeTheme } from 'electron';
 import { localized } from '../intl';
+import { waitForStatusNotifierHost } from './sni-host';
 import Application from './application';
 
 function _getMenuTemplate(platform: string, application: Application) {
@@ -47,6 +48,7 @@ class SystemTrayManager {
   _iconPath = null;
   _unreadString = null;
   _tray = null;
+  _awaitingTrayHost = false;
   _platform: string = null;
   _application: Application;
 
@@ -96,18 +98,30 @@ class SystemTrayManager {
     );
   }
 
-  initTray() {
-    const enabled = this._application.config.get('core.workspace.systemTray') !== false;
-    const created = this._tray !== null;
+  _trayEnabled() {
+    return this._application.config.get('core.workspace.systemTray') !== false;
+  }
 
-    if (enabled && !created) {
-      this._tray = new Tray(_getIcon(this._iconPath || this._defaultIconPath()));
-      this._tray.setToolTip(_getTooltip(this._unreadString));
-      this._tray.addListener('click', this._onClick);
-      this._tray.setContextMenu(
-        Menu.buildFromTemplate(_getMenuTemplate(this._platform, this._application) as any)
-      );
+  async initTray() {
+    if (!this._trayEnabled() || this._tray !== null || this._awaitingTrayHost) return;
+
+    if (this._platform === 'linux') {
+      this._awaitingTrayHost = true;
+      try {
+        await waitForStatusNotifierHost();
+      } finally {
+        this._awaitingTrayHost = false;
+      }
+      // The setting can be switched off while we were waiting for the host.
+      if (!this._trayEnabled() || this._tray !== null) return;
     }
+
+    this._tray = new Tray(_getIcon(this._iconPath || this._defaultIconPath()));
+    this._tray.setToolTip(_getTooltip(this._unreadString));
+    this._tray.addListener('click', this._onClick);
+    this._tray.setContextMenu(
+      Menu.buildFromTemplate(_getMenuTemplate(this._platform, this._application) as any)
+    );
   }
 
   _onClick = () => {


### PR DESCRIPTION
## Summary

Fixes the tray icon not appearing on Wayland and some X11 desktop environments (Hyprland, Sway) by waiting for the StatusNotifierHost to register before constructing the Electron Tray object.

## Problem

Electron's Linux tray implementation checks for `org.kde.StatusNotifierWatcher` and `IsStatusNotifierHostRegistered` at the moment the `Tray()` object is constructed. If the check fails at that moment, it permanently falls back to the legacy XEmbed backend for the lifetime of the process. The retry mechanism only activates after both checks pass, making the race unrecoverable.

Compositor bars (like those in Hyprland/Sway) often claim the StatusNotifierWatcher name a second or two into the session startup, causing the tray icon to never appear unless the app is relaunched.

## Changes

- **New module `app/src/browser/sni-host.ts`**: Implements `waitForStatusNotifierHost()` which polls the D-Bus `IsStatusNotifierHostRegistered` property until it returns true or a platform-specific timeout is reached:
  - Wayland: waits up to 15 seconds (no XEmbed fallback available)
  - X11: waits up to 3 seconds (XEmbed tray is a valid fallback)

- **Updated `app/src/browser/system-tray-manager.ts`**: Modified `initTray()` to be async and call `waitForStatusNotifierHost()` on Linux before constructing the Tray object. Includes guards to handle the tray being disabled or already created while waiting.

- **New test suite `app/spec/sni-host-spec.ts`**: Comprehensive tests covering:
  - Immediate return when host is already registered
  - Correct D-Bus query construction
  - Polling behavior for late-starting hosts
  - Handling of missing watcher service
  - Platform-specific timeout behavior

https://claude.ai/code/session_015azScof8VsQLNJ7emQRhS4